### PR TITLE
(MODULES-1956) Commit Generated Types / Specs

### DIFF
--- a/Repofile
+++ b/Repofile
@@ -1,5 +1,6 @@
 # This are the base resources definitions found in the Windows Management Framework 4.0
-# repo "dsc-resource-wmf-4", :git => "https://github.com/msutter/dsc-resource-wmf-4.git"
+repo "dsc-resource-wmf-4", :git => "https://github.com/msutter/dsc-resource-wmf-4.git"
 
 # # Microsoft DSC Resource Kit Wave 6 custom repo
-# repo "dsc-resource-kit-wave-6", :git => "https://github.com/msutter/dsc-resource-kit-wave-6.git"
+repo "dsc-resource-kit", :git => "https://github.com/msutter/dsc-resource-kit-wave-6.git"
+#repo "dsc-resource-kit", :git => "https://github.com/ferventcoder/dsc-resource-kit.git"

--- a/build/dsc.rake
+++ b/build/dsc.rake
@@ -98,7 +98,7 @@ eod
 
     desc "Build #{item_name}"
     task :build, [:module_path] do |t, args|
-      module_path = args[:module_path] || default_module_path
+      module_path = args[:module_path] || default_dsc_module_path
       m = Dsc::Manager.new
       m.target_module_path = module_path
       msgs = m.build_dsc_types
@@ -107,7 +107,7 @@ eod
 
     desc "Cleanup #{item_name}"
     task :clean, [:module_path] do |t, args|
-      module_path = args[:module_path] || default_module_path
+      module_path = args[:module_path] || default_dsc_module_path
       puts "Cleaning #{item_name}"
       m = Dsc::Manager.new
       m.target_module_path = module_path
@@ -125,7 +125,7 @@ eod
 
     desc "Generate skeleton for #{item_name}"
     task :skeleton, [:dsc_module_path] do |t, args|
-      dsc_module_path = args[:dsc_module_path] || default_module_path
+      dsc_module_path = args[:dsc_module_path] || default_dsc_module_path
       module_name = Pathname.new(dsc_module_path).basename.to_s
       ext_module_files = [
         '.gitignore',

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -1,0 +1,143 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_archive) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC Archive resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_ArchiveResource/MSFT_ArchiveResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_path is a required attribute') if self[:dsc_path].nil?
+      fail('dsc_destination is a required attribute') if self[:dsc_destination].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "Archive"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_ArchiveResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_path) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Destination
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_destination) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Validate
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_validate) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         Checksum
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["SHA-1", "SHA-256", "SHA-512", "CreatedDate", "ModifiedDate"]
+  newparam(:dsc_checksum) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['SHA-1', 'sha-1', 'SHA-256', 'sha-256', 'SHA-512', 'sha-512', 'CreatedDate', 'createddate', 'ModifiedDate', 'modifieddate'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are SHA-1, SHA-256, SHA-512, CreatedDate, ModifiedDate")
+      end
+    end
+  end
+
+  # Name:         Force
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_force) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -1,0 +1,113 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_environment) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC Environment resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_EnvironmentResource/MSFT_EnvironmentResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "Environment"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_EnvironmentResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Value
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_value) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -1,0 +1,266 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_file) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC File resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_FileDirectoryConfiguration/MSFT_FileDirectoryConfiguration.Schema.mof
+  }
+
+  validate do
+      fail('dsc_destinationpath is a required attribute') if self[:dsc_destinationpath].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "File"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_FileDirectoryConfiguration"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         DestinationPath
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_destinationpath) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Type
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["File", "Directory"]
+  newparam(:dsc_type) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['File', 'file', 'Directory', 'directory'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are File, Directory")
+      end
+    end
+  end
+
+  # Name:         SourcePath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sourcepath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Contents
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_contents) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Checksum
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["SHA-1", "SHA-256", "SHA-512", "CreatedDate", "ModifiedDate"]
+  newparam(:dsc_checksum) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['SHA-1', 'sha-1', 'SHA-256', 'sha-256', 'SHA-512', 'sha-512', 'CreatedDate', 'createddate', 'ModifiedDate', 'modifieddate'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are SHA-1, SHA-256, SHA-512, CreatedDate, ModifiedDate")
+      end
+    end
+  end
+
+  # Name:         Recurse
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_recurse) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         Force
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_force) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         CreatedDate
+  # Type:         datetime
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_createddate) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ModifiedDate
+  # Type:         datetime
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_modifieddate) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Attributes
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       ["ReadOnly", "Hidden", "System", "Archive"]
+  newparam(:dsc_attributes, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+      if value.kind_of?(Array)
+        unless (['ReadOnly', 'readonly', 'Hidden', 'hidden', 'System', 'system', 'Archive', 'archive'] & value).count == value.count
+          fail("Invalid value #{value}. Valid values are ReadOnly, Hidden, System, Archive")
+        end
+      end
+      if value.kind_of?(String)
+        unless ['ReadOnly', 'readonly', 'Hidden', 'hidden', 'System', 'system', 'Archive', 'archive'].include?(value)
+          fail("Invalid value #{value}. Valid values are ReadOnly, Hidden, System, Archive")
+        end
+      end
+    end
+  end
+
+  # Name:         Size
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_size) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         SubItems
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_subitems, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         MatchSource
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_matchsource) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -1,0 +1,148 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_group) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC Group resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_GroupResource/MSFT_GroupResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_groupname is a required attribute') if self[:dsc_groupname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "Group"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_GroupResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         GroupName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_groupname) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Members
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_members, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         MembersToInclude
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_memberstoinclude, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         MembersToExclude
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_memberstoexclude, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -1,0 +1,65 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_log) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC Log resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_LogResource/MSFT_LogResource.schema.mof
+  }
+
+  validate do
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "Log"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_LogResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Message
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_message) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -1,0 +1,238 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_package) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC Package resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_PackageResource/MSFT_PackageResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+      fail('dsc_productid is a required attribute') if self[:dsc_productid].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "Package"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_PackageResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ProductId
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_productid) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Arguments
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_arguments) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ReturnCode
+  # Type:         uint32[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_returncode, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         LogPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_logpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PackageDescription
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_packagedescription) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Publisher
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_publisher) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InstalledOn
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_installedon) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Size
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_size) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         Version
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_version) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Installed
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_installed) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -1,0 +1,155 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_registry) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC Registry resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_RegistryResource/MSFT_RegistryResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_key is a required attribute') if self[:dsc_key].nil?
+      fail('dsc_valuename is a required attribute') if self[:dsc_valuename].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "Registry"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_RegistryResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Key
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_key) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ValueName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_valuename) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ValueData
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_valuedata, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         ValueType
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["String", "Binary", "Dword", "Qword", "MultiString", "ExpandString"]
+  newparam(:dsc_valuetype) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['String', 'string', 'Binary', 'binary', 'Dword', 'dword', 'Qword', 'qword', 'MultiString', 'multistring', 'ExpandString', 'expandstring'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are String, Binary, Dword, Qword, MultiString, ExpandString")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Hex
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_hex) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         Force
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_force) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -1,0 +1,119 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_script) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC Script resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_ScriptResource/MSFT_ScriptResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_getscript is a required attribute') if self[:dsc_getscript].nil?
+      fail('dsc_setscript is a required attribute') if self[:dsc_setscript].nil?
+      fail('dsc_testscript is a required attribute') if self[:dsc_testscript].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "Script"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_ScriptResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         GetScript
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_getscript) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SetScript
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_setscript) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         TestScript
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_testscript) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Result
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_result) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -1,0 +1,184 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_service) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC Service resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_ServiceResource/MSFT_ServiceResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "Service"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_ServiceResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         State
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Running", "Stopped"]
+  newparam(:dsc_state) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Running', 'running', 'Stopped', 'stopped'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Running, Stopped")
+      end
+    end
+  end
+
+  # Name:         StartupType
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Automatic", "Manual", "Disabled"]
+  newparam(:dsc_startuptype) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Automatic', 'automatic', 'Manual', 'manual', 'Disabled', 'disabled'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Automatic, Manual, Disabled")
+      end
+    end
+  end
+
+  # Name:         BuiltInAccount
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["LocalSystem", "LocalService", "NetworkService"]
+  newparam(:dsc_builtinaccount) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['LocalSystem', 'localsystem', 'LocalService', 'localservice', 'NetworkService', 'networkservice'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are LocalSystem, LocalService, NetworkService")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Status
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_status) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DisplayName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_displayname) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Dependencies
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dependencies, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -1,0 +1,176 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_user) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC User resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_UserResource/MSFT_UserResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_username is a required attribute') if self[:dsc_username].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "User"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_UserResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         UserName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_username) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         FullName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_fullname) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Password
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_password) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Disabled
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_disabled) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         PasswordNeverExpires
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_passwordneverexpires) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         PasswordChangeRequired
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_passwordchangerequired) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         PasswordChangeNotAllowed
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_passwordchangenotallowed) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_webdeploy.rb
+++ b/lib/puppet/type/dsc_webdeploy.rb
@@ -1,0 +1,105 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_webdeploy) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC WebDeploy resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWebAdministration/DSCResources/MSFT_xWebDeploy/MSFT_xWebdeploy.schema.mof
+  }
+
+  validate do
+      fail('dsc_packagepath is a required attribute') if self[:dsc_packagepath].nil?
+      fail('dsc_contentpath is a required attribute') if self[:dsc_contentpath].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "WebDeploy"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWebdeploy"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWebAdministration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.3.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         PackagePath
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_packagepath) do
+    desc "Path to Web Deploy package (zip format)."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ContentPath
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_contentpath) do
+    desc "Path to Web Site (content path or site name)."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Desired state of resource."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -1,0 +1,150 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_windowsfeature) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC WindowsFeature resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_RoleResource/MSFT_RoleResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "WindowsFeature"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_RoleResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "An enumerated value that describes if the role or feature is expected to be installed on not on the machine.\nPresent {default}  \nAbsent   \n"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         DisplayName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_displayname) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Source
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_source) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         IncludeAllSubFeature
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_includeallsubfeature) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         LogPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_logpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -1,0 +1,237 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_windowsprocess) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC WindowsProcess resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-wmf-4/PSDesiredStateConfiguration/DSCResources/MSFT_ProcessResource/MSFT_ProcessResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_path is a required attribute') if self[:dsc_path].nil?
+      fail('dsc_arguments is a required attribute') if self[:dsc_arguments].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "WindowsProcess"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_ProcessResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "PSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_path) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Arguments
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_arguments) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         StandardOutputPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_standardoutputpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         StandardErrorPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_standarderrorpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         StandardInputPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_standardinputpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         WorkingDirectory
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_workingdirectory) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PagedMemorySize
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_pagedmemorysize) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         NonPagedMemorySize
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_nonpagedmemorysize) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         VirtualMemorySize
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_virtualmemorysize) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         HandleCount
+  # Type:         sint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_handlecount) do
+    validate do |value|
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+          fail("Invalid value #{value}. Should be a signed Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         ProcessId
+  # Type:         sint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_processid) do
+    validate do |value|
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+          fail("Invalid value #{value}. Should be a signed Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -1,0 +1,115 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xaddomain) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xADDomain resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xActiveDirectory/DSCResources/MSFT_xADDomain/MSFT_xADDomain.schema.mof
+  }
+
+  validate do
+      fail('dsc_domainname is a required attribute') if self[:dsc_domainname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xADDomain"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xADDomain"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xActiveDirectory"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         DomainName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_domainname) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ParentDomainName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_parentdomainname) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DomainAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_domainadministratorcredential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SafemodeAdministratorPassword
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_safemodeadministratorpassword) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DnsDelegationCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dnsdelegationcredential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -1,0 +1,91 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xaddomaincontroller) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xADDomainController resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xActiveDirectory/DSCResources/MSFT_xADDomainController/MSFT_xADDomainController.schema.mof
+  }
+
+  validate do
+      fail('dsc_domainname is a required attribute') if self[:dsc_domainname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xADDomainController"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xADDomainController"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xActiveDirectory"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         DomainName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_domainname) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DomainAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_domainadministratorcredential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SafemodeAdministratorPassword
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_safemodeadministratorpassword) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -1,0 +1,150 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xaddomaintrust) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xADDomainTrust resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xActiveDirectory/DSCResources/MSFT_xADDomainTrust/MSFT_xADDomainTrust.schema.mof
+  }
+
+  validate do
+      fail('dsc_targetdomainname is a required attribute') if self[:dsc_targetdomainname].nil?
+      fail('dsc_sourcedomainname is a required attribute') if self[:dsc_sourcedomainname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xADDomainTrust"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xADDomainTrust"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xActiveDirectory"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Should this resource be present or absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         TargetDomainAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_targetdomainadministratorcredential) do
+    desc "Credentials to authenticate to the target domain"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         TargetDomainName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_targetdomainname) do
+    desc "Name of the AD domain that is being trusted"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         TrustType
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["External"]
+  newparam(:dsc_trusttype) do
+    desc "Type of trust"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['External', 'external'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are External")
+      end
+    end
+  end
+
+  # Name:         TrustDirection
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Bidirectional", "Inbound", "Outbound"]
+  newparam(:dsc_trustdirection) do
+    desc "Direction of trust"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Bidirectional', 'bidirectional', 'Inbound', 'inbound', 'Outbound', 'outbound'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Bidirectional, Inbound, Outbound")
+      end
+    end
+  end
+
+  # Name:         SourceDomainName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_sourcedomainname) do
+    desc "Name of the AD domain that is requesting the trust"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -1,0 +1,126 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xaduser) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xADUser resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xActiveDirectory/DSCResources/MSFT_xADUser/MSFT_xADUser.schema.mof
+  }
+
+  validate do
+      fail('dsc_domainname is a required attribute') if self[:dsc_domainname].nil?
+      fail('dsc_username is a required attribute') if self[:dsc_username].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xADUser"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xADUser"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xActiveDirectory"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         DomainName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_domainname) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         UserName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_username) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Password
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_password) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DomainAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_domainadministratorcredential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -1,0 +1,181 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xarchive) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xArchive resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xArchive/MSFT_xArchive.schema.mof
+  }
+
+  validate do
+      fail('dsc_destination is a required attribute') if self[:dsc_destination].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xArchive"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xArchive"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Destination
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_destination) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path, :array_matching => :all) do
+    desc "Represnts the source path to one or more files or directories.\n"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         CompressionLevel
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Optimal", "NoCompression", "Fastest"]
+  newparam(:dsc_compressionlevel) do
+    desc "Specifies values that indicate whether a compression operation emphasizes speed or compression size.\nOptimal {default} \n"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Optimal', 'optimal', 'NoCompression', 'nocompression', 'Fastest', 'fastest'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Optimal, NoCompression, Fastest")
+      end
+    end
+  end
+
+  # Name:         DestinationType
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["File", "Directory"]
+  newparam(:dsc_destinationtype) do
+    desc "An enumerated value that describes if the Destination path points to a File or Directory. If Directory is specified then the archive file contents would be expanded to the specified path on the other hand if File is specified, an archive file would be created at the specified destination path.\nDirectory {default} \n"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['File', 'file', 'Directory', 'directory'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are File, Directory")
+      end
+    end
+  end
+
+  # Name:         MatchSource
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_matchsource) do
+    desc "An boolean value to indicate if the destination contents have to be always kept in sync with the files or directories specified in the source path.\n"
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         CreationTime
+  # Type:         datetime
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_creationtime) do
+    desc "Specifies the local time at which the file or directory was created in datetime format.\n"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Attributes
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_attributes) do
+    desc "Specifies the attributes of the file or directory in string format.\n"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Mode
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_mode) do
+    desc "Specifies the mode of the file or directory.\n"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Size
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_size) do
+    desc "Specifis the size of the file or directory in bytes.\n"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -1,0 +1,129 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureAffinityGroup resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureAffinityGroup/MSFT_xAzureAffinityGroup.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureAffinityGroup"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureAffinityGroup"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Specifies a name for the new affinity group that is unique to the subscription."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Specifies whether the Azure Affinity Group should be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Location
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_location) do
+    desc "Specifies the geographical location of the data center where the affinity group will be created.  This must match a value from the Name property of objects returned by Get-AzureLocation."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    desc "Specifies a description for the affinity group. The description may be up to 1024 characters in length. "
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Label
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_label) do
+    desc "Specifies a label for the affinity group. The label may be up to 100 characters in length. "
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -1,0 +1,196 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazurequickvm) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureQuickVM resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureQuickVM/MSFT_xAzureQuickVM.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureQuickVM"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureQuickVM"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Specifies the name of the virtual machine."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Specifies whether the Azure VM should be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ImageName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_imagename) do
+    desc "Specifies the name of the operating system image to use to create the operating system disk."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ServiceName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_servicename) do
+    desc "Specifies the new or existing service name. "
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Linux
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_linux) do
+    desc "Creates a Linux virtual machine."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         LinuxUser
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_linuxuser) do
+    desc "Specifies the Linux administrative account name to create."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Windows
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_windows) do
+    desc "Creates a Windows virtual machine."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         AdminUsername
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_adminusername) do
+    desc "Specifies the name for the administrative account to create."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Password
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_password) do
+    desc "Specifies the password for the administrative account."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InstanceSize
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_instancesize) do
+    desc "Specifies the size of the instance.   For a list of virtual machine sizes, see http://msdn.microsoft.com/library/azure/dn197896.aspx"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -1,0 +1,129 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazureservice) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureService resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureService/MSFT_xAzureService.schema.mof
+  }
+
+  validate do
+      fail('dsc_servicename is a required attribute') if self[:dsc_servicename].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureService"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureService"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         ServiceName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_servicename) do
+    desc "Specifies a name for the new cloud service that is unique to the subscription."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Specifies whether the service should be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    desc "Specifies the Azure Affinity Group for the service."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AffinityGroup
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_affinitygroup) do
+    desc "Specifies a description for the service."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Label
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_label) do
+    desc "Specifies a label for the service."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -1,0 +1,184 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazuresqldatabase) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureSqlDatabase resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureSqlDatabase/MSFT_xAzureSqlDatabase.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureSqlDatabase"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureSqlDatabase"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the database"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         MaximumSizeInGB
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_maximumsizeingb) do
+    desc "Maximum size of the database in GB"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         Collation
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_collation) do
+    desc "Collation of the database"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Edition
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_edition) do
+    desc "Edition of the database"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ServerCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_servercredential) do
+    desc "Credential to the database server"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ServerName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_servername) do
+    desc "Name of the database server"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AzureSubscriptionName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_azuresubscriptionname) do
+    desc "Specifies the name of the Azure subscription that should be set to Current"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AzurePublishSettingsFile
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_azurepublishsettingsfile) do
+    desc "Specifies the location of the Publish Settings file for the Azure Subscription"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Ensure that database is present or absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -1,0 +1,157 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureSqlDatabaseServerFirewallRule resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureSqlDatabaseServerFirewallRule/MSFT_xAzureSqlDatabaseServerFirewallRule.schema.mof
+  }
+
+  validate do
+      fail('dsc_rulename is a required attribute') if self[:dsc_rulename].nil?
+      fail('dsc_servername is a required attribute') if self[:dsc_servername].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureSqlDatabaseServerFirewallRule"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureSqlDatabaseServerFirewallRule"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         RuleName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_rulename) do
+    desc "Name of the firewall rule"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ServerName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_servername) do
+    desc "Name of the database server for which firewall rule should be created"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         StartIPAddress
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_startipaddress) do
+    desc "Start IP address of the firewall rule"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         EndIPAddress
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_endipaddress) do
+    desc "End IP address of the firewall rule"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AzureSubscriptionName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_azuresubscriptionname) do
+    desc "Specifies the name of the Azure subscription that should be set to Current"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AzurePublishSettingsFile
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_azurepublishsettingsfile) do
+    desc "Specifies the location of the Publish Settings file for the Azure Subscription"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Ensure that firewall rule is present or absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -1,0 +1,142 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazurestorageaccount) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureStorageAccount resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureStorageAccount/MSFT_xAzureStorageAccount.schema.mof
+  }
+
+  validate do
+      fail('dsc_storageaccountname is a required attribute') if self[:dsc_storageaccountname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureStorageAccount"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureStorageAccount"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         StorageAccountName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_storageaccountname) do
+    desc "Specifies a name for the storage account. The storage account name must be unique to Windows Azure and must be between 3 and 24 characters in length and use lowercase letters and numbers only."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Specifies whether the Azure Storage Account should be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         AffinityGroup
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_affinitygroup) do
+    desc "Specifies the name of an existing affinity group in the current subscription. You can specify either a Location or an AffinityGroup parameter, but not both. "
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Container
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_container) do
+    desc "Specifies a name for the Container that should be created in the Azure Storage Account."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Folder
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_folder) do
+    desc "Specifies a local folder.  All files in the root of the folder will be uploaded to the new container."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Label
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_label) do
+    desc "Specifies a label for the storage account. The label may be up to 100 characters in length."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -1,0 +1,103 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazuresubscription) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureSubscription resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureSubscription/MSFT_xAzureSubscription.schema.mof
+  }
+
+  validate do
+      fail('dsc_azuresubscriptionname is a required attribute') if self[:dsc_azuresubscriptionname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureSubscription"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureSubscription"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Specifies whether the subscription should be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         AzureSubscriptionName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_azuresubscriptionname) do
+    desc "Specifies the name of the Azure subscription that should be set to Current."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AzurePublishSettingsFile
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_azurepublishsettingsfile) do
+    desc "Specifies the location of the Publish Settings file for the Azure Subscription."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -1,0 +1,221 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazurevm) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureVM resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureVM/MSFT_xAzureVM.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureVM"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureVM"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Specifies the name of the virtual machine."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Specifies whether the Azure VM should be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ImageName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_imagename) do
+    desc "Specifies the name of the operating system image to use to create the operating system disk."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ServiceName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_servicename) do
+    desc "Specifies the new or existing service name."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         StorageAccountName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_storageaccountname) do
+    desc "Specifies the name of the storage account for the VM."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InstanceSize
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_instancesize) do
+    desc "Specifies the size of the instance.   For a list of virtual machine sizes, see http://msdn.microsoft.com/library/azure/dn197896.aspx"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Linux
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_linux) do
+    desc "Creates a Linux virtual machine."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         Windows
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_windows) do
+    desc "Creates a Windows virtual machine."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ExtensionContainerName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_extensioncontainername) do
+    desc "The name of the Container in Azure Blob storage where the script files will reside.  Case sensitive."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ExtensionFileList
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_extensionfilelist) do
+    desc "List of files in Azure Blob container that should be copied in to the VM.  Case sensitive."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ExtensionScriptName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_extensionscriptname) do
+    desc "Name of one of the files in the container that will be exectued at startup.  Case sensitive."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -1,0 +1,155 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xAzureVMDscConfiguration resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xAzure/DSCResources/MSFT_xAzureVMDscConfiguration/MSFT_xAzureVMDscConfiguration.schema.mof
+  }
+
+  validate do
+      fail('dsc_storageaccountname is a required attribute') if self[:dsc_storageaccountname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xAzureVMDscConfiguration"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xAzureVMDscConfiguration"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xAzure"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         StorageAccountName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_storageaccountname) do
+    desc "Specifies name of the existing storage account."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Specifies whether the supplied Configuration is Present or Absent in Azure Storage"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ContainerName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_containername) do
+    desc "Specifies the name of the Container in the Azure Storage Account."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ConfigurationPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_configurationpath) do
+    desc "Specifies location of the Dsc Configuration document"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AzureSubscriptionName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_azuresubscriptionname) do
+    desc "Specifies the name of the Azure subscription that should be set to Current."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AzurePublishSettingsPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_azurepublishsettingspath) do
+    desc "Specifies the location of the Publish Settings file for the Azure Subscription."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         BlobUri
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_bloburi) do
+    desc "Absolute Uri of the Blob"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -1,0 +1,94 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xcluster) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xCluster resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xFailOverCluster/DSCResources/MSFT_xCluster/MSFT_xCluster.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xCluster"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xCluster"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xFailOverCluster"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the Cluster"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         StaticIPAddress
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_staticipaddress) do
+    desc "StaticIPAddress of the Cluster"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DomainAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_domainadministratorcredential) do
+    desc "Credential to create the cluster"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -1,0 +1,115 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xcomputer) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xComputer resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xComputerManagement/DSCResources/MSFT_xComputer/MSFT_xComputer.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xComputer"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xComputer"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xComputerManagement"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DomainName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_domainname) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         UnjoinCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_unjoincredential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         WorkGroupName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_workgroupname) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -1,0 +1,183 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdatabase) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDatabase resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xDatabase/DSCResources/MSFT_xDatabase/MSFT_xDatabase.schema.mof
+  }
+
+  validate do
+      fail('dsc_databasename is a required attribute') if self[:dsc_databasename].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDatabase"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDatabase"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xDatabase"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Credentials
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credentials) do
+    desc "Credentials to Connect to the sql server"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         SqlServer
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sqlserver) do
+    desc "Sql Server Name"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SqlServerVersion
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["2008-R2", "2012", "2014"]
+  newparam(:dsc_sqlserverversion) do
+    desc "Sql Server Version For DacFx"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['2008-R2', '2008-r2', '2012', '2012', '2014', '2014'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are 2008-R2, 2012, 2014")
+      end
+    end
+  end
+
+  # Name:         BacPacPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_bacpacpath) do
+    desc "Path to BacPac, if this is specified resore is performed"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DatabaseName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_databasename) do
+    desc "Name of the Database"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DacPacPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dacpacpath) do
+    desc "Path to DacPac, if this is specified dacpac deployment is performed"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DacPacApplicationName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dacpacapplicationname) do
+    desc "DacPac Application Name for Registration"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DacPacApplicationVersion
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dacpacapplicationversion) do
+    desc "DacPac Application Version for Registration"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -1,0 +1,139 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdbpackage) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDBPackage resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xDatabase/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.schema.mof
+  }
+
+  validate do
+      fail('dsc_databasename is a required attribute') if self[:dsc_databasename].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDBPackage"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDBPackage"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xDatabase"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Credentials
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credentials) do
+    desc "Credentials to Connect to the sql server"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DatabaseName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_databasename) do
+    desc "Name of the Database"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SqlServer
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sqlserver) do
+    desc "Sql Server Name"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path) do
+    desc "Path to BacPac/DacPac"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Type
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["DACPAC", "BACPAC"]
+  newparam(:dsc_type) do
+    desc "Type for backup(Extract id done for DACPAC and Import for BACPAC)"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['DACPAC', 'dacpac', 'BACPAC', 'bacpac'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are DACPAC, BACPAC")
+      end
+    end
+  end
+
+  # Name:         SqlServerVersion
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["2008-R2", "2012", "2014"]
+  newparam(:dsc_sqlserverversion) do
+    desc "Sql Server Version For DacFx"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['2008-R2', '2008-r2', '2012', '2012', '2014', '2014'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are 2008-R2, 2012, 2014")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -1,0 +1,132 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdhcpserveroption) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDhcpServerOption resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xDhcpServer/DSCResources/MSFT_xDhcpServerOption/MSFT_xDhcpServerOption.schema.mof
+  }
+
+  validate do
+      fail('dsc_scopeid is a required attribute') if self[:dsc_scopeid].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDhcpServerOption"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDhcpServerOption"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xDhcpServer"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         ScopeID
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_scopeid) do
+    desc "ScopeId for which options are set"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DnsServerIPAddress
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dnsserveripaddress, :array_matching => :all) do
+    desc "IP address of DNS Servers"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         DnsDomain
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dnsdomain) do
+    desc "Domain name of DNS Server"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AddressFamily
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["IPv4"]
+  newparam(:dsc_addressfamily) do
+    desc "Address family type"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['IPv4', 'ipv4'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are IPv4")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Whether option should be set or removed"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -1,0 +1,147 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDhcpServerReservation resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xDhcpServer/DSCResources/MSFT_xDhcpServerReservation/MSFT_xDhcpServerReservation.schema.mof
+  }
+
+  validate do
+      fail('dsc_scopeid is a required attribute') if self[:dsc_scopeid].nil?
+      fail('dsc_ipaddress is a required attribute') if self[:dsc_ipaddress].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDhcpServerReservation"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDhcpServerReservation"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xDhcpServer"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         ScopeID
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_scopeid) do
+    desc "ScopeId for which reservations are set"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         IPAddress
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_ipaddress) do
+    desc "IP address of the reservation for which the properties are modified"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ClientMACAddress
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_clientmacaddress) do
+    desc "Client MAC Address to set on the reservation"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Reservation name"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AddressFamily
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["IPv4"]
+  newparam(:dsc_addressfamily) do
+    desc "Address family type"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['IPv4', 'ipv4'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are IPv4")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Whether option should be set or removed"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -1,0 +1,189 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdhcpserverscope) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDhcpServerScope resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xDhcpServer/DSCResources/MSFT_xDhcpServerScope/MSFT_xDhcpServerScope.schema.mof
+  }
+
+  validate do
+      fail('dsc_ipstartrange is a required attribute') if self[:dsc_ipstartrange].nil?
+      fail('dsc_ipendrange is a required attribute') if self[:dsc_ipendrange].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDhcpServerScope"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDhcpServerScope"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xDhcpServer"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         IPStartRange
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_ipstartrange) do
+    desc "Starting address to set for this scope"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         IPEndRange
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_ipendrange) do
+    desc "Ending address to set for this scope"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of DHCP Scope"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SubnetMask
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_subnetmask) do
+    desc "Subnet mask for the scope specified in IP address format"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         LeaseDuration
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_leaseduration) do
+    desc "Time interval for which an IP address should be leased"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         State
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Active", "Inactive"]
+  newparam(:dsc_state) do
+    desc "Whether scope should be active or inactive"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Active', 'active', 'Inactive', 'inactive'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Active, Inactive")
+      end
+    end
+  end
+
+  # Name:         AddressFamily
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["IPv4"]
+  newparam(:dsc_addressfamily) do
+    desc "Address family type"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['IPv4', 'ipv4'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are IPv4")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Whether scope should be set or removed"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ScopeID
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_scopeid) do
+    desc "ScopeId for the given scope"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -1,0 +1,94 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdnsserveraddress) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDNSServerAddress resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xNetworking/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.schema.mof
+  }
+
+  validate do
+      fail('dsc_interfacealias is a required attribute') if self[:dsc_interfacealias].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDNSServerAddress"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDNSServerAddress"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xNetworking"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Address
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_address, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         InterfaceAlias
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_interfacealias) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AddressFamily
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["IPv4", "IPv6"]
+  newparam(:dsc_addressfamily) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['IPv4', 'ipv4', 'IPv6', 'ipv6'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are IPv4, IPv6")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -1,0 +1,116 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDnsServerSecondaryZone resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xDnsServer/DSCResources/MSFT_xDnsServerSecondaryZone/MSFT_xDnsServerSecondaryZone.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDnsServerSecondaryZone"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDnsServerSecondaryZone"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xDnsServer"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the secondary zone"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         MasterServers
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_masterservers, :array_matching => :all) do
+    desc "IP address or DNS name of the secondary DNS servers"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Should this resource be present or absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Type
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_type) do
+    desc "Type of the DNS server zone"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -1,0 +1,97 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDnsServerZoneTransfer resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xDnsServer/DSCResources/MSFT_xDnsServerZoneTransfer/MSFT_xDnsServerZoneTransfer.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDnsServerZoneTransfer"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDnsServerZoneTransfer"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xDnsServer"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the DNS zone"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Type
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["None", "Any", "Named", "Specific"]
+  newparam(:dsc_type) do
+    desc "Type of transfer allowed"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['None', 'none', 'Any', 'any', 'Named', 'named', 'Specific', 'specific'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are None, Any, Named, Specific")
+      end
+    end
+  end
+
+  # Name:         SecondaryServer
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_secondaryserver, :array_matching => :all) do
+    desc "IP address or DNS name of DNS servers where zone information can be transfered"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -1,0 +1,191 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xdscwebservice) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xDSCWebService resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xDSCWebService/MSFT_xDSCWebService.Schema.mof
+  }
+
+  validate do
+      fail('dsc_endpointname is a required attribute') if self[:dsc_endpointname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xDSCWebService"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xDSCWebService"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         EndpointName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_endpointname) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         CertificateThumbPrint
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_certificatethumbprint) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Port
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_port) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         PhysicalPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_physicalpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         State
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Started", "Stopped"]
+  newparam(:dsc_state) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Started', 'started', 'Stopped', 'stopped'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Started, Stopped")
+      end
+    end
+  end
+
+  # Name:         ModulePath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_modulepath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ConfigurationPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_configurationpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         IsComplianceServer
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_iscomplianceserver) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         DSCServerUrl
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dscserverurl) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -1,0 +1,265 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xfirewall) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xFirewall resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.Schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xFirewall"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xFirewall"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xNetworking"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the Firewall Rule"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DisplayName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_displayname) do
+    desc "Localized, user-facing name of the Firewall Rule being created"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DisplayGroup
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_displaygroup) do
+    desc "Name of the Firewall Group where we want to put the Firewall Rules"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Ensure the presence/absence of the resource"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Access
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["NotConfigured", "Allow", "Block"]
+  newparam(:dsc_access) do
+    desc "Permit or Block the supplied configuration"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['NotConfigured', 'notconfigured', 'Allow', 'allow', 'Block', 'block'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are NotConfigured, Allow, Block")
+      end
+    end
+  end
+
+  # Name:         State
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Enabled", "Disabled"]
+  newparam(:dsc_state) do
+    desc "Enable or disable the supplied configuration"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Enabled', 'enabled', 'Disabled', 'disabled'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Enabled, Disabled")
+      end
+    end
+  end
+
+  # Name:         Profile
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       ["Any", "Public", "Private", "Domain"]
+  newparam(:dsc_profile, :array_matching => :all) do
+    desc "Specifies one or more profiles to which the rule is assigned"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+      if value.kind_of?(Array)
+        unless (['Any', 'any', 'Public', 'public', 'Private', 'private', 'Domain', 'domain'] & value).count == value.count
+          fail("Invalid value #{value}. Valid values are Any, Public, Private, Domain")
+        end
+      end
+      if value.kind_of?(String)
+        unless ['Any', 'any', 'Public', 'public', 'Private', 'private', 'Domain', 'domain'].include?(value)
+          fail("Invalid value #{value}. Valid values are Any, Public, Private, Domain")
+        end
+      end
+    end
+  end
+
+  # Name:         Direction
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Inbound", "Outbound"]
+  newparam(:dsc_direction) do
+    desc "Direction of the connection"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Inbound', 'inbound', 'Outbound', 'outbound'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Inbound, Outbound")
+      end
+    end
+  end
+
+  # Name:         RemotePort
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_remoteport, :array_matching => :all) do
+    desc "Specific Port used for filter. Specified by port number, range, or keyword"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         LocalPort
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_localport, :array_matching => :all) do
+    desc "Local Port used for the filter"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Protocol
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_protocol) do
+    desc "Specific Protocol for filter. Specified by name, number, or range"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    desc "Documentation for the Rule"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ApplicationPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_applicationpath) do
+    desc "Path and file name of the program for which the rule is applied"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Service
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_service) do
+    desc "Specifies the short name of a Windows service to which the firewall rule applies"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -1,0 +1,148 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xgroup) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xGroup resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xGroupResource/MSFT_xGroupResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_groupname is a required attribute') if self[:dsc_groupname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xGroup"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xGroupResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         GroupName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_groupname) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Members
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_members, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         MembersToInclude
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_memberstoinclude, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         MembersToExclude
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_memberstoexclude, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -1,0 +1,172 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xiismodule) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xIisModule resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWebAdministration/DSCResources/MSFT_xIisModule/MSFT_xIisModule.schema.mof
+  }
+
+  validate do
+      fail('dsc_path is a required attribute') if self[:dsc_path].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xIisModule"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xIisModule"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWebAdministration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.3.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_path) do
+    desc "The path to the module, usually a dll, to be added to IIS."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "The logical name of the module to add to IIS."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         RequestPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_requestpath) do
+    desc "The allowed request Path example: *.php"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Verb
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_verb, :array_matching => :all) do
+    desc "The supported verbs for the module."
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         SiteName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sitename) do
+    desc "The IIS Site to register the module."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Should the module be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ModuleType
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["FastCgiModule"]
+  newparam(:dsc_moduletype) do
+    desc "The type of the module."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['FastCgiModule', 'fastcgimodule'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are FastCgiModule")
+      end
+    end
+  end
+
+  # Name:         EndPointSetup
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_endpointsetup) do
+    desc "The End Point is setup.  Such as a Fast Cgi endpoint."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xiiswordpresssite.rb
+++ b/lib/puppet/type/dsc_xiiswordpresssite.rb
@@ -1,0 +1,103 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xiiswordpresssite) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xIisWordPressSite resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWordPress/DscResources/xIisWordPressSite/xIisWordPressSite.schema.mof
+  }
+
+  validate do
+      fail('dsc_destinationpath is a required attribute') if self[:dsc_destinationpath].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xIisWordPressSite"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "xIisWordPressSite"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWordPress"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0.0.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         DestinationPath
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_destinationpath) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DownloadUri
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_downloaduri) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PackageFolder
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_packagefolder) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Configuration
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_configuration) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -1,0 +1,123 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xipaddress) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xIPAddress resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xNetworking/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.schema.mof
+  }
+
+  validate do
+      fail('dsc_ipaddress is a required attribute') if self[:dsc_ipaddress].nil?
+      fail('dsc_interfacealias is a required attribute') if self[:dsc_interfacealias].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xIPAddress"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xIPAddress"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xNetworking"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         IPAddress
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_ipaddress) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InterfaceAlias
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_interfacealias) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DefaultGateway
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_defaultgateway) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SubnetMask
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_subnetmask) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         AddressFamily
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["IPv4", "IPv6"]
+  newparam(:dsc_addressfamily) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['IPv4', 'ipv4', 'IPv6', 'ipv6'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are IPv4, IPv6")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -1,0 +1,141 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xjeaendpoint) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xJeaEndPoint resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xJea/DSCResources/MSFT_xJeaEndpoint/MSFT_xJeaEndpoint.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xJeaEndPoint"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xJeaEndpoint"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xJea"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.2.16.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the JEA toolkit to be generated"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Toolkit
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_toolkit, :array_matching => :all) do
+    desc "List of Jea Toolkits to make available via this endpoint"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         SecurityDescriptorSddl
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_securitydescriptorsddl) do
+    desc "Sddl to define who can access this JeaEndpoint"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Group
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_group, :array_matching => :all) do
+    desc "List of local groups that this Endpoints JeaSessionAccount should be a member of"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         CleanAll
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_cleanall) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -1,0 +1,128 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xjeatoolkit) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xJeaToolKit resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xJea/DSCResources/MSFT_xJeaToolkit/MSFT_xJeaToolkit.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xJeaToolKit"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xJeaToolkit"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xJea"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.2.16.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the JEA toolkit to be generated"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         CommandSpecs
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_commandspecs) do
+    desc "CSV formated list of command specifications"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ScriptDirectory
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_scriptdirectory, :array_matching => :all) do
+    desc "array of script directories that can be run"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Applications
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_applications, :array_matching => :all) do
+    desc "Array of executables that are allowed to run"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -1,0 +1,103 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xmysqldatabase) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xMySqlDatabase resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xMySql/DscResources/MSFT_xMySqlDatabase/MSFT_xMySqlDatabase.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xMySqlDatabase"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xMySqlDatabase"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xMySql"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0.0.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the database."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Should the database be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ConnectionCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_connectioncredential) do
+    desc "The root credential that is used to install MySql server."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -1,0 +1,134 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xmysqlgrant) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xMySqlGrant resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xMySql/DscResources/MSFT_xMySqlGrant/MSFT_xMySqlGrant.schema.mof
+  }
+
+  validate do
+      fail('dsc_username is a required attribute') if self[:dsc_username].nil?
+      fail('dsc_databasename is a required attribute') if self[:dsc_databasename].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xMySqlGrant"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xMySqlGrant"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xMySql"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0.0.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         UserName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_username) do
+    desc "Name of MySQL user."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DatabaseName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_databasename) do
+    desc "MySql database name to grant permissions."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ConnectionCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_connectioncredential) do
+    desc "MySql connection credential used for the root."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PermissionType
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["ALL PRIVILEGES", "CREATE", "DROP", "DELETE", "INSERT", "SELECT", "UPDATE", "EXECUTE"]
+  newparam(:dsc_permissiontype) do
+    desc "MySql user permission type."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['ALL PRIVILEGES', 'all privileges', 'CREATE', 'create', 'DROP', 'drop', 'DELETE', 'delete', 'INSERT', 'insert', 'SELECT', 'select', 'UPDATE', 'update', 'EXECUTE', 'execute'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are ALL PRIVILEGES, CREATE, DROP, DELETE, INSERT, SELECT, UPDATE, EXECUTE")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Ensure given grant to mySql database present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -1,0 +1,103 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xmysqlserver) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xMySqlServer resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xMySql/DscResources/MSFT_xMySqlServer/MSFT_xMySqlServer.schema.mof
+  }
+
+  validate do
+      fail('dsc_servicename is a required attribute') if self[:dsc_servicename].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xMySqlServer"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xMySqlServer"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xMySql"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0.0.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         ServiceName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_servicename) do
+    desc "Provides the service name to use during setup of MySQL"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Ensure resource is present or absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         RootPassword
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_rootpassword) do
+    desc "The root credential that is used to install mySql server."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -1,0 +1,116 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xmysqluser) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xMySqlUser resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xMySql/DscResources/MSFT_xMySqlUser/MSFT_xMySqlUser.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xMySqlUser"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xMySqlUser"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xMySql"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0.0.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of MySQL user to create or remove."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    desc "Credential for MySql user."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ConnectionCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_connectioncredential) do
+    desc "MySql connection credential used to create a user."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Ensure mysql user is present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -1,0 +1,286 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xpackage) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xPackage resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xPackageResource/MSFT_xPackageResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+      fail('dsc_productid is a required attribute') if self[:dsc_productid].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xPackage"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xPackageResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ProductId
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_productid) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Arguments
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_arguments) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ReturnCode
+  # Type:         uint32[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_returncode, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         LogPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_logpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PackageDescription
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_packagedescription) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Publisher
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_publisher) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InstalledOn
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_installedon) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Size
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_size) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         Version
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_version) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Installed
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_installed) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         RunAsCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_runascredential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InstalledCheckRegKey
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_installedcheckregkey) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InstalledCheckRegValueName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_installedcheckregvaluename) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InstalledCheckRegValueData
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_installedcheckregvaluedata) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -1,0 +1,145 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xpsendpoint) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xPSEndpoint resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xPSSessionConfiguration/MSFT_xPSSessionConfiguration.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xPSEndpoint"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xPSSessionConfiguration"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the PS Remoting Endpoint"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Whether to create the endpoint or delete it"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         StartupScript
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_startupscript) do
+    desc "Path for the startup script"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         RunAsCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_runascredential) do
+    desc "Credential for Running under different user context"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SecurityDescriptorSDDL
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_securitydescriptorsddl) do
+    desc "SDDL for allowed users to connect to this endpoint"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AccessMode
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Local", "Remote", "Disabled"]
+  newparam(:dsc_accessmode) do
+    desc "Whether the endpoint is remotely accessible or has local access only or no access"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Local', 'local', 'Remote', 'remote', 'Disabled', 'disabled'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Local, Remote, Disabled")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -1,0 +1,109 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xrdsessioncollection) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xRDSessionCollection resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xRemoteDesktopSessionHost/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.schema.mof
+  }
+
+  validate do
+      fail('dsc_collectionname is a required attribute') if self[:dsc_collectionname].nil?
+      fail('dsc_sessionhost is a required attribute') if self[:dsc_sessionhost].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xRDSessionCollection"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xRDSessionCollection"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xRemoteDesktopSessionHost"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         CollectionName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_collectionname) do
+    desc "Specifies a name for the session collection. "
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SessionHost
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_sessionhost) do
+    desc "Specifies an RD Session Host server to include in the session collection. "
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         CollectionDescription
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_collectiondescription) do
+    desc "Specifies a description for the collection."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ConnectionBroker
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_connectionbroker) do
+    desc "Specifies the Remote Desktop Connection Broker (RD Connection Broker) server for a Remote Desktop deployment."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -1,0 +1,320 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xRDSessionCollectionConfiguration resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xRemoteDesktopSessionHost/DSCResources/MSFT_xRDSessionCollectionConfiguration/MSFT_xRDSessionCollectionConfiguration.schema.mof
+  }
+
+  validate do
+      fail('dsc_collectionname is a required attribute') if self[:dsc_collectionname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xRDSessionCollectionConfiguration"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xRDSessionCollectionConfiguration"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xRemoteDesktopSessionHost"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         CollectionName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_collectionname) do
+    desc "Specifies the name of a session collection. "
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ActiveSessionLimitMin
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_activesessionlimitmin) do
+    desc "Specifies the maximum time, in minutes, an active session runs. After this period, the RD Session Host server ends the session. "
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         AuthenticateUsingNLA
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_authenticateusingnla) do
+    desc "Indicates whether to use Network Level Authentication (NLA). If this value is $True, Remote Desktop uses NLA to authenticate a user before the user sees a logon screen. "
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         AutomaticReconnectionEnabled
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_automaticreconnectionenabled) do
+    desc "Indicates whether the Remote Desktop client attempts to reconnect after a connection interruption. "
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         BrokenConnectionAction
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_brokenconnectionaction) do
+    desc "Specifies an action for an RD Session Host server to take after a connection interruption. The acceptable values for this parameter are: None, Disconnect, LogOff."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ClientDeviceRedirectionOptions
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_clientdeviceredirectionoptions) do
+    desc "Specifies a type of client device to be redirected to an RD Session Host server in this session collection. The acceptable values for this parameter are: None, AudioVideoPlayBack, AudioRecording, COMPort, PlugAndPlayDevice, SmartCard, Clipboard, LPTPort, Drive, TimeZone.  You can use binary-or to combine two or more values of this enum to specify multiple client device types."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ClientPrinterAsDefault
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_clientprinterasdefault) do
+    desc "Indicates whether to use the client printer or server printer as the default printer. If this value is $True, use the client printer as default. If this value is $False, use the server as default."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         ClientPrinterRedirected
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_clientprinterredirected) do
+    desc "Indicates whether to use client printer redirection, which routes print jobs from the Remote Desktop session to a printer attached to the client computer."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         CollectionDescription
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_collectiondescription) do
+    desc "Specifies a description of the session collection. "
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ConnectionBroker
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_connectionbroker) do
+    desc "Specifies the Remote Desktop Connection Broker (RD Connection Broker) server for a Remote Desktop deployment."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         CustomRdpProperty
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_customrdpproperty) do
+    desc "Specifies Remote Desktop Protocol (RDP) settings to include in the .rdp files for all Windows Server 2012 RemoteApp programs and remote desktops published in this collection. "
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DisconnectedSessionLimitMin
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_disconnectedsessionlimitmin) do
+    desc "Specifies a length of time, in minutes. After client disconnection from a session for this period, the RD Session Host ends the session."
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         EncryptionLevel
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_encryptionlevel) do
+    desc "Specifies the level of data encryption used for a Remote Desktop session. The acceptable values for this parameter are: Low, ClientCompatible, High, FipsCompliant. The default value is ClientCompatible."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         IdleSessionLimitMin
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_idlesessionlimitmin) do
+    desc "Specifies the length of time, in minutes, to wait before an RD Session Host logs off or disconnects an idle session. The BrokenConnectionAction parameter determines whether to log off or disconnect. "
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         MaxRedirectedMonitors
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_maxredirectedmonitors) do
+    desc "Specifies the maximum number of client monitors that an RD Session Host server can redirect to a remote session. The highest value for this parameter is 16."
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         RDEasyPrintDriverEnabled
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_rdeasyprintdriverenabled) do
+    desc "Specifies whether to enable the Remote Desktop Easy Print driver."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         SecurityLayer
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_securitylayer) do
+    desc "Specifies which security protocol to use. The acceptable values for this parameter are:  RDP, Negotiate, SSL.  The default value is Negotiate."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         TemporaryFoldersDeletedOnExit
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_temporaryfoldersdeletedonexit) do
+    desc "Specifies whether to delete temporary folders from the RD Session Host server for a disconnected session. "
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         UserGroup
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_usergroup) do
+    desc "Specifies a domain group authorized to connect to the RD Session Host servers in a session collection. "
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -1,0 +1,98 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xRDSessionDeployment resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xRemoteDesktopSessionHost/DSCResources/MSFT_xRDSessionDeployment/MSFT_xRDSessionDeployment.schema.mof
+  }
+
+  validate do
+      fail('dsc_sessionhost is a required attribute') if self[:dsc_sessionhost].nil?
+      fail('dsc_connectionbroker is a required attribute') if self[:dsc_connectionbroker].nil?
+      fail('dsc_webaccessserver is a required attribute') if self[:dsc_webaccessserver].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xRDSessionDeployment"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xRDSessionDeployment"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xRemoteDesktopSessionHost"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         SessionHost
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_sessionhost) do
+    desc "Specifies the FQDN of a server to host the RD Session Host role service. "
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ConnectionBroker
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_connectionbroker) do
+    desc "Specifies the FQDN of a server to host the RD Connection Broker role service."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         WebAccessServer
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_webaccessserver) do
+    desc "Specifies the FQDN of a server to host the RD Web Access role service. "
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -1,0 +1,93 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xRemoteDesktopAdmin resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xRemoteDesktopAdmin/DSCResources/MSFT_xRemoteDesktopAdmin/MSFT_xRemoteDesktopAdmin.schema.mof
+  }
+
+  validate do
+      fail('dsc_ensure is a required attribute') if self[:dsc_ensure].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xRemoteDesktopAdmin"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xRemoteDesktopAdmin"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xRemoteDesktopAdmin"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Determines whether or not the computer should accept remote connections.  Present sets the value to Enabled and Absent sets the value to Disabled."
+    isrequired
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         UserAuthentication
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Secure", "NonSecure"]
+  newparam(:dsc_userauthentication) do
+    desc "User Authentication.  Setting this value to Secure configures the machine to require NLA."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Secure', 'secure', 'NonSecure', 'nonsecure'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Secure, NonSecure")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -1,0 +1,142 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xremotefile) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xRemoteFile resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xRemoteFile/MSFT_xRemoteFile.schema.mof
+  }
+
+  validate do
+      fail('dsc_destinationpath is a required attribute') if self[:dsc_destinationpath].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xRemoteFile"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xRemoteFile"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         DestinationPath
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_destinationpath) do
+    desc "Path under which downloaded or copied file should be accessible after operation."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Uri
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_uri) do
+    desc "Uri of a file which should be copied or downloaded. This parameter supports HTTP and HTTPS values."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         UserAgent
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_useragent) do
+    desc "User agent for the web request."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Headers
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_headers, :array_matching => :all) do
+    desc "Headers of the web request."
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    desc "Specifies a user account that has permission to send the request."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Says whether DestinationPath exists on the machine"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -1,0 +1,205 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xservice) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xService resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xServiceResource/MSFT_xServiceResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xService"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xServiceResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         State
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Running", "Stopped"]
+  newparam(:dsc_state) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Running', 'running', 'Stopped', 'stopped'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Running, Stopped")
+      end
+    end
+  end
+
+  # Name:         StartupType
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Automatic", "Manual", "Disabled"]
+  newparam(:dsc_startuptype) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Automatic', 'automatic', 'Manual', 'manual', 'Disabled', 'disabled'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Automatic, Manual, Disabled")
+      end
+    end
+  end
+
+  # Name:         BuiltInAccount
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["LocalSystem", "LocalService", "NetworkService"]
+  newparam(:dsc_builtinaccount) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['LocalSystem', 'localsystem', 'LocalService', 'localservice', 'NetworkService', 'networkservice'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are LocalSystem, LocalService, NetworkService")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Status
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_status) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DisplayName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_displayname) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Dependencies
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_dependencies, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -1,0 +1,266 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xsmbshare) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xSmbShare resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xSmbShare/DscResources/MSFT_xSmbShare/MSFT_xSmbShare.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xSmbShare"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xSmbShare"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xSmbShare"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the SMB Share"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path) do
+    desc "Path to the share"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    desc "Description of the share"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ChangeAccess
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_changeaccess, :array_matching => :all) do
+    desc "Specifies which user will be granted modify permission to access the share"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         ConcurrentUserLimit
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_concurrentuserlimit) do
+    desc "Specifies the maximum number of concurrently connected users that the new SMB share may accommodate. If this parameter is set to zero (0), then the number of users is unlimited. The default value is zero (0)."
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         EncryptData
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_encryptdata) do
+    desc "Indicates that the share is encrypted."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         FolderEnumerationMode
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["AccessBased", "Unrestricted"]
+  newparam(:dsc_folderenumerationmode) do
+    desc "Specifies which files and folders in the new SMB share are visible to users."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['AccessBased', 'accessbased', 'Unrestricted', 'unrestricted'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are AccessBased, Unrestricted")
+      end
+    end
+  end
+
+  # Name:         FullAccess
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_fullaccess, :array_matching => :all) do
+    desc "Specifies which accounts are granted full permission to access the share."
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         NoAccess
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_noaccess, :array_matching => :all) do
+    desc "Specifies which accounts are denied access to the share."
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         ReadAccess
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_readaccess, :array_matching => :all) do
+    desc "Specifies which user is granted read permission to access the share."
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Specifies if the share should be added or removed"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ShareState
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sharestate) do
+    desc "Specfies the state of the share"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ShareType
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sharetype) do
+    desc "Specfies the type of the share"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ShadowCopy
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_shadowcopy) do
+    desc "Specifies if this share is a ShadowCopy"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Special
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_special) do
+    desc "Specifies if this share is a Special Share. Admin share, default shares, IPC$ share are examples."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -1,0 +1,112 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xSqlHAEndPoint resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xSqlPs/DSCResources/MSFT_xSqlHAEndPoint/MSFT_xSqlHAEndPoint.schema.mof
+  }
+
+  validate do
+      fail('dsc_instancename is a required attribute') if self[:dsc_instancename].nil?
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xSqlHAEndPoint"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xSqlHAEndPoint"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xSqlPs"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1.3"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         InstanceName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_instancename) do
+    desc "Name of Sql Instance."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AllowedUser
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_alloweduser) do
+    desc "Windows Account that could access the HA database mirroring endpoing."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Unique name for HA database mirroring endpoint of the sql instance."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PortNumber
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_portnumber) do
+    desc "The single port number(nnnn) on which the Sql HA to listen to."
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -1,0 +1,159 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xsqlhagroup) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xSqlHAGroup resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xSqlPs/DSCResources/MSFT_xSqlHAGroup/MSFT_xSqlHAGroup.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xSqlHAGroup"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xSqlHAGroup"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xSqlPs"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1.3"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "The name of sql availability group"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Database
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_database, :array_matching => :all) do
+    desc "Array of databases on the local sql instance. Each database can belong to only one HA group."
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         ClusterName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_clustername) do
+    desc "The name of windows failover cluster for the availability group"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DatabaseBackupPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_databasebackuppath) do
+    desc "The net share for Sql replication initialization"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         InstanceName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_instancename) do
+    desc "Name of sql instance"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         EndPointName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_endpointname) do
+    desc "Name of EndPoint to access High Availability sql instance."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DomainCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_domaincredential) do
+    desc "Domain credential could get list of cluster nodes."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SqlAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sqladministratorcredential) do
+    desc "Sql sa credential."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -1,0 +1,94 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xsqlhaservice) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xSqlHAService resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xSqlPs/DSCResources/MSFT_xSqlHAService/MSFT_xSqlHAService.schema.mof
+  }
+
+  validate do
+      fail('dsc_instancename is a required attribute') if self[:dsc_instancename].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xSqlHAService"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xSqlHAService"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xSqlPs"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1.3"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         InstanceName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_instancename) do
+    desc "The name of Sql instance."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SqlAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sqladministratorcredential) do
+    desc "Sql sa credential"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ServiceCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_servicecredential) do
+    desc "Domain credential to run sql service"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -1,0 +1,173 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xsqlserverinstall) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xSqlServerInstall resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xSqlPs/DSCResources/MSFT_xSqlServerInstall/MSFT_xSqlServerInstall.schema.mof
+  }
+
+  validate do
+      fail('dsc_instancename is a required attribute') if self[:dsc_instancename].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xSqlServerInstall"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xSqlServerInstall"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xSqlPs"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1.3"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         InstanceName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_instancename) do
+    desc "The name of sql instance."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SourcePath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sourcepath) do
+    desc "The share path of sql server software."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SourcePathCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sourcepathcredential) do
+    desc "The credential that vm could use to access net share of sql server software."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Features
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_features) do
+    desc "List of names of Sql Server features to install"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SqlAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sqladministratorcredential) do
+    desc "Sql sa credential"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         UpdateEnabled
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_updateenabled) do
+    desc "Specify whether SQL server setup should discover and include product updates."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         SvcAccount
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_svcaccount) do
+    desc "Specify the startup account for the SQL server service."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SysAdminAccounts
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sysadminaccounts) do
+    desc "Specify logins to be members of the sysadmin role."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AgentSvcAccount
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_agentsvcaccount) do
+    desc "Specify the account for SQL server agent service."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -1,0 +1,206 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xvhd) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xVHD resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xHyper-V/DSCResources/MSFT_xVHD/MSFT_xVHD.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+      fail('dsc_path is a required attribute') if self[:dsc_path].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xVHD"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xVHD"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xHyper-V"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the VHD File"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_path) do
+    desc "Folder where the VHD will be created"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ParentPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_parentpath) do
+    desc "Parent VHD file path, for differencing disk"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         MaximumSizeBytes
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_maximumsizebytes) do
+    desc "Maximum size of Vhd to be created"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         Generation
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Vhd", "Vhdx"]
+  newparam(:dsc_generation) do
+    desc "Virtual disk format - Vhd or Vhdx"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Vhd', 'vhd', 'Vhdx', 'vhdx'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Vhd, Vhdx")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Should the VHD be created or deleted"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ID
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_id) do
+    desc "Virtual Disk Identifier"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Type
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_type) do
+    desc "Type of Vhd - Dynamic, Fixed, Differencing"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         FileSizeBytes
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_filesizebytes) do
+    desc "Current size of the VHD"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         IsAttached
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_isattached) do
+    desc "Is the VHD attached to a VM or not"
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -1,0 +1,81 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xvhdfile) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xVhdFile resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xHyper-V/DSCResources/MSFT_xVhdFileDirectory/MSFT_xVhdFileDirectory.schema.mof
+  }
+
+  validate do
+      fail('dsc_vhdpath is a required attribute') if self[:dsc_vhdpath].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xVhdFile"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xVhdFileDirectory"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xHyper-V"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         VhdPath
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_vhdpath) do
+    desc "Path to the VHD"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         FileDirectory
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_filedirectory, :array_matching => :all) do
+    desc "The FileDirectory objects to copy to the VHD"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -1,0 +1,377 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xvmhyperv) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xVMHyperV resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xHyper-V/DSCResources/MSFT_xVMHyperV/MSFT_xVMHyperV.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xVMHyperV"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xVMHyperV"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xHyper-V"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the VM"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         VhdPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_vhdpath) do
+    desc "VHD associated with the VM"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SwitchName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_switchname) do
+    desc "Virtual switch associated with the VM"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         State
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Running", "Paused", "Off"]
+  newparam(:dsc_state) do
+    desc "State of the VM"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Running', 'running', 'Paused', 'paused', 'Off', 'off'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Running, Paused, Off")
+      end
+    end
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_path) do
+    desc "Folder where the VM data will be stored"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Generation
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Vhd", "Vhdx"]
+  newparam(:dsc_generation) do
+    desc "Associated Virtual disk format - Vhd or Vhdx"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Vhd', 'vhd', 'Vhdx', 'vhdx'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Vhd, Vhdx")
+      end
+    end
+  end
+
+  # Name:         StartupMemory
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_startupmemory) do
+    desc "Startup RAM for the VM"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         MinimumMemory
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_minimummemory) do
+    desc "Minimum RAM for the VM. This enables dynamic memory"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         MaximumMemory
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_maximummemory) do
+    desc "Maximum RAM for the VM. This enable dynamic memory"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         MACAddress
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_macaddress) do
+    desc "MAC address of the VM"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ProcessorCount
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_processorcount) do
+    desc "Processor count for the VM"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         WaitForIP
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_waitforip) do
+    desc "Waits for VM to get valid IP address"
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         RestartIfNeeded
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_restartifneeded) do
+    desc "If specified, shutdowns and restarts the VM as needed for property changes"
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Should the VM be created or deleted"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         ID
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_id) do
+    desc "VM unique ID"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Status
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_status) do
+    desc "Status of the VM"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         CPUUsage
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_cpuusage) do
+    desc "CPU Usage of the VM"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         MemoryAssigned
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_memoryassigned) do
+    desc "Memory assigned to the VM"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         Uptime
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_uptime) do
+    desc "Uptime of the VM"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         CreationTime
+  # Type:         datetime
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_creationtime) do
+    desc "Creation time of the VM"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         HasDynamicMemory
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_hasdynamicmemory) do
+    desc "Does VM has dynamic memory enabled"
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         NetworkAdapters
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_networkadapters, :array_matching => :all) do
+    desc "Network adapters of the VM"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -1,0 +1,161 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xvmswitch) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xVMSwitch resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xHyper-V/DSCResources/MSFT_xVMSwitch/MSFT_xVMSwitch.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+      fail('dsc_type is a required attribute') if self[:dsc_type].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xVMSwitch"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xVMSwitch"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xHyper-V"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the VM Switch"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Type
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       ["External", "Internal", "Private"]
+  newparam(:dsc_type) do
+    desc "Type of switch"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['External', 'external', 'Internal', 'internal', 'Private', 'private'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are External, Internal, Private")
+      end
+    end
+  end
+
+  # Name:         NetAdapterName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_netadaptername) do
+    desc "Network adapter name for external switch type"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AllowManagementOS
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_allowmanagementos) do
+    desc "Specify is the VM host has access to the physical NIC"
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Whether switch should be present or absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Id
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_id) do
+    desc "Unique ID for the switch"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         NetAdapterInterfaceDescription
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_netadapterinterfacedescription) do
+    desc "Description of the network interface"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -1,0 +1,109 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwaitforaddomain) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWaitForADDomain resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xActiveDirectory/DSCResources/MSFT_xWaitForADDomain/MSFT_xWaitForADDomain.schema.mof
+  }
+
+  validate do
+      fail('dsc_domainname is a required attribute') if self[:dsc_domainname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWaitForADDomain"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWaitForADDomain"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xActiveDirectory"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "2.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         DomainName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_domainname) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DomainUserCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_domainusercredential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         RetryIntervalSec
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_retryintervalsec) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         RetryCount
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_retrycount) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -1,0 +1,100 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwaitforcluster) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWaitForCluster resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xFailOverCluster/DSCResources/MSFT_xWaitForCluster/MSFT_xWaitForCluster.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWaitForCluster"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWaitForCluster"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xFailOverCluster"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the cluster"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         RetryIntervalSec
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_retryintervalsec) do
+    desc "Interval to check the cluster existency"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         RetryCount
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_retrycount) do
+    desc "Maximum number of retries to check cluster existency"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -1,0 +1,152 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWaitForSqlHAGroup resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xSqlPs/DSCResources/MSFT_xWaitForSqlHAGroup/MSFT_xWaitForSqlHAGroup.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWaitForSqlHAGroup"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWaitForSqlHAGroup"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xSqlPs"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.1.3"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "The name of Sql High Availability group"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ClusterName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_clustername) do
+    desc "The name of windows failover cluster for the availability group."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         RetryIntervalSec
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_retryintervalsec) do
+    desc "Interval to check the HA group existency"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         RetryCount
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_retrycount) do
+    desc "Maximum number of retries to check HA group existency"
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         InstanceName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_instancename) do
+    desc "The name of sql instance."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DomainCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_domaincredential) do
+    desc "Domain credential could get list of cluster nodes."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         SqlAdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_sqladministratorcredential) do
+    desc "Sql sa credential"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -1,0 +1,131 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwebapplication) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWebApplication resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWebAdministration/DSCResources/MSFT_xWebApplication/MSFT_xWebApplication.schema.mof
+  }
+
+  validate do
+      fail('dsc_website is a required attribute') if self[:dsc_website].nil?
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWebApplication"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWebApplication"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWebAdministration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.3.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Website
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_website) do
+    desc "Name of website with which web application is associated"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of web application"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         WebAppPool
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_webapppool) do
+    desc "Web application pool for the web application"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PhysicalPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_physicalpath) do
+    desc "Physical path for the web application directory"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Whether web application should be present or absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -1,0 +1,106 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwebapppool) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWebAppPool resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWebAdministration/DSCResources/MSFT_xWebAppPool/MSFT_xWebAppPool.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWebAppPool"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWebAppPool"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWebAdministration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.3.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of the Web Application Pool"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Web Application Pool Present/Absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         State
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Started", "Stopped"]
+  newparam(:dsc_state) do
+    desc "State of Web Application Pool"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Started', 'started', 'Stopped', 'stopped'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Started, Stopped")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -1,0 +1,147 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWebConfigKeyValue resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWebAdministration/DSCResources/MSFT_xWebConfigKeyValue/MSFT_xWebConfigKeyValue.schema.mof
+  }
+
+  validate do
+      fail('dsc_websitepath is a required attribute') if self[:dsc_websitepath].nil?
+      fail('dsc_configsection is a required attribute') if self[:dsc_configsection].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWebConfigKeyValue"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWebConfigKeyValue"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWebAdministration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.3.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         WebsitePath
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_websitepath) do
+    desc "Path to website location(IIS or WebAdministration format)"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         ConfigSection
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       ["AppSettings"]
+  newparam(:dsc_configsection) do
+    desc "Config Section to be update"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['AppSettings', 'appsettings'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are AppSettings")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Key
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_key) do
+    desc "Key for AppSettings"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Value
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_value) do
+    desc "Value for AppSettings"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         IsAttribute
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_isattribute) do
+    desc "If the given key value pair is for attribute, default is element"
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -1,0 +1,165 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwebsite) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWebsite resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWebAdministration/DSCResources/MSFT_xWebsite/MSFT_xWebsite.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWebsite"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWebsite"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWebAdministration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.3.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PhysicalPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_physicalpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         State
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Started", "Stopped"]
+  newparam(:dsc_state) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Started', 'started', 'Stopped', 'stopped'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Started, Stopped")
+      end
+    end
+  end
+
+  # Name:         BindingInfo
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_bindinginfo, :array_matching => :all) do
+    desc "Hashtable containing binding information (Port, Protocol, IPAddress, HostName, CertificateThumbPrint, CertificateStore)"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         ApplicationPool
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_applicationpool) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Id
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_id) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DefaultPage
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_defaultpage, :array_matching => :all) do
+    desc "The default pages for the website"
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -1,0 +1,133 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWebVirtualDirectory resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWebAdministration/DSCResources/MSFT_xWebVirtualDirectory/MSFT_xWebVirtualDirectory.schema.mof
+  }
+
+  validate do
+      fail('dsc_website is a required attribute') if self[:dsc_website].nil?
+      fail('dsc_webapplication is a required attribute') if self[:dsc_webapplication].nil?
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWebVirtualDirectory"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWebVirtualDirectory"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWebAdministration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.3.2"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Website
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_website) do
+    desc "Name of website with which Web Application is associated"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         WebApplication
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_webapplication) do
+    desc "Web application name for the virtual directory"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    desc "Name of virtual directory"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PhysicalPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_physicalpath) do
+    desc "Physical path for the virtual directory"
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Whether virtual directory should be present or absent"
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -1,0 +1,189 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWindowsOptionalFeature resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xWindowsOptionalFeature/MSFT_xWindowsOptionalFeature.schema.mof
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWindowsOptionalFeature"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWindowsOptionalFeature"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Source
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_source, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         NoWindowsUpdateCheck
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_nowindowsupdatecheck) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         RemoveFilesOnDisable
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_removefilesondisable) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         LogLevel
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["ErrorsOnly", "ErrorsAndWarning", "ErrorsAndWarningAndInformation"]
+  newparam(:dsc_loglevel) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['ErrorsOnly', 'errorsonly', 'ErrorsAndWarning', 'errorsandwarning', 'ErrorsAndWarningAndInformation', 'errorsandwarningandinformation'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are ErrorsOnly, ErrorsAndWarning, ErrorsAndWarningAndInformation")
+      end
+    end
+  end
+
+  # Name:         LogPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_logpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         CustomProperties
+  # Type:         string[]
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_customproperties, :array_matching => :all) do
+    validate do |value|
+      unless value.kind_of?(Array) || value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         DisplayName
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_displayname) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -1,0 +1,237 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwindowsprocess) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWindowsProcess resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xPSDesiredStateConfiguration/DSCResources/MSFT_xProcessResource/MSFT_xProcessResource.schema.mof
+  }
+
+  validate do
+      fail('dsc_path is a required attribute') if self[:dsc_path].nil?
+      fail('dsc_arguments is a required attribute') if self[:dsc_arguments].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWindowsProcess"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xProcessResource"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xPSDesiredStateConfiguration"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "3.0.2.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Path
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_path) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Arguments
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_arguments) do
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Credential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_credential) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         StandardOutputPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_standardoutputpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         StandardErrorPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_standarderrorpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         StandardInputPath
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_standardinputpath) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         WorkingDirectory
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_workingdirectory) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         PagedMemorySize
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_pagedmemorysize) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         NonPagedMemorySize
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_nonpagedmemorysize) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         VirtualMemorySize
+  # Type:         uint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_virtualmemorysize) do
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         HandleCount
+  # Type:         sint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_handlecount) do
+    validate do |value|
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+          fail("Invalid value #{value}. Should be a signed Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         ProcessId
+  # Type:         sint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_processid) do
+    validate do |value|
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+          fail("Invalid value #{value}. Should be a signed Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -1,0 +1,124 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwineventlog) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWinEventLog resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWinEventLog/DSCResources/MSFT_xWinEventLog/MSFT_xWinEventLog.schema.mof
+  }
+
+  validate do
+      fail('dsc_logname is a required attribute') if self[:dsc_logname].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWinEventLog"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWinEventLog"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWinEventLog"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "0.0.0.1"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  # Name:         LogName
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_logname) do
+    desc "Name of the event log"
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         MaximumSizeInBytes
+  # Type:         sint64
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_maximumsizeinbytes) do
+    desc "sizethat the event log file is allowed to be When the file reaches this maximum size it is considered full"
+    validate do |value|
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+          fail("Invalid value #{value}. Should be a signed Integer")
+      end
+    end
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  # Name:         IsEnabled
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_isenabled) do
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+  end
+
+  # Name:         LogMode
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["AutoBackup", "Circular", "Retain"]
+  newparam(:dsc_logmode) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['AutoBackup', 'autobackup', 'Circular', 'circular', 'Retain', 'retain'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are AutoBackup, Circular, Retain")
+      end
+    end
+  end
+
+  # Name:         SecurityDescriptor
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_securitydescriptor) do
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+
+end

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -1,0 +1,129 @@
+# workaround for cross modules dependencies
+master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
+$:.push(master_path) if File.directory?(master_path)
+require 'puppet/type/base_dsc'
+
+Puppet::Type.newtype(:dsc_xwordpresssite) do
+
+  provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+    defaultfor :operatingsystem => :windows
+  end
+
+  provide :mof, :parent => Puppet::Type.type(:base_dsc).provider(:mof)
+
+  @doc = %q{
+    The DSC xWordPressSite resource type.
+    Originally generated from the following schema.mof file:
+      import/dsc_resources/dsc-resource-kit/xWordPress/DscResources/MSFT_xWordPressSite/MSFT_xWordPressSite.schema.mof
+  }
+
+  validate do
+      fail('dsc_uri is a required attribute') if self[:dsc_uri].nil?
+    end
+
+  newparam(:dscmeta_resource_friendly_name) do
+    defaultto "xWordPressSite"
+  end
+
+  newparam(:dscmeta_resource_name) do
+    defaultto "MSFT_xWordPressSite"
+  end
+
+  newparam(:dscmeta_import_resource) do
+    newvalues(true, false)
+
+    munge do |value|
+      value.to_s.downcase.to_bool
+    end
+
+    defaultto true
+  end
+
+  newparam(:dscmeta_module_name) do
+    defaultto "xWordPress"
+  end
+
+  newparam(:dscmeta_module_version) do
+    defaultto "1.0.0.0"
+  end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  # Name:         Uri
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_uri) do
+    desc "The WordPress Site URI."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Title
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_title) do
+    desc "The WordPress Site Default page title."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AdministratorCredential
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_administratorcredential) do
+    desc "The username and password of the WordPress administrator to create when creating the site."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         AdministratorEmail
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_administratoremail) do
+    desc "The email address of the WordPress administrator to create."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    desc "Should the module be present or absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+
+end

--- a/spec/unit/puppet/type/dsc_archive_spec.rb
+++ b/spec/unit/puppet/type/dsc_archive_spec.rb
@@ -1,0 +1,425 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_archive) do
+
+  let :dsc_archive do
+    Puppet::Type.type(:dsc_archive).new(
+      :name     => 'foo',
+      :dsc_path => 'foo',
+      :dsc_destination => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_archive.to_s).to eq("Dsc_archive[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_archive[:ensure]).to eq :present
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_archive[:dsc_ensure] = 'Present'
+    expect(dsc_archive[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_archive[:dsc_ensure] = 'present'
+    expect(dsc_archive[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_archive[:dsc_ensure] = 'present'
+    expect(dsc_archive[:ensure]).to eq(dsc_archive[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_archive[:dsc_ensure] = 'Absent'
+    expect(dsc_archive[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_archive[:dsc_ensure] = 'absent'
+    expect(dsc_archive[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_archive[:dsc_ensure] = 'absent'
+    expect(dsc_archive[:ensure]).to eq(dsc_archive[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_archive[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_archive[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_archive[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_archive[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_archive[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_path is specified' do
+    #dsc_archive[:dsc_path]
+    expect { Puppet::Type.type(:dsc_archive).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_destination => 'foo',
+      :dsc_validate => true,
+      :dsc_checksum => 'SHA-1',
+      :dsc_force => true,
+    )}.to raise_error(Puppet::Error, /dsc_path is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_archive[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_archive[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_archive[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_archive[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_destination is specified' do
+    #dsc_archive[:dsc_destination]
+    expect { Puppet::Type.type(:dsc_archive).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_path => 'foo',
+      :dsc_validate => true,
+      :dsc_checksum => 'SHA-1',
+      :dsc_force => true,
+    )}.to raise_error(Puppet::Error, /dsc_destination is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_destination' do
+    expect{dsc_archive[:dsc_destination] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_destination' do
+    expect{dsc_archive[:dsc_destination] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_destination' do
+    expect{dsc_archive[:dsc_destination] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_destination' do
+    expect{dsc_archive[:dsc_destination] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_validate' do
+    expect{dsc_archive[:dsc_validate] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_validate' do
+    dsc_archive[:dsc_validate] = true
+    expect(dsc_archive[:dsc_validate]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_validate" do
+    dsc_archive[:dsc_validate] = 'true'
+    expect(dsc_archive[:dsc_validate]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_validate" do
+    dsc_archive[:dsc_validate] = 'false'
+    expect(dsc_archive[:dsc_validate]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_validate" do
+    dsc_archive[:dsc_validate] = 'True'
+    expect(dsc_archive[:dsc_validate]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_validate" do
+    dsc_archive[:dsc_validate] = 'False'
+    expect(dsc_archive[:dsc_validate]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_validate" do
+    dsc_archive[:dsc_validate] = :true
+    expect(dsc_archive[:dsc_validate]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_validate" do
+    dsc_archive[:dsc_validate] = :false
+    expect(dsc_archive[:dsc_validate]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_validate' do
+    expect{dsc_archive[:dsc_validate] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_validate' do
+    expect{dsc_archive[:dsc_validate] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_checksum predefined value SHA-1' do
+    dsc_archive[:dsc_checksum] = 'SHA-1'
+    expect(dsc_archive[:dsc_checksum]).to eq('SHA-1')
+  end
+
+  it 'should accept dsc_checksum predefined value sha-1' do
+    dsc_archive[:dsc_checksum] = 'sha-1'
+    expect(dsc_archive[:dsc_checksum]).to eq('sha-1')
+  end
+
+  it 'should accept dsc_checksum predefined value SHA-256' do
+    dsc_archive[:dsc_checksum] = 'SHA-256'
+    expect(dsc_archive[:dsc_checksum]).to eq('SHA-256')
+  end
+
+  it 'should accept dsc_checksum predefined value sha-256' do
+    dsc_archive[:dsc_checksum] = 'sha-256'
+    expect(dsc_archive[:dsc_checksum]).to eq('sha-256')
+  end
+
+  it 'should accept dsc_checksum predefined value SHA-512' do
+    dsc_archive[:dsc_checksum] = 'SHA-512'
+    expect(dsc_archive[:dsc_checksum]).to eq('SHA-512')
+  end
+
+  it 'should accept dsc_checksum predefined value sha-512' do
+    dsc_archive[:dsc_checksum] = 'sha-512'
+    expect(dsc_archive[:dsc_checksum]).to eq('sha-512')
+  end
+
+  it 'should accept dsc_checksum predefined value CreatedDate' do
+    dsc_archive[:dsc_checksum] = 'CreatedDate'
+    expect(dsc_archive[:dsc_checksum]).to eq('CreatedDate')
+  end
+
+  it 'should accept dsc_checksum predefined value createddate' do
+    dsc_archive[:dsc_checksum] = 'createddate'
+    expect(dsc_archive[:dsc_checksum]).to eq('createddate')
+  end
+
+  it 'should accept dsc_checksum predefined value ModifiedDate' do
+    dsc_archive[:dsc_checksum] = 'ModifiedDate'
+    expect(dsc_archive[:dsc_checksum]).to eq('ModifiedDate')
+  end
+
+  it 'should accept dsc_checksum predefined value modifieddate' do
+    dsc_archive[:dsc_checksum] = 'modifieddate'
+    expect(dsc_archive[:dsc_checksum]).to eq('modifieddate')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_archive[:dsc_checksum] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_checksum' do
+    expect{dsc_archive[:dsc_checksum] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_checksum' do
+    expect{dsc_archive[:dsc_checksum] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_checksum' do
+    expect{dsc_archive[:dsc_checksum] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_checksum' do
+    expect{dsc_archive[:dsc_checksum] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_force' do
+    expect{dsc_archive[:dsc_force] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_force' do
+    dsc_archive[:dsc_force] = true
+    expect(dsc_archive[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_force" do
+    dsc_archive[:dsc_force] = 'true'
+    expect(dsc_archive[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_force" do
+    dsc_archive[:dsc_force] = 'false'
+    expect(dsc_archive[:dsc_force]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_force" do
+    dsc_archive[:dsc_force] = 'True'
+    expect(dsc_archive[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_force" do
+    dsc_archive[:dsc_force] = 'False'
+    expect(dsc_archive[:dsc_force]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_force" do
+    dsc_archive[:dsc_force] = :true
+    expect(dsc_archive[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_force" do
+    dsc_archive[:dsc_force] = :false
+    expect(dsc_archive[:dsc_force]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_force' do
+    expect{dsc_archive[:dsc_force] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_force' do
+    expect{dsc_archive[:dsc_force] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_archive)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_archive)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_archive[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_archive[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_archive.original_parameters[:dsc_ensure] = 'present'
+        dsc_archive[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_archive)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_archive[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_archive.original_parameters[:dsc_ensure] = 'absent'
+        dsc_archive[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_archive)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_archive[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_archive)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_archive)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_ArchiveResource as $MSFT_ArchiveResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_ArchiveResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_archive[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_archive)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_archive[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_archive[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_archive)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_archive[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_environment_spec.rb
+++ b/spec/unit/puppet/type/dsc_environment_spec.rb
@@ -1,0 +1,293 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_environment) do
+
+  let :dsc_environment do
+    Puppet::Type.type(:dsc_environment).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_environment.to_s).to eq("Dsc_environment[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_environment[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_environment[:dsc_name]
+    expect { Puppet::Type.type(:dsc_environment).new(
+      :name     => 'foo',
+      :dsc_value => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_path => true,
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_environment[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_environment[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_environment[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_environment[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_value' do
+    expect{dsc_environment[:dsc_value] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_value' do
+    expect{dsc_environment[:dsc_value] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_value' do
+    expect{dsc_environment[:dsc_value] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_value' do
+    expect{dsc_environment[:dsc_value] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_environment[:dsc_ensure] = 'Present'
+    expect(dsc_environment[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_environment[:dsc_ensure] = 'present'
+    expect(dsc_environment[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_environment[:dsc_ensure] = 'present'
+    expect(dsc_environment[:ensure]).to eq(dsc_environment[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_environment[:dsc_ensure] = 'Absent'
+    expect(dsc_environment[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_environment[:dsc_ensure] = 'absent'
+    expect(dsc_environment[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_environment[:dsc_ensure] = 'absent'
+    expect(dsc_environment[:ensure]).to eq(dsc_environment[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_environment[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_environment[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_environment[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_environment[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_environment[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_environment[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_path' do
+    dsc_environment[:dsc_path] = true
+    expect(dsc_environment[:dsc_path]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_path" do
+    dsc_environment[:dsc_path] = 'true'
+    expect(dsc_environment[:dsc_path]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_path" do
+    dsc_environment[:dsc_path] = 'false'
+    expect(dsc_environment[:dsc_path]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_path" do
+    dsc_environment[:dsc_path] = 'True'
+    expect(dsc_environment[:dsc_path]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_path" do
+    dsc_environment[:dsc_path] = 'False'
+    expect(dsc_environment[:dsc_path]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_path" do
+    dsc_environment[:dsc_path] = :true
+    expect(dsc_environment[:dsc_path]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_path" do
+    dsc_environment[:dsc_path] = :false
+    expect(dsc_environment[:dsc_path]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_environment[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_environment[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_environment)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_environment)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_environment[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_environment[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_environment.original_parameters[:dsc_ensure] = 'present'
+        dsc_environment[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_environment)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_environment[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_environment.original_parameters[:dsc_ensure] = 'absent'
+        dsc_environment[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_environment)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_environment[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_environment)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_environment)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_EnvironmentResource as $MSFT_EnvironmentResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_EnvironmentResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_environment[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_environment)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_environment[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_environment[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_environment)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_environment[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_file_spec.rb
+++ b/spec/unit/puppet/type/dsc_file_spec.rb
@@ -1,0 +1,659 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_file) do
+
+  let :dsc_file do
+    Puppet::Type.type(:dsc_file).new(
+      :name     => 'foo',
+      :dsc_destinationpath => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_file.to_s).to eq("Dsc_file[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_file[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_destinationpath is specified' do
+    #dsc_file[:dsc_destinationpath]
+    expect { Puppet::Type.type(:dsc_file).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_type => 'File',
+      :dsc_sourcepath => 'foo',
+      :dsc_contents => 'foo',
+      :dsc_checksum => 'SHA-1',
+      :dsc_recurse => true,
+      :dsc_force => true,
+      :dsc_credential => 'foo',
+      :dsc_createddate => '20140711',
+      :dsc_modifieddate => '20140711',
+      :dsc_attributes => 'ReadOnly',
+      :dsc_size => 64,
+      :dsc_subitems => ["foo", "bar", "spec"],
+      :dsc_matchsource => true,
+    )}.to raise_error(Puppet::Error, /dsc_destinationpath is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_destinationpath' do
+    expect{dsc_file[:dsc_destinationpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_destinationpath' do
+    expect{dsc_file[:dsc_destinationpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_destinationpath' do
+    expect{dsc_file[:dsc_destinationpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_destinationpath' do
+    expect{dsc_file[:dsc_destinationpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_file[:dsc_ensure] = 'Present'
+    expect(dsc_file[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_file[:dsc_ensure] = 'present'
+    expect(dsc_file[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_file[:dsc_ensure] = 'present'
+    expect(dsc_file[:ensure]).to eq(dsc_file[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_file[:dsc_ensure] = 'Absent'
+    expect(dsc_file[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_file[:dsc_ensure] = 'absent'
+    expect(dsc_file[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_file[:dsc_ensure] = 'absent'
+    expect(dsc_file[:ensure]).to eq(dsc_file[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_file[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_file[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_file[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_file[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_file[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_type predefined value File' do
+    dsc_file[:dsc_type] = 'File'
+    expect(dsc_file[:dsc_type]).to eq('File')
+  end
+
+  it 'should accept dsc_type predefined value file' do
+    dsc_file[:dsc_type] = 'file'
+    expect(dsc_file[:dsc_type]).to eq('file')
+  end
+
+  it 'should accept dsc_type predefined value Directory' do
+    dsc_file[:dsc_type] = 'Directory'
+    expect(dsc_file[:dsc_type]).to eq('Directory')
+  end
+
+  it 'should accept dsc_type predefined value directory' do
+    dsc_file[:dsc_type] = 'directory'
+    expect(dsc_file[:dsc_type]).to eq('directory')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_file[:dsc_type] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_type' do
+    expect{dsc_file[:dsc_type] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_type' do
+    expect{dsc_file[:dsc_type] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_type' do
+    expect{dsc_file[:dsc_type] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_type' do
+    expect{dsc_file[:dsc_type] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sourcepath' do
+    expect{dsc_file[:dsc_sourcepath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sourcepath' do
+    expect{dsc_file[:dsc_sourcepath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sourcepath' do
+    expect{dsc_file[:dsc_sourcepath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sourcepath' do
+    expect{dsc_file[:dsc_sourcepath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_contents' do
+    expect{dsc_file[:dsc_contents] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_contents' do
+    expect{dsc_file[:dsc_contents] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_contents' do
+    expect{dsc_file[:dsc_contents] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_contents' do
+    expect{dsc_file[:dsc_contents] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_checksum predefined value SHA-1' do
+    dsc_file[:dsc_checksum] = 'SHA-1'
+    expect(dsc_file[:dsc_checksum]).to eq('SHA-1')
+  end
+
+  it 'should accept dsc_checksum predefined value sha-1' do
+    dsc_file[:dsc_checksum] = 'sha-1'
+    expect(dsc_file[:dsc_checksum]).to eq('sha-1')
+  end
+
+  it 'should accept dsc_checksum predefined value SHA-256' do
+    dsc_file[:dsc_checksum] = 'SHA-256'
+    expect(dsc_file[:dsc_checksum]).to eq('SHA-256')
+  end
+
+  it 'should accept dsc_checksum predefined value sha-256' do
+    dsc_file[:dsc_checksum] = 'sha-256'
+    expect(dsc_file[:dsc_checksum]).to eq('sha-256')
+  end
+
+  it 'should accept dsc_checksum predefined value SHA-512' do
+    dsc_file[:dsc_checksum] = 'SHA-512'
+    expect(dsc_file[:dsc_checksum]).to eq('SHA-512')
+  end
+
+  it 'should accept dsc_checksum predefined value sha-512' do
+    dsc_file[:dsc_checksum] = 'sha-512'
+    expect(dsc_file[:dsc_checksum]).to eq('sha-512')
+  end
+
+  it 'should accept dsc_checksum predefined value CreatedDate' do
+    dsc_file[:dsc_checksum] = 'CreatedDate'
+    expect(dsc_file[:dsc_checksum]).to eq('CreatedDate')
+  end
+
+  it 'should accept dsc_checksum predefined value createddate' do
+    dsc_file[:dsc_checksum] = 'createddate'
+    expect(dsc_file[:dsc_checksum]).to eq('createddate')
+  end
+
+  it 'should accept dsc_checksum predefined value ModifiedDate' do
+    dsc_file[:dsc_checksum] = 'ModifiedDate'
+    expect(dsc_file[:dsc_checksum]).to eq('ModifiedDate')
+  end
+
+  it 'should accept dsc_checksum predefined value modifieddate' do
+    dsc_file[:dsc_checksum] = 'modifieddate'
+    expect(dsc_file[:dsc_checksum]).to eq('modifieddate')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_file[:dsc_checksum] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_checksum' do
+    expect{dsc_file[:dsc_checksum] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_checksum' do
+    expect{dsc_file[:dsc_checksum] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_checksum' do
+    expect{dsc_file[:dsc_checksum] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_checksum' do
+    expect{dsc_file[:dsc_checksum] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_recurse' do
+    expect{dsc_file[:dsc_recurse] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_recurse' do
+    dsc_file[:dsc_recurse] = true
+    expect(dsc_file[:dsc_recurse]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_recurse" do
+    dsc_file[:dsc_recurse] = 'true'
+    expect(dsc_file[:dsc_recurse]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_recurse" do
+    dsc_file[:dsc_recurse] = 'false'
+    expect(dsc_file[:dsc_recurse]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_recurse" do
+    dsc_file[:dsc_recurse] = 'True'
+    expect(dsc_file[:dsc_recurse]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_recurse" do
+    dsc_file[:dsc_recurse] = 'False'
+    expect(dsc_file[:dsc_recurse]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_recurse" do
+    dsc_file[:dsc_recurse] = :true
+    expect(dsc_file[:dsc_recurse]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_recurse" do
+    dsc_file[:dsc_recurse] = :false
+    expect(dsc_file[:dsc_recurse]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_recurse' do
+    expect{dsc_file[:dsc_recurse] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_recurse' do
+    expect{dsc_file[:dsc_recurse] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_force' do
+    expect{dsc_file[:dsc_force] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_force' do
+    dsc_file[:dsc_force] = true
+    expect(dsc_file[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_force" do
+    dsc_file[:dsc_force] = 'true'
+    expect(dsc_file[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_force" do
+    dsc_file[:dsc_force] = 'false'
+    expect(dsc_file[:dsc_force]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_force" do
+    dsc_file[:dsc_force] = 'True'
+    expect(dsc_file[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_force" do
+    dsc_file[:dsc_force] = 'False'
+    expect(dsc_file[:dsc_force]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_force" do
+    dsc_file[:dsc_force] = :true
+    expect(dsc_file[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_force" do
+    dsc_file[:dsc_force] = :false
+    expect(dsc_file[:dsc_force]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_force' do
+    expect{dsc_file[:dsc_force] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_force' do
+    expect{dsc_file[:dsc_force] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_file[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_file[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_file[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_file[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_createddate' do
+    expect{dsc_file[:dsc_createddate] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_createddate' do
+    expect{dsc_file[:dsc_createddate] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_createddate' do
+    expect{dsc_file[:dsc_createddate] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_createddate' do
+    expect{dsc_file[:dsc_createddate] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_modifieddate' do
+    expect{dsc_file[:dsc_modifieddate] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_modifieddate' do
+    expect{dsc_file[:dsc_modifieddate] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_modifieddate' do
+    expect{dsc_file[:dsc_modifieddate] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_modifieddate' do
+    expect{dsc_file[:dsc_modifieddate] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_attributes predefined value ReadOnly' do
+    dsc_file[:dsc_attributes] = 'ReadOnly'
+    expect(dsc_file[:dsc_attributes]).to eq('ReadOnly')
+  end
+
+  it 'should accept dsc_attributes predefined value readonly' do
+    dsc_file[:dsc_attributes] = 'readonly'
+    expect(dsc_file[:dsc_attributes]).to eq('readonly')
+  end
+
+  it 'should accept dsc_attributes predefined value Hidden' do
+    dsc_file[:dsc_attributes] = 'Hidden'
+    expect(dsc_file[:dsc_attributes]).to eq('Hidden')
+  end
+
+  it 'should accept dsc_attributes predefined value hidden' do
+    dsc_file[:dsc_attributes] = 'hidden'
+    expect(dsc_file[:dsc_attributes]).to eq('hidden')
+  end
+
+  it 'should accept dsc_attributes predefined value System' do
+    dsc_file[:dsc_attributes] = 'System'
+    expect(dsc_file[:dsc_attributes]).to eq('System')
+  end
+
+  it 'should accept dsc_attributes predefined value system' do
+    dsc_file[:dsc_attributes] = 'system'
+    expect(dsc_file[:dsc_attributes]).to eq('system')
+  end
+
+  it 'should accept dsc_attributes predefined value Archive' do
+    dsc_file[:dsc_attributes] = 'Archive'
+    expect(dsc_file[:dsc_attributes]).to eq('Archive')
+  end
+
+  it 'should accept dsc_attributes predefined value archive' do
+    dsc_file[:dsc_attributes] = 'archive'
+    expect(dsc_file[:dsc_attributes]).to eq('archive')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_file[:dsc_attributes] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array of predefined values for dsc_attributes' do
+    dsc_file[:dsc_attributes] = ["ReadOnly", "Hidden", "System", "Archive"]
+    expect(dsc_file[:dsc_attributes]).to eq(["ReadOnly", "Hidden", "System", "Archive"])
+  end
+
+  it 'should not accept boolean for dsc_attributes' do
+    expect{dsc_file[:dsc_attributes] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_attributes' do
+    expect{dsc_file[:dsc_attributes] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_attributes' do
+    expect{dsc_file[:dsc_attributes] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_size' do
+    expect{dsc_file[:dsc_size] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_size' do
+    expect{dsc_file[:dsc_size] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_size' do
+    expect{dsc_file[:dsc_size] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_size' do
+    dsc_file[:dsc_size] = 64
+    expect(dsc_file[:dsc_size]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_file[:dsc_size] = '16'
+    expect(dsc_file[:dsc_size]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_file[:dsc_size] = '32'
+    expect(dsc_file[:dsc_size]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_file[:dsc_size] = '64'
+    expect(dsc_file[:dsc_size]).to eq(64)
+  end
+
+  it 'should accept array for dsc_subitems' do
+    dsc_file[:dsc_subitems] = ["foo", "bar", "spec"]
+    expect(dsc_file[:dsc_subitems]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_subitems' do
+    expect{dsc_file[:dsc_subitems] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_subitems' do
+    expect{dsc_file[:dsc_subitems] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_subitems' do
+    expect{dsc_file[:dsc_subitems] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_matchsource' do
+    expect{dsc_file[:dsc_matchsource] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_matchsource' do
+    dsc_file[:dsc_matchsource] = true
+    expect(dsc_file[:dsc_matchsource]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_matchsource" do
+    dsc_file[:dsc_matchsource] = 'true'
+    expect(dsc_file[:dsc_matchsource]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_matchsource" do
+    dsc_file[:dsc_matchsource] = 'false'
+    expect(dsc_file[:dsc_matchsource]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_matchsource" do
+    dsc_file[:dsc_matchsource] = 'True'
+    expect(dsc_file[:dsc_matchsource]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_matchsource" do
+    dsc_file[:dsc_matchsource] = 'False'
+    expect(dsc_file[:dsc_matchsource]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_matchsource" do
+    dsc_file[:dsc_matchsource] = :true
+    expect(dsc_file[:dsc_matchsource]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_matchsource" do
+    dsc_file[:dsc_matchsource] = :false
+    expect(dsc_file[:dsc_matchsource]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_matchsource' do
+    expect{dsc_file[:dsc_matchsource] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_matchsource' do
+    expect{dsc_file[:dsc_matchsource] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_file)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_file)
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_file.original_parameters[:dsc_ensure] = 'present'
+        dsc_file[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_file)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_file[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_file.original_parameters[:dsc_ensure] = 'absent'
+        dsc_file[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_file)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_file[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_file)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_file)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_FileDirectoryConfiguration as $MSFT_FileDirectoryConfiguration1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_FileDirectoryConfiguration/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_file[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_file)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_file[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_file[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_file)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_file[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_group_spec.rb
+++ b/spec/unit/puppet/type/dsc_group_spec.rb
@@ -1,0 +1,316 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_group) do
+
+  let :dsc_group do
+    Puppet::Type.type(:dsc_group).new(
+      :name     => 'foo',
+      :dsc_groupname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_group.to_s).to eq("Dsc_group[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_group[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_groupname is specified' do
+    #dsc_group[:dsc_groupname]
+    expect { Puppet::Type.type(:dsc_group).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_description => 'foo',
+      :dsc_members => ["foo", "bar", "spec"],
+      :dsc_memberstoinclude => ["foo", "bar", "spec"],
+      :dsc_memberstoexclude => ["foo", "bar", "spec"],
+      :dsc_credential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_groupname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_groupname' do
+    expect{dsc_group[:dsc_groupname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_groupname' do
+    expect{dsc_group[:dsc_groupname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_groupname' do
+    expect{dsc_group[:dsc_groupname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_groupname' do
+    expect{dsc_group[:dsc_groupname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_group[:dsc_ensure] = 'Present'
+    expect(dsc_group[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_group[:dsc_ensure] = 'present'
+    expect(dsc_group[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_group[:dsc_ensure] = 'present'
+    expect(dsc_group[:ensure]).to eq(dsc_group[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_group[:dsc_ensure] = 'Absent'
+    expect(dsc_group[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_group[:dsc_ensure] = 'absent'
+    expect(dsc_group[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_group[:dsc_ensure] = 'absent'
+    expect(dsc_group[:ensure]).to eq(dsc_group[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_group[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_group[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_group[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_group[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_group[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_group[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_group[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_group[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_group[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_members' do
+    dsc_group[:dsc_members] = ["foo", "bar", "spec"]
+    expect(dsc_group[:dsc_members]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_members' do
+    expect{dsc_group[:dsc_members] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_members' do
+    expect{dsc_group[:dsc_members] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_members' do
+    expect{dsc_group[:dsc_members] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_memberstoinclude' do
+    dsc_group[:dsc_memberstoinclude] = ["foo", "bar", "spec"]
+    expect(dsc_group[:dsc_memberstoinclude]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_memberstoinclude' do
+    expect{dsc_group[:dsc_memberstoinclude] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_memberstoinclude' do
+    expect{dsc_group[:dsc_memberstoinclude] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_memberstoinclude' do
+    expect{dsc_group[:dsc_memberstoinclude] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_memberstoexclude' do
+    dsc_group[:dsc_memberstoexclude] = ["foo", "bar", "spec"]
+    expect(dsc_group[:dsc_memberstoexclude]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_memberstoexclude' do
+    expect{dsc_group[:dsc_memberstoexclude] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_memberstoexclude' do
+    expect{dsc_group[:dsc_memberstoexclude] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_memberstoexclude' do
+    expect{dsc_group[:dsc_memberstoexclude] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_group[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_group[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_group[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_group[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_group)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_group)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_group[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_group[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_group.original_parameters[:dsc_ensure] = 'present'
+        dsc_group[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_group)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_group[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_group.original_parameters[:dsc_ensure] = 'absent'
+        dsc_group[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_group)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_group[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_group)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_group)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_GroupResource as $MSFT_GroupResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_GroupResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_group[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_group)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_group[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_group[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_group)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_group[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_log_spec.rb
+++ b/spec/unit/puppet/type/dsc_log_spec.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_log) do
+
+  let :dsc_log do
+    Puppet::Type.type(:dsc_log).new(
+      :name     => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_log.to_s).to eq("Dsc_log[foo]")
+  end
+
+  it 'should not accept array for dsc_message' do
+    expect{dsc_log[:dsc_message] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_message' do
+    expect{dsc_log[:dsc_message] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_message' do
+    expect{dsc_log[:dsc_message] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_message' do
+    expect{dsc_log[:dsc_message] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_log)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_log)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_log[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_log[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_log)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_log)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_LogResource as $MSFT_LogResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_LogResource/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_package_spec.rb
+++ b/spec/unit/puppet/type/dsc_package_spec.rb
@@ -1,0 +1,504 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_package) do
+
+  let :dsc_package do
+    Puppet::Type.type(:dsc_package).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_productid => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_package.to_s).to eq("Dsc_package[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_package[:ensure]).to eq :present
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_package[:dsc_ensure] = 'Present'
+    expect(dsc_package[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_package[:dsc_ensure] = 'present'
+    expect(dsc_package[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_package[:dsc_ensure] = 'present'
+    expect(dsc_package[:ensure]).to eq(dsc_package[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_package[:dsc_ensure] = 'Absent'
+    expect(dsc_package[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_package[:dsc_ensure] = 'absent'
+    expect(dsc_package[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_package[:dsc_ensure] = 'absent'
+    expect(dsc_package[:ensure]).to eq(dsc_package[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_package[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_package[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_package[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_package[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_package[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_package[:dsc_name]
+    expect { Puppet::Type.type(:dsc_package).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_path => 'foo',
+      :dsc_productid => 'foo',
+      :dsc_arguments => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_returncode => [32, 64, 128],
+      :dsc_logpath => 'foo',
+      :dsc_packagedescription => 'foo',
+      :dsc_publisher => 'foo',
+      :dsc_installedon => 'foo',
+      :dsc_size => 32,
+      :dsc_version => 'foo',
+      :dsc_installed => true,
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_package[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_package[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_package[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_package[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_package[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_package[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_package[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_package[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_productid is specified' do
+    #dsc_package[:dsc_productid]
+    expect { Puppet::Type.type(:dsc_package).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_name => 'foo',
+      :dsc_path => 'foo',
+      :dsc_arguments => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_returncode => [32, 64, 128],
+      :dsc_logpath => 'foo',
+      :dsc_packagedescription => 'foo',
+      :dsc_publisher => 'foo',
+      :dsc_installedon => 'foo',
+      :dsc_size => 32,
+      :dsc_version => 'foo',
+      :dsc_installed => true,
+    )}.to raise_error(Puppet::Error, /dsc_productid is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_productid' do
+    expect{dsc_package[:dsc_productid] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_productid' do
+    expect{dsc_package[:dsc_productid] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_productid' do
+    expect{dsc_package[:dsc_productid] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_productid' do
+    expect{dsc_package[:dsc_productid] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_arguments' do
+    expect{dsc_package[:dsc_arguments] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_arguments' do
+    expect{dsc_package[:dsc_arguments] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_arguments' do
+    expect{dsc_package[:dsc_arguments] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_arguments' do
+    expect{dsc_package[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_package[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_package[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_package[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_package[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_returncode' do
+    dsc_package[:dsc_returncode] = [32, 64, 128]
+    expect(dsc_package[:dsc_returncode]).to eq([32, 64, 128])
+  end
+
+  it 'should not accept boolean for dsc_returncode' do
+    expect{dsc_package[:dsc_returncode] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_returncode' do
+    expect{dsc_package[:dsc_returncode] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_returncode' do
+    expect{dsc_package[:dsc_returncode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_logpath' do
+    expect{dsc_package[:dsc_logpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_logpath' do
+    expect{dsc_package[:dsc_logpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_logpath' do
+    expect{dsc_package[:dsc_logpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_logpath' do
+    expect{dsc_package[:dsc_logpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_packagedescription' do
+    expect{dsc_package[:dsc_packagedescription] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_packagedescription' do
+    expect{dsc_package[:dsc_packagedescription] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_packagedescription' do
+    expect{dsc_package[:dsc_packagedescription] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_packagedescription' do
+    expect{dsc_package[:dsc_packagedescription] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_publisher' do
+    expect{dsc_package[:dsc_publisher] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_publisher' do
+    expect{dsc_package[:dsc_publisher] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_publisher' do
+    expect{dsc_package[:dsc_publisher] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_publisher' do
+    expect{dsc_package[:dsc_publisher] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_installedon' do
+    expect{dsc_package[:dsc_installedon] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_installedon' do
+    expect{dsc_package[:dsc_installedon] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_installedon' do
+    expect{dsc_package[:dsc_installedon] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_installedon' do
+    expect{dsc_package[:dsc_installedon] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_size' do
+    expect{dsc_package[:dsc_size] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_size' do
+    expect{dsc_package[:dsc_size] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_size' do
+    expect{dsc_package[:dsc_size] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_size' do
+    dsc_package[:dsc_size] = 32
+    expect(dsc_package[:dsc_size]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_package[:dsc_size] = '16'
+    expect(dsc_package[:dsc_size]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_package[:dsc_size] = '32'
+    expect(dsc_package[:dsc_size]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_package[:dsc_size] = '64'
+    expect(dsc_package[:dsc_size]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_version' do
+    expect{dsc_package[:dsc_version] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_version' do
+    expect{dsc_package[:dsc_version] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_version' do
+    expect{dsc_package[:dsc_version] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_version' do
+    expect{dsc_package[:dsc_version] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_installed' do
+    expect{dsc_package[:dsc_installed] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_installed' do
+    dsc_package[:dsc_installed] = true
+    expect(dsc_package[:dsc_installed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_installed" do
+    dsc_package[:dsc_installed] = 'true'
+    expect(dsc_package[:dsc_installed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_installed" do
+    dsc_package[:dsc_installed] = 'false'
+    expect(dsc_package[:dsc_installed]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_installed" do
+    dsc_package[:dsc_installed] = 'True'
+    expect(dsc_package[:dsc_installed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_installed" do
+    dsc_package[:dsc_installed] = 'False'
+    expect(dsc_package[:dsc_installed]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_installed" do
+    dsc_package[:dsc_installed] = :true
+    expect(dsc_package[:dsc_installed]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_installed" do
+    dsc_package[:dsc_installed] = :false
+    expect(dsc_package[:dsc_installed]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_installed' do
+    expect{dsc_package[:dsc_installed] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_installed' do
+    expect{dsc_package[:dsc_installed] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_package)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_package)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_package[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_package[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_package.original_parameters[:dsc_ensure] = 'present'
+        dsc_package[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_package)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_package[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_package.original_parameters[:dsc_ensure] = 'absent'
+        dsc_package[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_package)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_package[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_package)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_package)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_PackageResource as $MSFT_PackageResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_PackageResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_package[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_package)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_package[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_package[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_package)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_package[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_registry_spec.rb
+++ b/spec/unit/puppet/type/dsc_registry_spec.rb
@@ -1,0 +1,454 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_registry) do
+
+  let :dsc_registry do
+    Puppet::Type.type(:dsc_registry).new(
+      :name     => 'foo',
+      :dsc_key => 'foo',
+      :dsc_valuename => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_registry.to_s).to eq("Dsc_registry[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_registry[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_key is specified' do
+    #dsc_registry[:dsc_key]
+    expect { Puppet::Type.type(:dsc_registry).new(
+      :name     => 'foo',
+      :dsc_valuename => 'foo',
+      :dsc_valuedata => ["foo", "bar", "spec"],
+      :dsc_valuetype => 'String',
+      :dsc_ensure => 'Present',
+      :dsc_hex => true,
+      :dsc_force => true,
+    )}.to raise_error(Puppet::Error, /dsc_key is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_key' do
+    expect{dsc_registry[:dsc_key] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_key' do
+    expect{dsc_registry[:dsc_key] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_key' do
+    expect{dsc_registry[:dsc_key] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_key' do
+    expect{dsc_registry[:dsc_key] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_valuename is specified' do
+    #dsc_registry[:dsc_valuename]
+    expect { Puppet::Type.type(:dsc_registry).new(
+      :name     => 'foo',
+      :dsc_key => 'foo',
+      :dsc_valuedata => ["foo", "bar", "spec"],
+      :dsc_valuetype => 'String',
+      :dsc_ensure => 'Present',
+      :dsc_hex => true,
+      :dsc_force => true,
+    )}.to raise_error(Puppet::Error, /dsc_valuename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_valuename' do
+    expect{dsc_registry[:dsc_valuename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_valuename' do
+    expect{dsc_registry[:dsc_valuename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_valuename' do
+    expect{dsc_registry[:dsc_valuename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_valuename' do
+    expect{dsc_registry[:dsc_valuename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_valuedata' do
+    dsc_registry[:dsc_valuedata] = ["foo", "bar", "spec"]
+    expect(dsc_registry[:dsc_valuedata]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_valuedata' do
+    expect{dsc_registry[:dsc_valuedata] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_valuedata' do
+    expect{dsc_registry[:dsc_valuedata] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_valuedata' do
+    expect{dsc_registry[:dsc_valuedata] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_valuetype predefined value String' do
+    dsc_registry[:dsc_valuetype] = 'String'
+    expect(dsc_registry[:dsc_valuetype]).to eq('String')
+  end
+
+  it 'should accept dsc_valuetype predefined value string' do
+    dsc_registry[:dsc_valuetype] = 'string'
+    expect(dsc_registry[:dsc_valuetype]).to eq('string')
+  end
+
+  it 'should accept dsc_valuetype predefined value Binary' do
+    dsc_registry[:dsc_valuetype] = 'Binary'
+    expect(dsc_registry[:dsc_valuetype]).to eq('Binary')
+  end
+
+  it 'should accept dsc_valuetype predefined value binary' do
+    dsc_registry[:dsc_valuetype] = 'binary'
+    expect(dsc_registry[:dsc_valuetype]).to eq('binary')
+  end
+
+  it 'should accept dsc_valuetype predefined value Dword' do
+    dsc_registry[:dsc_valuetype] = 'Dword'
+    expect(dsc_registry[:dsc_valuetype]).to eq('Dword')
+  end
+
+  it 'should accept dsc_valuetype predefined value dword' do
+    dsc_registry[:dsc_valuetype] = 'dword'
+    expect(dsc_registry[:dsc_valuetype]).to eq('dword')
+  end
+
+  it 'should accept dsc_valuetype predefined value Qword' do
+    dsc_registry[:dsc_valuetype] = 'Qword'
+    expect(dsc_registry[:dsc_valuetype]).to eq('Qword')
+  end
+
+  it 'should accept dsc_valuetype predefined value qword' do
+    dsc_registry[:dsc_valuetype] = 'qword'
+    expect(dsc_registry[:dsc_valuetype]).to eq('qword')
+  end
+
+  it 'should accept dsc_valuetype predefined value MultiString' do
+    dsc_registry[:dsc_valuetype] = 'MultiString'
+    expect(dsc_registry[:dsc_valuetype]).to eq('MultiString')
+  end
+
+  it 'should accept dsc_valuetype predefined value multistring' do
+    dsc_registry[:dsc_valuetype] = 'multistring'
+    expect(dsc_registry[:dsc_valuetype]).to eq('multistring')
+  end
+
+  it 'should accept dsc_valuetype predefined value ExpandString' do
+    dsc_registry[:dsc_valuetype] = 'ExpandString'
+    expect(dsc_registry[:dsc_valuetype]).to eq('ExpandString')
+  end
+
+  it 'should accept dsc_valuetype predefined value expandstring' do
+    dsc_registry[:dsc_valuetype] = 'expandstring'
+    expect(dsc_registry[:dsc_valuetype]).to eq('expandstring')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_registry[:dsc_valuetype] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_valuetype' do
+    expect{dsc_registry[:dsc_valuetype] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_valuetype' do
+    expect{dsc_registry[:dsc_valuetype] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_valuetype' do
+    expect{dsc_registry[:dsc_valuetype] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_valuetype' do
+    expect{dsc_registry[:dsc_valuetype] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_registry[:dsc_ensure] = 'Present'
+    expect(dsc_registry[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_registry[:dsc_ensure] = 'present'
+    expect(dsc_registry[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_registry[:dsc_ensure] = 'present'
+    expect(dsc_registry[:ensure]).to eq(dsc_registry[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_registry[:dsc_ensure] = 'Absent'
+    expect(dsc_registry[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_registry[:dsc_ensure] = 'absent'
+    expect(dsc_registry[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_registry[:dsc_ensure] = 'absent'
+    expect(dsc_registry[:ensure]).to eq(dsc_registry[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_registry[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_registry[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_registry[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_registry[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_registry[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_hex' do
+    expect{dsc_registry[:dsc_hex] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_hex' do
+    dsc_registry[:dsc_hex] = true
+    expect(dsc_registry[:dsc_hex]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_hex" do
+    dsc_registry[:dsc_hex] = 'true'
+    expect(dsc_registry[:dsc_hex]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_hex" do
+    dsc_registry[:dsc_hex] = 'false'
+    expect(dsc_registry[:dsc_hex]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_hex" do
+    dsc_registry[:dsc_hex] = 'True'
+    expect(dsc_registry[:dsc_hex]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_hex" do
+    dsc_registry[:dsc_hex] = 'False'
+    expect(dsc_registry[:dsc_hex]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_hex" do
+    dsc_registry[:dsc_hex] = :true
+    expect(dsc_registry[:dsc_hex]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_hex" do
+    dsc_registry[:dsc_hex] = :false
+    expect(dsc_registry[:dsc_hex]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_hex' do
+    expect{dsc_registry[:dsc_hex] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_hex' do
+    expect{dsc_registry[:dsc_hex] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_force' do
+    expect{dsc_registry[:dsc_force] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_force' do
+    dsc_registry[:dsc_force] = true
+    expect(dsc_registry[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_force" do
+    dsc_registry[:dsc_force] = 'true'
+    expect(dsc_registry[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_force" do
+    dsc_registry[:dsc_force] = 'false'
+    expect(dsc_registry[:dsc_force]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_force" do
+    dsc_registry[:dsc_force] = 'True'
+    expect(dsc_registry[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_force" do
+    dsc_registry[:dsc_force] = 'False'
+    expect(dsc_registry[:dsc_force]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_force" do
+    dsc_registry[:dsc_force] = :true
+    expect(dsc_registry[:dsc_force]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_force" do
+    dsc_registry[:dsc_force] = :false
+    expect(dsc_registry[:dsc_force]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_force' do
+    expect{dsc_registry[:dsc_force] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_force' do
+    expect{dsc_registry[:dsc_force] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_registry)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_registry)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_registry[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_registry[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_registry.original_parameters[:dsc_ensure] = 'present'
+        dsc_registry[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_registry)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_registry[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_registry.original_parameters[:dsc_ensure] = 'absent'
+        dsc_registry[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_registry)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_registry[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_registry)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_registry)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_RegistryResource as $MSFT_RegistryResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_RegistryResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_registry[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_registry)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_registry[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_registry[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_registry)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_registry[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_script_spec.rb
+++ b/spec/unit/puppet/type/dsc_script_spec.rb
@@ -1,0 +1,191 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_script) do
+
+  let :dsc_script do
+    Puppet::Type.type(:dsc_script).new(
+      :name     => 'foo',
+      :dsc_getscript => 'foo',
+      :dsc_setscript => 'foo',
+      :dsc_testscript => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_script.to_s).to eq("Dsc_script[foo]")
+  end
+
+  it 'should require that dsc_getscript is specified' do
+    #dsc_script[:dsc_getscript]
+    expect { Puppet::Type.type(:dsc_script).new(
+      :name     => 'foo',
+      :dsc_setscript => 'foo',
+      :dsc_testscript => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_result => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_getscript is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_getscript' do
+    expect{dsc_script[:dsc_getscript] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_getscript' do
+    expect{dsc_script[:dsc_getscript] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_getscript' do
+    expect{dsc_script[:dsc_getscript] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_getscript' do
+    expect{dsc_script[:dsc_getscript] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_setscript is specified' do
+    #dsc_script[:dsc_setscript]
+    expect { Puppet::Type.type(:dsc_script).new(
+      :name     => 'foo',
+      :dsc_getscript => 'foo',
+      :dsc_testscript => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_result => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_setscript is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_setscript' do
+    expect{dsc_script[:dsc_setscript] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_setscript' do
+    expect{dsc_script[:dsc_setscript] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_setscript' do
+    expect{dsc_script[:dsc_setscript] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_setscript' do
+    expect{dsc_script[:dsc_setscript] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_testscript is specified' do
+    #dsc_script[:dsc_testscript]
+    expect { Puppet::Type.type(:dsc_script).new(
+      :name     => 'foo',
+      :dsc_getscript => 'foo',
+      :dsc_setscript => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_result => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_testscript is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_testscript' do
+    expect{dsc_script[:dsc_testscript] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_testscript' do
+    expect{dsc_script[:dsc_testscript] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_testscript' do
+    expect{dsc_script[:dsc_testscript] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_testscript' do
+    expect{dsc_script[:dsc_testscript] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_script[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_script[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_script[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_script[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_result' do
+    expect{dsc_script[:dsc_result] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_result' do
+    expect{dsc_script[:dsc_result] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_result' do
+    expect{dsc_script[:dsc_result] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_result' do
+    expect{dsc_script[:dsc_result] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_script)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_script)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_script[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_script[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_script)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_script)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_ScriptResource as $MSFT_ScriptResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_ScriptResource/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_service_spec.rb
+++ b/spec/unit/puppet/type/dsc_service_spec.rb
@@ -1,0 +1,345 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_service) do
+
+  let :dsc_service do
+    Puppet::Type.type(:dsc_service).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_service.to_s).to eq("Dsc_service[foo]")
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_service[:dsc_name]
+    expect { Puppet::Type.type(:dsc_service).new(
+      :name     => 'foo',
+      :dsc_state => 'Running',
+      :dsc_startuptype => 'Automatic',
+      :dsc_builtinaccount => 'LocalSystem',
+      :dsc_credential => 'foo',
+      :dsc_status => 'foo',
+      :dsc_displayname => 'foo',
+      :dsc_description => 'foo',
+      :dsc_path => 'foo',
+      :dsc_dependencies => ["foo", "bar", "spec"],
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_service[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_service[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_service[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_service[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_state predefined value Running' do
+    dsc_service[:dsc_state] = 'Running'
+    expect(dsc_service[:dsc_state]).to eq('Running')
+  end
+
+  it 'should accept dsc_state predefined value running' do
+    dsc_service[:dsc_state] = 'running'
+    expect(dsc_service[:dsc_state]).to eq('running')
+  end
+
+  it 'should accept dsc_state predefined value Stopped' do
+    dsc_service[:dsc_state] = 'Stopped'
+    expect(dsc_service[:dsc_state]).to eq('Stopped')
+  end
+
+  it 'should accept dsc_state predefined value stopped' do
+    dsc_service[:dsc_state] = 'stopped'
+    expect(dsc_service[:dsc_state]).to eq('stopped')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_service[:dsc_state] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_state' do
+    expect{dsc_service[:dsc_state] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_state' do
+    expect{dsc_service[:dsc_state] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_state' do
+    expect{dsc_service[:dsc_state] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_state' do
+    expect{dsc_service[:dsc_state] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_startuptype predefined value Automatic' do
+    dsc_service[:dsc_startuptype] = 'Automatic'
+    expect(dsc_service[:dsc_startuptype]).to eq('Automatic')
+  end
+
+  it 'should accept dsc_startuptype predefined value automatic' do
+    dsc_service[:dsc_startuptype] = 'automatic'
+    expect(dsc_service[:dsc_startuptype]).to eq('automatic')
+  end
+
+  it 'should accept dsc_startuptype predefined value Manual' do
+    dsc_service[:dsc_startuptype] = 'Manual'
+    expect(dsc_service[:dsc_startuptype]).to eq('Manual')
+  end
+
+  it 'should accept dsc_startuptype predefined value manual' do
+    dsc_service[:dsc_startuptype] = 'manual'
+    expect(dsc_service[:dsc_startuptype]).to eq('manual')
+  end
+
+  it 'should accept dsc_startuptype predefined value Disabled' do
+    dsc_service[:dsc_startuptype] = 'Disabled'
+    expect(dsc_service[:dsc_startuptype]).to eq('Disabled')
+  end
+
+  it 'should accept dsc_startuptype predefined value disabled' do
+    dsc_service[:dsc_startuptype] = 'disabled'
+    expect(dsc_service[:dsc_startuptype]).to eq('disabled')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_service[:dsc_startuptype] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_startuptype' do
+    expect{dsc_service[:dsc_startuptype] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_startuptype' do
+    expect{dsc_service[:dsc_startuptype] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_startuptype' do
+    expect{dsc_service[:dsc_startuptype] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_startuptype' do
+    expect{dsc_service[:dsc_startuptype] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_builtinaccount predefined value LocalSystem' do
+    dsc_service[:dsc_builtinaccount] = 'LocalSystem'
+    expect(dsc_service[:dsc_builtinaccount]).to eq('LocalSystem')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value localsystem' do
+    dsc_service[:dsc_builtinaccount] = 'localsystem'
+    expect(dsc_service[:dsc_builtinaccount]).to eq('localsystem')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value LocalService' do
+    dsc_service[:dsc_builtinaccount] = 'LocalService'
+    expect(dsc_service[:dsc_builtinaccount]).to eq('LocalService')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value localservice' do
+    dsc_service[:dsc_builtinaccount] = 'localservice'
+    expect(dsc_service[:dsc_builtinaccount]).to eq('localservice')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value NetworkService' do
+    dsc_service[:dsc_builtinaccount] = 'NetworkService'
+    expect(dsc_service[:dsc_builtinaccount]).to eq('NetworkService')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value networkservice' do
+    dsc_service[:dsc_builtinaccount] = 'networkservice'
+    expect(dsc_service[:dsc_builtinaccount]).to eq('networkservice')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_service[:dsc_builtinaccount] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_builtinaccount' do
+    expect{dsc_service[:dsc_builtinaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_builtinaccount' do
+    expect{dsc_service[:dsc_builtinaccount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_builtinaccount' do
+    expect{dsc_service[:dsc_builtinaccount] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_builtinaccount' do
+    expect{dsc_service[:dsc_builtinaccount] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_service[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_service[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_service[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_service[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_status' do
+    expect{dsc_service[:dsc_status] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_status' do
+    expect{dsc_service[:dsc_status] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_status' do
+    expect{dsc_service[:dsc_status] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_status' do
+    expect{dsc_service[:dsc_status] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_displayname' do
+    expect{dsc_service[:dsc_displayname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_displayname' do
+    expect{dsc_service[:dsc_displayname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_displayname' do
+    expect{dsc_service[:dsc_displayname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_displayname' do
+    expect{dsc_service[:dsc_displayname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_service[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_service[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_service[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_service[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_service[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_service[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_service[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_service[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_dependencies' do
+    dsc_service[:dsc_dependencies] = ["foo", "bar", "spec"]
+    expect(dsc_service[:dsc_dependencies]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_dependencies' do
+    expect{dsc_service[:dsc_dependencies] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dependencies' do
+    expect{dsc_service[:dsc_dependencies] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dependencies' do
+    expect{dsc_service[:dsc_dependencies] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_service)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_service)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_service[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_service[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_service)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_service)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_ServiceResource as $MSFT_ServiceResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_ServiceResource/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_user_spec.rb
+++ b/spec/unit/puppet/type/dsc_user_spec.rb
@@ -1,0 +1,471 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_user) do
+
+  let :dsc_user do
+    Puppet::Type.type(:dsc_user).new(
+      :name     => 'foo',
+      :dsc_username => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_user.to_s).to eq("Dsc_user[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_user[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_username is specified' do
+    #dsc_user[:dsc_username]
+    expect { Puppet::Type.type(:dsc_user).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_fullname => 'foo',
+      :dsc_description => 'foo',
+      :dsc_password => 'foo',
+      :dsc_disabled => true,
+      :dsc_passwordneverexpires => true,
+      :dsc_passwordchangerequired => true,
+      :dsc_passwordchangenotallowed => true,
+    )}.to raise_error(Puppet::Error, /dsc_username is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_username' do
+    expect{dsc_user[:dsc_username] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_username' do
+    expect{dsc_user[:dsc_username] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_username' do
+    expect{dsc_user[:dsc_username] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_username' do
+    expect{dsc_user[:dsc_username] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_user[:dsc_ensure] = 'Present'
+    expect(dsc_user[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_user[:dsc_ensure] = 'present'
+    expect(dsc_user[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_user[:dsc_ensure] = 'present'
+    expect(dsc_user[:ensure]).to eq(dsc_user[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_user[:dsc_ensure] = 'Absent'
+    expect(dsc_user[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_user[:dsc_ensure] = 'absent'
+    expect(dsc_user[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_user[:dsc_ensure] = 'absent'
+    expect(dsc_user[:ensure]).to eq(dsc_user[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_user[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_user[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_user[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_user[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_user[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_fullname' do
+    expect{dsc_user[:dsc_fullname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_fullname' do
+    expect{dsc_user[:dsc_fullname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_fullname' do
+    expect{dsc_user[:dsc_fullname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_fullname' do
+    expect{dsc_user[:dsc_fullname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_user[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_user[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_user[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_user[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_password' do
+    expect{dsc_user[:dsc_password] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_password' do
+    expect{dsc_user[:dsc_password] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_password' do
+    expect{dsc_user[:dsc_password] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_password' do
+    expect{dsc_user[:dsc_password] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_disabled' do
+    expect{dsc_user[:dsc_disabled] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_disabled' do
+    dsc_user[:dsc_disabled] = true
+    expect(dsc_user[:dsc_disabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_disabled" do
+    dsc_user[:dsc_disabled] = 'true'
+    expect(dsc_user[:dsc_disabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_disabled" do
+    dsc_user[:dsc_disabled] = 'false'
+    expect(dsc_user[:dsc_disabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_disabled" do
+    dsc_user[:dsc_disabled] = 'True'
+    expect(dsc_user[:dsc_disabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_disabled" do
+    dsc_user[:dsc_disabled] = 'False'
+    expect(dsc_user[:dsc_disabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_disabled" do
+    dsc_user[:dsc_disabled] = :true
+    expect(dsc_user[:dsc_disabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_disabled" do
+    dsc_user[:dsc_disabled] = :false
+    expect(dsc_user[:dsc_disabled]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_disabled' do
+    expect{dsc_user[:dsc_disabled] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_disabled' do
+    expect{dsc_user[:dsc_disabled] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_passwordneverexpires' do
+    expect{dsc_user[:dsc_passwordneverexpires] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_passwordneverexpires' do
+    dsc_user[:dsc_passwordneverexpires] = true
+    expect(dsc_user[:dsc_passwordneverexpires]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_passwordneverexpires" do
+    dsc_user[:dsc_passwordneverexpires] = 'true'
+    expect(dsc_user[:dsc_passwordneverexpires]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_passwordneverexpires" do
+    dsc_user[:dsc_passwordneverexpires] = 'false'
+    expect(dsc_user[:dsc_passwordneverexpires]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_passwordneverexpires" do
+    dsc_user[:dsc_passwordneverexpires] = 'True'
+    expect(dsc_user[:dsc_passwordneverexpires]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_passwordneverexpires" do
+    dsc_user[:dsc_passwordneverexpires] = 'False'
+    expect(dsc_user[:dsc_passwordneverexpires]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_passwordneverexpires" do
+    dsc_user[:dsc_passwordneverexpires] = :true
+    expect(dsc_user[:dsc_passwordneverexpires]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_passwordneverexpires" do
+    dsc_user[:dsc_passwordneverexpires] = :false
+    expect(dsc_user[:dsc_passwordneverexpires]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_passwordneverexpires' do
+    expect{dsc_user[:dsc_passwordneverexpires] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_passwordneverexpires' do
+    expect{dsc_user[:dsc_passwordneverexpires] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_passwordchangerequired' do
+    expect{dsc_user[:dsc_passwordchangerequired] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_passwordchangerequired' do
+    dsc_user[:dsc_passwordchangerequired] = true
+    expect(dsc_user[:dsc_passwordchangerequired]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_passwordchangerequired" do
+    dsc_user[:dsc_passwordchangerequired] = 'true'
+    expect(dsc_user[:dsc_passwordchangerequired]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_passwordchangerequired" do
+    dsc_user[:dsc_passwordchangerequired] = 'false'
+    expect(dsc_user[:dsc_passwordchangerequired]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_passwordchangerequired" do
+    dsc_user[:dsc_passwordchangerequired] = 'True'
+    expect(dsc_user[:dsc_passwordchangerequired]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_passwordchangerequired" do
+    dsc_user[:dsc_passwordchangerequired] = 'False'
+    expect(dsc_user[:dsc_passwordchangerequired]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_passwordchangerequired" do
+    dsc_user[:dsc_passwordchangerequired] = :true
+    expect(dsc_user[:dsc_passwordchangerequired]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_passwordchangerequired" do
+    dsc_user[:dsc_passwordchangerequired] = :false
+    expect(dsc_user[:dsc_passwordchangerequired]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_passwordchangerequired' do
+    expect{dsc_user[:dsc_passwordchangerequired] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_passwordchangerequired' do
+    expect{dsc_user[:dsc_passwordchangerequired] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_passwordchangenotallowed' do
+    expect{dsc_user[:dsc_passwordchangenotallowed] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_passwordchangenotallowed' do
+    dsc_user[:dsc_passwordchangenotallowed] = true
+    expect(dsc_user[:dsc_passwordchangenotallowed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_passwordchangenotallowed" do
+    dsc_user[:dsc_passwordchangenotallowed] = 'true'
+    expect(dsc_user[:dsc_passwordchangenotallowed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_passwordchangenotallowed" do
+    dsc_user[:dsc_passwordchangenotallowed] = 'false'
+    expect(dsc_user[:dsc_passwordchangenotallowed]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_passwordchangenotallowed" do
+    dsc_user[:dsc_passwordchangenotallowed] = 'True'
+    expect(dsc_user[:dsc_passwordchangenotallowed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_passwordchangenotallowed" do
+    dsc_user[:dsc_passwordchangenotallowed] = 'False'
+    expect(dsc_user[:dsc_passwordchangenotallowed]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_passwordchangenotallowed" do
+    dsc_user[:dsc_passwordchangenotallowed] = :true
+    expect(dsc_user[:dsc_passwordchangenotallowed]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_passwordchangenotallowed" do
+    dsc_user[:dsc_passwordchangenotallowed] = :false
+    expect(dsc_user[:dsc_passwordchangenotallowed]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_passwordchangenotallowed' do
+    expect{dsc_user[:dsc_passwordchangenotallowed] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_passwordchangenotallowed' do
+    expect{dsc_user[:dsc_passwordchangenotallowed] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_user)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_user)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_user[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_user[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_user.original_parameters[:dsc_ensure] = 'present'
+        dsc_user[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_user)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_user[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_user.original_parameters[:dsc_ensure] = 'absent'
+        dsc_user[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_user)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_user[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_user)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_user)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_UserResource as $MSFT_UserResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_UserResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_user[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_user)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_user[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_user[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_user)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_user[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_webdeploy_spec.rb
+++ b/spec/unit/puppet/type/dsc_webdeploy_spec.rb
@@ -1,0 +1,255 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_webdeploy) do
+
+  let :dsc_webdeploy do
+    Puppet::Type.type(:dsc_webdeploy).new(
+      :name     => 'foo',
+      :dsc_packagepath => 'foo',
+      :dsc_contentpath => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_webdeploy.to_s).to eq("Dsc_webdeploy[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_webdeploy[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_packagepath is specified' do
+    #dsc_webdeploy[:dsc_packagepath]
+    expect { Puppet::Type.type(:dsc_webdeploy).new(
+      :name     => 'foo',
+      :dsc_contentpath => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_packagepath is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_packagepath' do
+    expect{dsc_webdeploy[:dsc_packagepath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_packagepath' do
+    expect{dsc_webdeploy[:dsc_packagepath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_packagepath' do
+    expect{dsc_webdeploy[:dsc_packagepath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_packagepath' do
+    expect{dsc_webdeploy[:dsc_packagepath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_contentpath is specified' do
+    #dsc_webdeploy[:dsc_contentpath]
+    expect { Puppet::Type.type(:dsc_webdeploy).new(
+      :name     => 'foo',
+      :dsc_packagepath => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_contentpath is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_contentpath' do
+    expect{dsc_webdeploy[:dsc_contentpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_contentpath' do
+    expect{dsc_webdeploy[:dsc_contentpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_contentpath' do
+    expect{dsc_webdeploy[:dsc_contentpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_contentpath' do
+    expect{dsc_webdeploy[:dsc_contentpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_webdeploy[:dsc_ensure] = 'Present'
+    expect(dsc_webdeploy[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_webdeploy[:dsc_ensure] = 'present'
+    expect(dsc_webdeploy[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_webdeploy[:dsc_ensure] = 'present'
+    expect(dsc_webdeploy[:ensure]).to eq(dsc_webdeploy[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_webdeploy[:dsc_ensure] = 'Absent'
+    expect(dsc_webdeploy[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_webdeploy[:dsc_ensure] = 'absent'
+    expect(dsc_webdeploy[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_webdeploy[:dsc_ensure] = 'absent'
+    expect(dsc_webdeploy[:ensure]).to eq(dsc_webdeploy[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_webdeploy[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_webdeploy[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_webdeploy[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_webdeploy[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_webdeploy[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_webdeploy)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_webdeploy)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_webdeploy[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_webdeploy[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_webdeploy.original_parameters[:dsc_ensure] = 'present'
+        dsc_webdeploy[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_webdeploy)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_webdeploy[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_webdeploy.original_parameters[:dsc_ensure] = 'absent'
+        dsc_webdeploy[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_webdeploy)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_webdeploy[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_webdeploy)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_webdeploy)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWebdeploy as $MSFT_xWebdeploy1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWebdeploy/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_webdeploy[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_webdeploy)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_webdeploy[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_webdeploy[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_webdeploy)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_webdeploy[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_windowsfeature_spec.rb
+++ b/spec/unit/puppet/type/dsc_windowsfeature_spec.rb
@@ -1,0 +1,344 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_windowsfeature) do
+
+  let :dsc_windowsfeature do
+    Puppet::Type.type(:dsc_windowsfeature).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_windowsfeature.to_s).to eq("Dsc_windowsfeature[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_windowsfeature[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_windowsfeature[:dsc_name]
+    expect { Puppet::Type.type(:dsc_windowsfeature).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_displayname => 'foo',
+      :dsc_source => 'foo',
+      :dsc_includeallsubfeature => true,
+      :dsc_logpath => 'foo',
+      :dsc_credential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_windowsfeature[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_windowsfeature[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_windowsfeature[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_windowsfeature[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_windowsfeature[:dsc_ensure] = 'Present'
+    expect(dsc_windowsfeature[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_windowsfeature[:dsc_ensure] = 'present'
+    expect(dsc_windowsfeature[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_windowsfeature[:dsc_ensure] = 'present'
+    expect(dsc_windowsfeature[:ensure]).to eq(dsc_windowsfeature[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_windowsfeature[:dsc_ensure] = 'Absent'
+    expect(dsc_windowsfeature[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_windowsfeature[:dsc_ensure] = 'absent'
+    expect(dsc_windowsfeature[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_windowsfeature[:dsc_ensure] = 'absent'
+    expect(dsc_windowsfeature[:ensure]).to eq(dsc_windowsfeature[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_windowsfeature[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_windowsfeature[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_windowsfeature[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_windowsfeature[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_windowsfeature[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_displayname' do
+    expect{dsc_windowsfeature[:dsc_displayname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_displayname' do
+    expect{dsc_windowsfeature[:dsc_displayname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_displayname' do
+    expect{dsc_windowsfeature[:dsc_displayname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_displayname' do
+    expect{dsc_windowsfeature[:dsc_displayname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_source' do
+    expect{dsc_windowsfeature[:dsc_source] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_source' do
+    expect{dsc_windowsfeature[:dsc_source] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_source' do
+    expect{dsc_windowsfeature[:dsc_source] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_source' do
+    expect{dsc_windowsfeature[:dsc_source] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_includeallsubfeature' do
+    expect{dsc_windowsfeature[:dsc_includeallsubfeature] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_includeallsubfeature' do
+    dsc_windowsfeature[:dsc_includeallsubfeature] = true
+    expect(dsc_windowsfeature[:dsc_includeallsubfeature]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_includeallsubfeature" do
+    dsc_windowsfeature[:dsc_includeallsubfeature] = 'true'
+    expect(dsc_windowsfeature[:dsc_includeallsubfeature]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_includeallsubfeature" do
+    dsc_windowsfeature[:dsc_includeallsubfeature] = 'false'
+    expect(dsc_windowsfeature[:dsc_includeallsubfeature]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_includeallsubfeature" do
+    dsc_windowsfeature[:dsc_includeallsubfeature] = 'True'
+    expect(dsc_windowsfeature[:dsc_includeallsubfeature]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_includeallsubfeature" do
+    dsc_windowsfeature[:dsc_includeallsubfeature] = 'False'
+    expect(dsc_windowsfeature[:dsc_includeallsubfeature]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_includeallsubfeature" do
+    dsc_windowsfeature[:dsc_includeallsubfeature] = :true
+    expect(dsc_windowsfeature[:dsc_includeallsubfeature]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_includeallsubfeature" do
+    dsc_windowsfeature[:dsc_includeallsubfeature] = :false
+    expect(dsc_windowsfeature[:dsc_includeallsubfeature]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_includeallsubfeature' do
+    expect{dsc_windowsfeature[:dsc_includeallsubfeature] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_includeallsubfeature' do
+    expect{dsc_windowsfeature[:dsc_includeallsubfeature] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_logpath' do
+    expect{dsc_windowsfeature[:dsc_logpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_logpath' do
+    expect{dsc_windowsfeature[:dsc_logpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_logpath' do
+    expect{dsc_windowsfeature[:dsc_logpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_logpath' do
+    expect{dsc_windowsfeature[:dsc_logpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_windowsfeature[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_windowsfeature[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_windowsfeature[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_windowsfeature[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_windowsfeature)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_windowsfeature)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_windowsfeature[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_windowsfeature[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_windowsfeature.original_parameters[:dsc_ensure] = 'present'
+        dsc_windowsfeature[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_windowsfeature)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_windowsfeature[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_windowsfeature.original_parameters[:dsc_ensure] = 'absent'
+        dsc_windowsfeature[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_windowsfeature)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_windowsfeature[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_windowsfeature)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_windowsfeature)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_RoleResource as $MSFT_RoleResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_RoleResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_windowsfeature[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_windowsfeature)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_windowsfeature[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_windowsfeature[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_windowsfeature)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_windowsfeature[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_windowsprocess_spec.rb
+++ b/spec/unit/puppet/type/dsc_windowsprocess_spec.rb
@@ -1,0 +1,582 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_windowsprocess) do
+
+  let :dsc_windowsprocess do
+    Puppet::Type.type(:dsc_windowsprocess).new(
+      :name     => 'foo',
+      :dsc_path => 'foo',
+      :dsc_arguments => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_windowsprocess.to_s).to eq("Dsc_windowsprocess[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_windowsprocess[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_path is specified' do
+    #dsc_windowsprocess[:dsc_path]
+    expect { Puppet::Type.type(:dsc_windowsprocess).new(
+      :name     => 'foo',
+      :dsc_arguments => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_standardoutputpath => 'foo',
+      :dsc_standarderrorpath => 'foo',
+      :dsc_standardinputpath => 'foo',
+      :dsc_workingdirectory => 'foo',
+      :dsc_pagedmemorysize => 64,
+      :dsc_nonpagedmemorysize => 64,
+      :dsc_virtualmemorysize => 64,
+      :dsc_handlecount => -32,
+      :dsc_processid => -32,
+    )}.to raise_error(Puppet::Error, /dsc_path is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_windowsprocess[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_windowsprocess[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_windowsprocess[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_windowsprocess[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_arguments is specified' do
+    #dsc_windowsprocess[:dsc_arguments]
+    expect { Puppet::Type.type(:dsc_windowsprocess).new(
+      :name     => 'foo',
+      :dsc_path => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_standardoutputpath => 'foo',
+      :dsc_standarderrorpath => 'foo',
+      :dsc_standardinputpath => 'foo',
+      :dsc_workingdirectory => 'foo',
+      :dsc_pagedmemorysize => 64,
+      :dsc_nonpagedmemorysize => 64,
+      :dsc_virtualmemorysize => 64,
+      :dsc_handlecount => -32,
+      :dsc_processid => -32,
+    )}.to raise_error(Puppet::Error, /dsc_arguments is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_arguments' do
+    expect{dsc_windowsprocess[:dsc_arguments] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_arguments' do
+    expect{dsc_windowsprocess[:dsc_arguments] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_arguments' do
+    expect{dsc_windowsprocess[:dsc_arguments] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_arguments' do
+    expect{dsc_windowsprocess[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_windowsprocess[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_windowsprocess[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_windowsprocess[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_windowsprocess[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_windowsprocess[:dsc_ensure] = 'Present'
+    expect(dsc_windowsprocess[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_windowsprocess[:dsc_ensure] = 'present'
+    expect(dsc_windowsprocess[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_windowsprocess[:dsc_ensure] = 'present'
+    expect(dsc_windowsprocess[:ensure]).to eq(dsc_windowsprocess[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_windowsprocess[:dsc_ensure] = 'Absent'
+    expect(dsc_windowsprocess[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_windowsprocess[:dsc_ensure] = 'absent'
+    expect(dsc_windowsprocess[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_windowsprocess[:dsc_ensure] = 'absent'
+    expect(dsc_windowsprocess[:ensure]).to eq(dsc_windowsprocess[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_windowsprocess[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_windowsprocess[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_windowsprocess[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_windowsprocess[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_windowsprocess[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_standardoutputpath' do
+    expect{dsc_windowsprocess[:dsc_standardoutputpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_standardoutputpath' do
+    expect{dsc_windowsprocess[:dsc_standardoutputpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_standardoutputpath' do
+    expect{dsc_windowsprocess[:dsc_standardoutputpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_standardoutputpath' do
+    expect{dsc_windowsprocess[:dsc_standardoutputpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_standarderrorpath' do
+    expect{dsc_windowsprocess[:dsc_standarderrorpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_standarderrorpath' do
+    expect{dsc_windowsprocess[:dsc_standarderrorpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_standarderrorpath' do
+    expect{dsc_windowsprocess[:dsc_standarderrorpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_standarderrorpath' do
+    expect{dsc_windowsprocess[:dsc_standarderrorpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_standardinputpath' do
+    expect{dsc_windowsprocess[:dsc_standardinputpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_standardinputpath' do
+    expect{dsc_windowsprocess[:dsc_standardinputpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_standardinputpath' do
+    expect{dsc_windowsprocess[:dsc_standardinputpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_standardinputpath' do
+    expect{dsc_windowsprocess[:dsc_standardinputpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_workingdirectory' do
+    expect{dsc_windowsprocess[:dsc_workingdirectory] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_workingdirectory' do
+    expect{dsc_windowsprocess[:dsc_workingdirectory] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_workingdirectory' do
+    expect{dsc_windowsprocess[:dsc_workingdirectory] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_workingdirectory' do
+    expect{dsc_windowsprocess[:dsc_workingdirectory] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_pagedmemorysize' do
+    expect{dsc_windowsprocess[:dsc_pagedmemorysize] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_pagedmemorysize' do
+    expect{dsc_windowsprocess[:dsc_pagedmemorysize] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_pagedmemorysize' do
+    expect{dsc_windowsprocess[:dsc_pagedmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_pagedmemorysize' do
+    dsc_windowsprocess[:dsc_pagedmemorysize] = 64
+    expect(dsc_windowsprocess[:dsc_pagedmemorysize]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_pagedmemorysize' do
+    dsc_windowsprocess[:dsc_pagedmemorysize] = '16'
+    expect(dsc_windowsprocess[:dsc_pagedmemorysize]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_pagedmemorysize' do
+    dsc_windowsprocess[:dsc_pagedmemorysize] = '32'
+    expect(dsc_windowsprocess[:dsc_pagedmemorysize]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_pagedmemorysize' do
+    dsc_windowsprocess[:dsc_pagedmemorysize] = '64'
+    expect(dsc_windowsprocess[:dsc_pagedmemorysize]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_nonpagedmemorysize' do
+    expect{dsc_windowsprocess[:dsc_nonpagedmemorysize] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_nonpagedmemorysize' do
+    expect{dsc_windowsprocess[:dsc_nonpagedmemorysize] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_nonpagedmemorysize' do
+    expect{dsc_windowsprocess[:dsc_nonpagedmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_nonpagedmemorysize' do
+    dsc_windowsprocess[:dsc_nonpagedmemorysize] = 64
+    expect(dsc_windowsprocess[:dsc_nonpagedmemorysize]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_nonpagedmemorysize' do
+    dsc_windowsprocess[:dsc_nonpagedmemorysize] = '16'
+    expect(dsc_windowsprocess[:dsc_nonpagedmemorysize]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_nonpagedmemorysize' do
+    dsc_windowsprocess[:dsc_nonpagedmemorysize] = '32'
+    expect(dsc_windowsprocess[:dsc_nonpagedmemorysize]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_nonpagedmemorysize' do
+    dsc_windowsprocess[:dsc_nonpagedmemorysize] = '64'
+    expect(dsc_windowsprocess[:dsc_nonpagedmemorysize]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_virtualmemorysize' do
+    expect{dsc_windowsprocess[:dsc_virtualmemorysize] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_virtualmemorysize' do
+    expect{dsc_windowsprocess[:dsc_virtualmemorysize] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_virtualmemorysize' do
+    expect{dsc_windowsprocess[:dsc_virtualmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_virtualmemorysize' do
+    dsc_windowsprocess[:dsc_virtualmemorysize] = 64
+    expect(dsc_windowsprocess[:dsc_virtualmemorysize]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_virtualmemorysize' do
+    dsc_windowsprocess[:dsc_virtualmemorysize] = '16'
+    expect(dsc_windowsprocess[:dsc_virtualmemorysize]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_virtualmemorysize' do
+    dsc_windowsprocess[:dsc_virtualmemorysize] = '32'
+    expect(dsc_windowsprocess[:dsc_virtualmemorysize]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_virtualmemorysize' do
+    dsc_windowsprocess[:dsc_virtualmemorysize] = '64'
+    expect(dsc_windowsprocess[:dsc_virtualmemorysize]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_handlecount' do
+    expect{dsc_windowsprocess[:dsc_handlecount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_handlecount' do
+    expect{dsc_windowsprocess[:dsc_handlecount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept int for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = -32
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(-32)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = '16'
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = '-16'
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(-16)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = '32'
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = '-32'
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(-32)
+  end
+
+
+  it 'should accept uint for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = -32
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(-32)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = '16'
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = '32'
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_windowsprocess[:dsc_handlecount] = '64'
+    expect(dsc_windowsprocess[:dsc_handlecount]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_processid' do
+    expect{dsc_windowsprocess[:dsc_processid] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_processid' do
+    expect{dsc_windowsprocess[:dsc_processid] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept int for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = -32
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(-32)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = '16'
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = '-16'
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(-16)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = '32'
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = '-32'
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(-32)
+  end
+
+
+  it 'should accept uint for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = -32
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(-32)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = '16'
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = '32'
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_windowsprocess[:dsc_processid] = '64'
+    expect(dsc_windowsprocess[:dsc_processid]).to eq(64)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_windowsprocess)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_windowsprocess)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_windowsprocess[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_windowsprocess[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_windowsprocess.original_parameters[:dsc_ensure] = 'present'
+        dsc_windowsprocess[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_windowsprocess)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_windowsprocess[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_windowsprocess.original_parameters[:dsc_ensure] = 'absent'
+        dsc_windowsprocess[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_windowsprocess)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_windowsprocess[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_windowsprocess)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_windowsprocess)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_ProcessResource as $MSFT_ProcessResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_ProcessResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_windowsprocess[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_windowsprocess)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_windowsprocess[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_windowsprocess[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_windowsprocess)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_windowsprocess[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xaddomain_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaddomain_spec.rb
@@ -1,0 +1,167 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xaddomain) do
+
+  let :dsc_xaddomain do
+    Puppet::Type.type(:dsc_xaddomain).new(
+      :name     => 'foo',
+      :dsc_domainname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xaddomain.to_s).to eq("Dsc_xaddomain[foo]")
+  end
+
+  it 'should require that dsc_domainname is specified' do
+    #dsc_xaddomain[:dsc_domainname]
+    expect { Puppet::Type.type(:dsc_xaddomain).new(
+      :name     => 'foo',
+      :dsc_parentdomainname => 'foo',
+      :dsc_domainadministratorcredential => 'foo',
+      :dsc_safemodeadministratorpassword => 'foo',
+      :dsc_dnsdelegationcredential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_domainname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_domainname' do
+    expect{dsc_xaddomain[:dsc_domainname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainname' do
+    expect{dsc_xaddomain[:dsc_domainname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainname' do
+    expect{dsc_xaddomain[:dsc_domainname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainname' do
+    expect{dsc_xaddomain[:dsc_domainname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_parentdomainname' do
+    expect{dsc_xaddomain[:dsc_parentdomainname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_parentdomainname' do
+    expect{dsc_xaddomain[:dsc_parentdomainname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_parentdomainname' do
+    expect{dsc_xaddomain[:dsc_parentdomainname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_parentdomainname' do
+    expect{dsc_xaddomain[:dsc_parentdomainname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_domainadministratorcredential' do
+    expect{dsc_xaddomain[:dsc_domainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainadministratorcredential' do
+    expect{dsc_xaddomain[:dsc_domainadministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainadministratorcredential' do
+    expect{dsc_xaddomain[:dsc_domainadministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainadministratorcredential' do
+    expect{dsc_xaddomain[:dsc_domainadministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_safemodeadministratorpassword' do
+    expect{dsc_xaddomain[:dsc_safemodeadministratorpassword] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_safemodeadministratorpassword' do
+    expect{dsc_xaddomain[:dsc_safemodeadministratorpassword] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_safemodeadministratorpassword' do
+    expect{dsc_xaddomain[:dsc_safemodeadministratorpassword] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_safemodeadministratorpassword' do
+    expect{dsc_xaddomain[:dsc_safemodeadministratorpassword] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_dnsdelegationcredential' do
+    expect{dsc_xaddomain[:dsc_dnsdelegationcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_dnsdelegationcredential' do
+    expect{dsc_xaddomain[:dsc_dnsdelegationcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dnsdelegationcredential' do
+    expect{dsc_xaddomain[:dsc_dnsdelegationcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dnsdelegationcredential' do
+    expect{dsc_xaddomain[:dsc_dnsdelegationcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xaddomain)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xaddomain)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xaddomain[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xaddomain[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xaddomain)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xaddomain)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xADDomain as $MSFT_xADDomain1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xADDomain/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xaddomaincontroller_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaddomaincontroller_spec.rb
@@ -1,0 +1,133 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xaddomaincontroller) do
+
+  let :dsc_xaddomaincontroller do
+    Puppet::Type.type(:dsc_xaddomaincontroller).new(
+      :name     => 'foo',
+      :dsc_domainname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xaddomaincontroller.to_s).to eq("Dsc_xaddomaincontroller[foo]")
+  end
+
+  it 'should require that dsc_domainname is specified' do
+    #dsc_xaddomaincontroller[:dsc_domainname]
+    expect { Puppet::Type.type(:dsc_xaddomaincontroller).new(
+      :name     => 'foo',
+      :dsc_domainadministratorcredential => 'foo',
+      :dsc_safemodeadministratorpassword => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_domainname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_domainname' do
+    expect{dsc_xaddomaincontroller[:dsc_domainname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainname' do
+    expect{dsc_xaddomaincontroller[:dsc_domainname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainname' do
+    expect{dsc_xaddomaincontroller[:dsc_domainname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainname' do
+    expect{dsc_xaddomaincontroller[:dsc_domainname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_domainadministratorcredential' do
+    expect{dsc_xaddomaincontroller[:dsc_domainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainadministratorcredential' do
+    expect{dsc_xaddomaincontroller[:dsc_domainadministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainadministratorcredential' do
+    expect{dsc_xaddomaincontroller[:dsc_domainadministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainadministratorcredential' do
+    expect{dsc_xaddomaincontroller[:dsc_domainadministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_safemodeadministratorpassword' do
+    expect{dsc_xaddomaincontroller[:dsc_safemodeadministratorpassword] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_safemodeadministratorpassword' do
+    expect{dsc_xaddomaincontroller[:dsc_safemodeadministratorpassword] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_safemodeadministratorpassword' do
+    expect{dsc_xaddomaincontroller[:dsc_safemodeadministratorpassword] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_safemodeadministratorpassword' do
+    expect{dsc_xaddomaincontroller[:dsc_safemodeadministratorpassword] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xaddomaincontroller)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xaddomaincontroller)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xaddomaincontroller[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xaddomaincontroller[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xaddomaincontroller)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xaddomaincontroller)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xADDomainController as $MSFT_xADDomainController1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xADDomainController/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xaddomaintrust_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaddomaintrust_spec.rb
@@ -1,0 +1,357 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xaddomaintrust) do
+
+  let :dsc_xaddomaintrust do
+    Puppet::Type.type(:dsc_xaddomaintrust).new(
+      :name     => 'foo',
+      :dsc_targetdomainname => 'foo',
+      :dsc_sourcedomainname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xaddomaintrust.to_s).to eq("Dsc_xaddomaintrust[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xaddomaintrust[:ensure]).to eq :present
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xaddomaintrust[:dsc_ensure] = 'Present'
+    expect(dsc_xaddomaintrust[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xaddomaintrust[:dsc_ensure] = 'present'
+    expect(dsc_xaddomaintrust[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xaddomaintrust[:dsc_ensure] = 'present'
+    expect(dsc_xaddomaintrust[:ensure]).to eq(dsc_xaddomaintrust[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xaddomaintrust[:dsc_ensure] = 'Absent'
+    expect(dsc_xaddomaintrust[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xaddomaintrust[:dsc_ensure] = 'absent'
+    expect(dsc_xaddomaintrust[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xaddomaintrust[:dsc_ensure] = 'absent'
+    expect(dsc_xaddomaintrust[:ensure]).to eq(dsc_xaddomaintrust[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xaddomaintrust[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xaddomaintrust[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xaddomaintrust[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xaddomaintrust[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xaddomaintrust[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_targetdomainadministratorcredential' do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_targetdomainadministratorcredential' do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainadministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_targetdomainadministratorcredential' do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainadministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_targetdomainadministratorcredential' do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainadministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_targetdomainname is specified' do
+    #dsc_xaddomaintrust[:dsc_targetdomainname]
+    expect { Puppet::Type.type(:dsc_xaddomaintrust).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_targetdomainadministratorcredential => 'foo',
+      :dsc_trusttype => 'External',
+      :dsc_trustdirection => 'Bidirectional',
+      :dsc_sourcedomainname => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_targetdomainname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_targetdomainname' do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_targetdomainname' do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_targetdomainname' do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_targetdomainname' do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_trusttype predefined value External' do
+    dsc_xaddomaintrust[:dsc_trusttype] = 'External'
+    expect(dsc_xaddomaintrust[:dsc_trusttype]).to eq('External')
+  end
+
+  it 'should accept dsc_trusttype predefined value external' do
+    dsc_xaddomaintrust[:dsc_trusttype] = 'external'
+    expect(dsc_xaddomaintrust[:dsc_trusttype]).to eq('external')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xaddomaintrust[:dsc_trusttype] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_trusttype' do
+    expect{dsc_xaddomaintrust[:dsc_trusttype] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_trusttype' do
+    expect{dsc_xaddomaintrust[:dsc_trusttype] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_trusttype' do
+    expect{dsc_xaddomaintrust[:dsc_trusttype] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_trusttype' do
+    expect{dsc_xaddomaintrust[:dsc_trusttype] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_trustdirection predefined value Bidirectional' do
+    dsc_xaddomaintrust[:dsc_trustdirection] = 'Bidirectional'
+    expect(dsc_xaddomaintrust[:dsc_trustdirection]).to eq('Bidirectional')
+  end
+
+  it 'should accept dsc_trustdirection predefined value bidirectional' do
+    dsc_xaddomaintrust[:dsc_trustdirection] = 'bidirectional'
+    expect(dsc_xaddomaintrust[:dsc_trustdirection]).to eq('bidirectional')
+  end
+
+  it 'should accept dsc_trustdirection predefined value Inbound' do
+    dsc_xaddomaintrust[:dsc_trustdirection] = 'Inbound'
+    expect(dsc_xaddomaintrust[:dsc_trustdirection]).to eq('Inbound')
+  end
+
+  it 'should accept dsc_trustdirection predefined value inbound' do
+    dsc_xaddomaintrust[:dsc_trustdirection] = 'inbound'
+    expect(dsc_xaddomaintrust[:dsc_trustdirection]).to eq('inbound')
+  end
+
+  it 'should accept dsc_trustdirection predefined value Outbound' do
+    dsc_xaddomaintrust[:dsc_trustdirection] = 'Outbound'
+    expect(dsc_xaddomaintrust[:dsc_trustdirection]).to eq('Outbound')
+  end
+
+  it 'should accept dsc_trustdirection predefined value outbound' do
+    dsc_xaddomaintrust[:dsc_trustdirection] = 'outbound'
+    expect(dsc_xaddomaintrust[:dsc_trustdirection]).to eq('outbound')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xaddomaintrust[:dsc_trustdirection] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_trustdirection' do
+    expect{dsc_xaddomaintrust[:dsc_trustdirection] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_trustdirection' do
+    expect{dsc_xaddomaintrust[:dsc_trustdirection] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_trustdirection' do
+    expect{dsc_xaddomaintrust[:dsc_trustdirection] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_trustdirection' do
+    expect{dsc_xaddomaintrust[:dsc_trustdirection] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_sourcedomainname is specified' do
+    #dsc_xaddomaintrust[:dsc_sourcedomainname]
+    expect { Puppet::Type.type(:dsc_xaddomaintrust).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_targetdomainadministratorcredential => 'foo',
+      :dsc_targetdomainname => 'foo',
+      :dsc_trusttype => 'External',
+      :dsc_trustdirection => 'Bidirectional',
+    )}.to raise_error(Puppet::Error, /dsc_sourcedomainname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_sourcedomainname' do
+    expect{dsc_xaddomaintrust[:dsc_sourcedomainname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sourcedomainname' do
+    expect{dsc_xaddomaintrust[:dsc_sourcedomainname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sourcedomainname' do
+    expect{dsc_xaddomaintrust[:dsc_sourcedomainname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sourcedomainname' do
+    expect{dsc_xaddomaintrust[:dsc_sourcedomainname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xaddomaintrust)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xaddomaintrust)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xaddomaintrust[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xaddomaintrust[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xaddomaintrust.original_parameters[:dsc_ensure] = 'present'
+        dsc_xaddomaintrust[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xaddomaintrust)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xaddomaintrust[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xaddomaintrust.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xaddomaintrust[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xaddomaintrust)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xaddomaintrust[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xaddomaintrust)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xaddomaintrust)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xADDomainTrust as $MSFT_xADDomainTrust1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xADDomainTrust/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xaddomaintrust[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xaddomaintrust)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xaddomaintrust[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xaddomaintrust[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xaddomaintrust)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xaddomaintrust[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xaduser_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaduser_spec.rb
@@ -1,0 +1,291 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xaduser) do
+
+  let :dsc_xaduser do
+    Puppet::Type.type(:dsc_xaduser).new(
+      :name     => 'foo',
+      :dsc_domainname => 'foo',
+      :dsc_username => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xaduser.to_s).to eq("Dsc_xaduser[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xaduser[:ensure]).to eq :present
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xaduser[:dsc_ensure] = 'Present'
+    expect(dsc_xaduser[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xaduser[:dsc_ensure] = 'present'
+    expect(dsc_xaduser[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xaduser[:dsc_ensure] = 'present'
+    expect(dsc_xaduser[:ensure]).to eq(dsc_xaduser[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xaduser[:dsc_ensure] = 'Absent'
+    expect(dsc_xaduser[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xaduser[:dsc_ensure] = 'absent'
+    expect(dsc_xaduser[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xaduser[:dsc_ensure] = 'absent'
+    expect(dsc_xaduser[:ensure]).to eq(dsc_xaduser[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xaduser[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xaduser[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xaduser[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xaduser[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xaduser[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_domainname is specified' do
+    #dsc_xaduser[:dsc_domainname]
+    expect { Puppet::Type.type(:dsc_xaduser).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_username => 'foo',
+      :dsc_password => 'foo',
+      :dsc_domainadministratorcredential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_domainname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_domainname' do
+    expect{dsc_xaduser[:dsc_domainname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainname' do
+    expect{dsc_xaduser[:dsc_domainname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainname' do
+    expect{dsc_xaduser[:dsc_domainname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainname' do
+    expect{dsc_xaduser[:dsc_domainname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_username is specified' do
+    #dsc_xaduser[:dsc_username]
+    expect { Puppet::Type.type(:dsc_xaduser).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_domainname => 'foo',
+      :dsc_password => 'foo',
+      :dsc_domainadministratorcredential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_username is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_username' do
+    expect{dsc_xaduser[:dsc_username] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_username' do
+    expect{dsc_xaduser[:dsc_username] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_username' do
+    expect{dsc_xaduser[:dsc_username] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_username' do
+    expect{dsc_xaduser[:dsc_username] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_password' do
+    expect{dsc_xaduser[:dsc_password] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_password' do
+    expect{dsc_xaduser[:dsc_password] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_password' do
+    expect{dsc_xaduser[:dsc_password] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_password' do
+    expect{dsc_xaduser[:dsc_password] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_domainadministratorcredential' do
+    expect{dsc_xaduser[:dsc_domainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainadministratorcredential' do
+    expect{dsc_xaduser[:dsc_domainadministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainadministratorcredential' do
+    expect{dsc_xaduser[:dsc_domainadministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainadministratorcredential' do
+    expect{dsc_xaduser[:dsc_domainadministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xaduser)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xaduser)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xaduser[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xaduser[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xaduser.original_parameters[:dsc_ensure] = 'present'
+        dsc_xaduser[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xaduser)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xaduser[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xaduser.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xaduser[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xaduser)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xaduser[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xaduser)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xaduser)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xADUser as $MSFT_xADUser1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xADUser/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xaduser[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xaduser)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xaduser[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xaduser[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xaduser)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xaduser[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xarchive_spec.rb
+++ b/spec/unit/puppet/type/dsc_xarchive_spec.rb
@@ -1,0 +1,344 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xarchive) do
+
+  let :dsc_xarchive do
+    Puppet::Type.type(:dsc_xarchive).new(
+      :name     => 'foo',
+      :dsc_destination => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xarchive.to_s).to eq("Dsc_xarchive[foo]")
+  end
+
+  it 'should require that dsc_destination is specified' do
+    #dsc_xarchive[:dsc_destination]
+    expect { Puppet::Type.type(:dsc_xarchive).new(
+      :name     => 'foo',
+      :dsc_path => ["foo", "bar", "spec"],
+      :dsc_compressionlevel => 'Optimal',
+      :dsc_destinationtype => 'File',
+      :dsc_matchsource => true,
+      :dsc_creationtime => '20140711',
+      :dsc_attributes => 'foo',
+      :dsc_mode => 'foo',
+      :dsc_size => 64,
+    )}.to raise_error(Puppet::Error, /dsc_destination is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_destination' do
+    expect{dsc_xarchive[:dsc_destination] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_destination' do
+    expect{dsc_xarchive[:dsc_destination] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_destination' do
+    expect{dsc_xarchive[:dsc_destination] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_destination' do
+    expect{dsc_xarchive[:dsc_destination] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_path' do
+    dsc_xarchive[:dsc_path] = ["foo", "bar", "spec"]
+    expect(dsc_xarchive[:dsc_path]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xarchive[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xarchive[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xarchive[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_compressionlevel predefined value Optimal' do
+    dsc_xarchive[:dsc_compressionlevel] = 'Optimal'
+    expect(dsc_xarchive[:dsc_compressionlevel]).to eq('Optimal')
+  end
+
+  it 'should accept dsc_compressionlevel predefined value optimal' do
+    dsc_xarchive[:dsc_compressionlevel] = 'optimal'
+    expect(dsc_xarchive[:dsc_compressionlevel]).to eq('optimal')
+  end
+
+  it 'should accept dsc_compressionlevel predefined value NoCompression' do
+    dsc_xarchive[:dsc_compressionlevel] = 'NoCompression'
+    expect(dsc_xarchive[:dsc_compressionlevel]).to eq('NoCompression')
+  end
+
+  it 'should accept dsc_compressionlevel predefined value nocompression' do
+    dsc_xarchive[:dsc_compressionlevel] = 'nocompression'
+    expect(dsc_xarchive[:dsc_compressionlevel]).to eq('nocompression')
+  end
+
+  it 'should accept dsc_compressionlevel predefined value Fastest' do
+    dsc_xarchive[:dsc_compressionlevel] = 'Fastest'
+    expect(dsc_xarchive[:dsc_compressionlevel]).to eq('Fastest')
+  end
+
+  it 'should accept dsc_compressionlevel predefined value fastest' do
+    dsc_xarchive[:dsc_compressionlevel] = 'fastest'
+    expect(dsc_xarchive[:dsc_compressionlevel]).to eq('fastest')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xarchive[:dsc_compressionlevel] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_compressionlevel' do
+    expect{dsc_xarchive[:dsc_compressionlevel] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_compressionlevel' do
+    expect{dsc_xarchive[:dsc_compressionlevel] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_compressionlevel' do
+    expect{dsc_xarchive[:dsc_compressionlevel] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_compressionlevel' do
+    expect{dsc_xarchive[:dsc_compressionlevel] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_destinationtype predefined value File' do
+    dsc_xarchive[:dsc_destinationtype] = 'File'
+    expect(dsc_xarchive[:dsc_destinationtype]).to eq('File')
+  end
+
+  it 'should accept dsc_destinationtype predefined value file' do
+    dsc_xarchive[:dsc_destinationtype] = 'file'
+    expect(dsc_xarchive[:dsc_destinationtype]).to eq('file')
+  end
+
+  it 'should accept dsc_destinationtype predefined value Directory' do
+    dsc_xarchive[:dsc_destinationtype] = 'Directory'
+    expect(dsc_xarchive[:dsc_destinationtype]).to eq('Directory')
+  end
+
+  it 'should accept dsc_destinationtype predefined value directory' do
+    dsc_xarchive[:dsc_destinationtype] = 'directory'
+    expect(dsc_xarchive[:dsc_destinationtype]).to eq('directory')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xarchive[:dsc_destinationtype] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_destinationtype' do
+    expect{dsc_xarchive[:dsc_destinationtype] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_destinationtype' do
+    expect{dsc_xarchive[:dsc_destinationtype] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_destinationtype' do
+    expect{dsc_xarchive[:dsc_destinationtype] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_destinationtype' do
+    expect{dsc_xarchive[:dsc_destinationtype] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_matchsource' do
+    expect{dsc_xarchive[:dsc_matchsource] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_matchsource' do
+    dsc_xarchive[:dsc_matchsource] = true
+    expect(dsc_xarchive[:dsc_matchsource]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_matchsource" do
+    dsc_xarchive[:dsc_matchsource] = 'true'
+    expect(dsc_xarchive[:dsc_matchsource]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_matchsource" do
+    dsc_xarchive[:dsc_matchsource] = 'false'
+    expect(dsc_xarchive[:dsc_matchsource]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_matchsource" do
+    dsc_xarchive[:dsc_matchsource] = 'True'
+    expect(dsc_xarchive[:dsc_matchsource]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_matchsource" do
+    dsc_xarchive[:dsc_matchsource] = 'False'
+    expect(dsc_xarchive[:dsc_matchsource]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_matchsource" do
+    dsc_xarchive[:dsc_matchsource] = :true
+    expect(dsc_xarchive[:dsc_matchsource]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_matchsource" do
+    dsc_xarchive[:dsc_matchsource] = :false
+    expect(dsc_xarchive[:dsc_matchsource]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_matchsource' do
+    expect{dsc_xarchive[:dsc_matchsource] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_matchsource' do
+    expect{dsc_xarchive[:dsc_matchsource] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_creationtime' do
+    expect{dsc_xarchive[:dsc_creationtime] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_creationtime' do
+    expect{dsc_xarchive[:dsc_creationtime] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_creationtime' do
+    expect{dsc_xarchive[:dsc_creationtime] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_creationtime' do
+    expect{dsc_xarchive[:dsc_creationtime] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_attributes' do
+    expect{dsc_xarchive[:dsc_attributes] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_attributes' do
+    expect{dsc_xarchive[:dsc_attributes] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_attributes' do
+    expect{dsc_xarchive[:dsc_attributes] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_attributes' do
+    expect{dsc_xarchive[:dsc_attributes] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_mode' do
+    expect{dsc_xarchive[:dsc_mode] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_mode' do
+    expect{dsc_xarchive[:dsc_mode] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_mode' do
+    expect{dsc_xarchive[:dsc_mode] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_mode' do
+    expect{dsc_xarchive[:dsc_mode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_size' do
+    expect{dsc_xarchive[:dsc_size] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_size' do
+    expect{dsc_xarchive[:dsc_size] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_size' do
+    expect{dsc_xarchive[:dsc_size] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_size' do
+    dsc_xarchive[:dsc_size] = 64
+    expect(dsc_xarchive[:dsc_size]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_xarchive[:dsc_size] = '16'
+    expect(dsc_xarchive[:dsc_size]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_xarchive[:dsc_size] = '32'
+    expect(dsc_xarchive[:dsc_size]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_xarchive[:dsc_size] = '64'
+    expect(dsc_xarchive[:dsc_size]).to eq(64)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xarchive)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xarchive)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xarchive[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xarchive[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xarchive)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xarchive)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xArchive as $MSFT_xArchive1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xArchive/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazureaffinitygroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazureaffinitygroup_spec.rb
@@ -1,0 +1,279 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazureaffinitygroup) do
+
+  let :dsc_xazureaffinitygroup do
+    Puppet::Type.type(:dsc_xazureaffinitygroup).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazureaffinitygroup.to_s).to eq("Dsc_xazureaffinitygroup[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazureaffinitygroup[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xazureaffinitygroup[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xazureaffinitygroup).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_location => 'foo',
+      :dsc_description => 'foo',
+      :dsc_label => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xazureaffinitygroup[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xazureaffinitygroup[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xazureaffinitygroup[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xazureaffinitygroup[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazureaffinitygroup[:dsc_ensure] = 'Present'
+    expect(dsc_xazureaffinitygroup[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazureaffinitygroup[:dsc_ensure] = 'present'
+    expect(dsc_xazureaffinitygroup[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazureaffinitygroup[:dsc_ensure] = 'present'
+    expect(dsc_xazureaffinitygroup[:ensure]).to eq(dsc_xazureaffinitygroup[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazureaffinitygroup[:dsc_ensure] = 'Absent'
+    expect(dsc_xazureaffinitygroup[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazureaffinitygroup[:dsc_ensure] = 'absent'
+    expect(dsc_xazureaffinitygroup[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazureaffinitygroup[:dsc_ensure] = 'absent'
+    expect(dsc_xazureaffinitygroup[:ensure]).to eq(dsc_xazureaffinitygroup[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazureaffinitygroup[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazureaffinitygroup[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazureaffinitygroup[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazureaffinitygroup[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazureaffinitygroup[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_location' do
+    expect{dsc_xazureaffinitygroup[:dsc_location] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_location' do
+    expect{dsc_xazureaffinitygroup[:dsc_location] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_location' do
+    expect{dsc_xazureaffinitygroup[:dsc_location] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_location' do
+    expect{dsc_xazureaffinitygroup[:dsc_location] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_xazureaffinitygroup[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_xazureaffinitygroup[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_xazureaffinitygroup[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_xazureaffinitygroup[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_label' do
+    expect{dsc_xazureaffinitygroup[:dsc_label] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_label' do
+    expect{dsc_xazureaffinitygroup[:dsc_label] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_label' do
+    expect{dsc_xazureaffinitygroup[:dsc_label] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_label' do
+    expect{dsc_xazureaffinitygroup[:dsc_label] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazureaffinitygroup)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazureaffinitygroup)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazureaffinitygroup[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazureaffinitygroup[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazureaffinitygroup.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazureaffinitygroup[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazureaffinitygroup)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazureaffinitygroup[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazureaffinitygroup.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazureaffinitygroup[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazureaffinitygroup)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazureaffinitygroup[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazureaffinitygroup)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazureaffinitygroup)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureAffinityGroup as $MSFT_xAzureAffinityGroup1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureAffinityGroup/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazureaffinitygroup[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazureaffinitygroup)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazureaffinitygroup[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazureaffinitygroup[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazureaffinitygroup)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazureaffinitygroup[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazurequickvm_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurequickvm_spec.rb
@@ -1,0 +1,426 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazurequickvm) do
+
+  let :dsc_xazurequickvm do
+    Puppet::Type.type(:dsc_xazurequickvm).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazurequickvm.to_s).to eq("Dsc_xazurequickvm[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazurequickvm[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xazurequickvm[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xazurequickvm).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_imagename => 'foo',
+      :dsc_servicename => 'foo',
+      :dsc_linux => true,
+      :dsc_linuxuser => 'foo',
+      :dsc_windows => true,
+      :dsc_adminusername => 'foo',
+      :dsc_password => 'foo',
+      :dsc_instancesize => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xazurequickvm[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xazurequickvm[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xazurequickvm[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xazurequickvm[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazurequickvm[:dsc_ensure] = 'Present'
+    expect(dsc_xazurequickvm[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazurequickvm[:dsc_ensure] = 'present'
+    expect(dsc_xazurequickvm[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazurequickvm[:dsc_ensure] = 'present'
+    expect(dsc_xazurequickvm[:ensure]).to eq(dsc_xazurequickvm[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazurequickvm[:dsc_ensure] = 'Absent'
+    expect(dsc_xazurequickvm[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazurequickvm[:dsc_ensure] = 'absent'
+    expect(dsc_xazurequickvm[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazurequickvm[:dsc_ensure] = 'absent'
+    expect(dsc_xazurequickvm[:ensure]).to eq(dsc_xazurequickvm[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazurequickvm[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazurequickvm[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazurequickvm[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazurequickvm[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazurequickvm[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_imagename' do
+    expect{dsc_xazurequickvm[:dsc_imagename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_imagename' do
+    expect{dsc_xazurequickvm[:dsc_imagename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_imagename' do
+    expect{dsc_xazurequickvm[:dsc_imagename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_imagename' do
+    expect{dsc_xazurequickvm[:dsc_imagename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_servicename' do
+    expect{dsc_xazurequickvm[:dsc_servicename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_servicename' do
+    expect{dsc_xazurequickvm[:dsc_servicename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_servicename' do
+    expect{dsc_xazurequickvm[:dsc_servicename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_servicename' do
+    expect{dsc_xazurequickvm[:dsc_servicename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_linux' do
+    expect{dsc_xazurequickvm[:dsc_linux] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_linux' do
+    dsc_xazurequickvm[:dsc_linux] = true
+    expect(dsc_xazurequickvm[:dsc_linux]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_linux" do
+    dsc_xazurequickvm[:dsc_linux] = 'true'
+    expect(dsc_xazurequickvm[:dsc_linux]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_linux" do
+    dsc_xazurequickvm[:dsc_linux] = 'false'
+    expect(dsc_xazurequickvm[:dsc_linux]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_linux" do
+    dsc_xazurequickvm[:dsc_linux] = 'True'
+    expect(dsc_xazurequickvm[:dsc_linux]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_linux" do
+    dsc_xazurequickvm[:dsc_linux] = 'False'
+    expect(dsc_xazurequickvm[:dsc_linux]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_linux" do
+    dsc_xazurequickvm[:dsc_linux] = :true
+    expect(dsc_xazurequickvm[:dsc_linux]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_linux" do
+    dsc_xazurequickvm[:dsc_linux] = :false
+    expect(dsc_xazurequickvm[:dsc_linux]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_linux' do
+    expect{dsc_xazurequickvm[:dsc_linux] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_linux' do
+    expect{dsc_xazurequickvm[:dsc_linux] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_linuxuser' do
+    expect{dsc_xazurequickvm[:dsc_linuxuser] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_linuxuser' do
+    expect{dsc_xazurequickvm[:dsc_linuxuser] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_linuxuser' do
+    expect{dsc_xazurequickvm[:dsc_linuxuser] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_linuxuser' do
+    expect{dsc_xazurequickvm[:dsc_linuxuser] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_windows' do
+    expect{dsc_xazurequickvm[:dsc_windows] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_windows' do
+    dsc_xazurequickvm[:dsc_windows] = true
+    expect(dsc_xazurequickvm[:dsc_windows]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_windows" do
+    dsc_xazurequickvm[:dsc_windows] = 'true'
+    expect(dsc_xazurequickvm[:dsc_windows]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_windows" do
+    dsc_xazurequickvm[:dsc_windows] = 'false'
+    expect(dsc_xazurequickvm[:dsc_windows]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_windows" do
+    dsc_xazurequickvm[:dsc_windows] = 'True'
+    expect(dsc_xazurequickvm[:dsc_windows]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_windows" do
+    dsc_xazurequickvm[:dsc_windows] = 'False'
+    expect(dsc_xazurequickvm[:dsc_windows]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_windows" do
+    dsc_xazurequickvm[:dsc_windows] = :true
+    expect(dsc_xazurequickvm[:dsc_windows]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_windows" do
+    dsc_xazurequickvm[:dsc_windows] = :false
+    expect(dsc_xazurequickvm[:dsc_windows]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_windows' do
+    expect{dsc_xazurequickvm[:dsc_windows] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_windows' do
+    expect{dsc_xazurequickvm[:dsc_windows] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_adminusername' do
+    expect{dsc_xazurequickvm[:dsc_adminusername] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_adminusername' do
+    expect{dsc_xazurequickvm[:dsc_adminusername] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_adminusername' do
+    expect{dsc_xazurequickvm[:dsc_adminusername] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_adminusername' do
+    expect{dsc_xazurequickvm[:dsc_adminusername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_password' do
+    expect{dsc_xazurequickvm[:dsc_password] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_password' do
+    expect{dsc_xazurequickvm[:dsc_password] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_password' do
+    expect{dsc_xazurequickvm[:dsc_password] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_password' do
+    expect{dsc_xazurequickvm[:dsc_password] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_instancesize' do
+    expect{dsc_xazurequickvm[:dsc_instancesize] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_instancesize' do
+    expect{dsc_xazurequickvm[:dsc_instancesize] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_instancesize' do
+    expect{dsc_xazurequickvm[:dsc_instancesize] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_instancesize' do
+    expect{dsc_xazurequickvm[:dsc_instancesize] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazurequickvm)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazurequickvm)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazurequickvm[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazurequickvm[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazurequickvm.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazurequickvm[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazurequickvm)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazurequickvm[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazurequickvm.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazurequickvm[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazurequickvm)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazurequickvm[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazurequickvm)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazurequickvm)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureQuickVM as $MSFT_xAzureQuickVM1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureQuickVM/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazurequickvm[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazurequickvm)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazurequickvm[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazurequickvm[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazurequickvm)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazurequickvm[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazureservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazureservice_spec.rb
@@ -1,0 +1,279 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazureservice) do
+
+  let :dsc_xazureservice do
+    Puppet::Type.type(:dsc_xazureservice).new(
+      :name     => 'foo',
+      :dsc_servicename => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazureservice.to_s).to eq("Dsc_xazureservice[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazureservice[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_servicename is specified' do
+    #dsc_xazureservice[:dsc_servicename]
+    expect { Puppet::Type.type(:dsc_xazureservice).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_description => 'foo',
+      :dsc_affinitygroup => 'foo',
+      :dsc_label => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_servicename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_servicename' do
+    expect{dsc_xazureservice[:dsc_servicename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_servicename' do
+    expect{dsc_xazureservice[:dsc_servicename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_servicename' do
+    expect{dsc_xazureservice[:dsc_servicename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_servicename' do
+    expect{dsc_xazureservice[:dsc_servicename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazureservice[:dsc_ensure] = 'Present'
+    expect(dsc_xazureservice[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazureservice[:dsc_ensure] = 'present'
+    expect(dsc_xazureservice[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazureservice[:dsc_ensure] = 'present'
+    expect(dsc_xazureservice[:ensure]).to eq(dsc_xazureservice[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazureservice[:dsc_ensure] = 'Absent'
+    expect(dsc_xazureservice[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazureservice[:dsc_ensure] = 'absent'
+    expect(dsc_xazureservice[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazureservice[:dsc_ensure] = 'absent'
+    expect(dsc_xazureservice[:ensure]).to eq(dsc_xazureservice[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazureservice[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazureservice[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazureservice[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazureservice[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazureservice[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_xazureservice[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_xazureservice[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_xazureservice[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_xazureservice[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_affinitygroup' do
+    expect{dsc_xazureservice[:dsc_affinitygroup] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_affinitygroup' do
+    expect{dsc_xazureservice[:dsc_affinitygroup] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_affinitygroup' do
+    expect{dsc_xazureservice[:dsc_affinitygroup] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_affinitygroup' do
+    expect{dsc_xazureservice[:dsc_affinitygroup] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_label' do
+    expect{dsc_xazureservice[:dsc_label] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_label' do
+    expect{dsc_xazureservice[:dsc_label] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_label' do
+    expect{dsc_xazureservice[:dsc_label] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_label' do
+    expect{dsc_xazureservice[:dsc_label] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazureservice)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazureservice)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazureservice[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazureservice[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazureservice.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazureservice[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazureservice)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazureservice[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazureservice.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazureservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazureservice)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazureservice[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazureservice)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazureservice)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureService as $MSFT_xAzureService1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureService/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazureservice[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazureservice)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazureservice[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazureservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazureservice)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazureservice[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazuresqldatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazuresqldatabase_spec.rb
@@ -1,0 +1,366 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazuresqldatabase) do
+
+  let :dsc_xazuresqldatabase do
+    Puppet::Type.type(:dsc_xazuresqldatabase).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazuresqldatabase.to_s).to eq("Dsc_xazuresqldatabase[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazuresqldatabase[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xazuresqldatabase[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xazuresqldatabase).new(
+      :name     => 'foo',
+      :dsc_maximumsizeingb => 32,
+      :dsc_collation => 'foo',
+      :dsc_edition => 'foo',
+      :dsc_servercredential => 'foo',
+      :dsc_servername => 'foo',
+      :dsc_azuresubscriptionname => 'foo',
+      :dsc_azurepublishsettingsfile => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xazuresqldatabase[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xazuresqldatabase[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xazuresqldatabase[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xazuresqldatabase[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_maximumsizeingb' do
+    expect{dsc_xazuresqldatabase[:dsc_maximumsizeingb] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_maximumsizeingb' do
+    expect{dsc_xazuresqldatabase[:dsc_maximumsizeingb] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_maximumsizeingb' do
+    expect{dsc_xazuresqldatabase[:dsc_maximumsizeingb] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_maximumsizeingb' do
+    dsc_xazuresqldatabase[:dsc_maximumsizeingb] = 32
+    expect(dsc_xazuresqldatabase[:dsc_maximumsizeingb]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeingb' do
+    dsc_xazuresqldatabase[:dsc_maximumsizeingb] = '16'
+    expect(dsc_xazuresqldatabase[:dsc_maximumsizeingb]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeingb' do
+    dsc_xazuresqldatabase[:dsc_maximumsizeingb] = '32'
+    expect(dsc_xazuresqldatabase[:dsc_maximumsizeingb]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeingb' do
+    dsc_xazuresqldatabase[:dsc_maximumsizeingb] = '64'
+    expect(dsc_xazuresqldatabase[:dsc_maximumsizeingb]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_collation' do
+    expect{dsc_xazuresqldatabase[:dsc_collation] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_collation' do
+    expect{dsc_xazuresqldatabase[:dsc_collation] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_collation' do
+    expect{dsc_xazuresqldatabase[:dsc_collation] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_collation' do
+    expect{dsc_xazuresqldatabase[:dsc_collation] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_edition' do
+    expect{dsc_xazuresqldatabase[:dsc_edition] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_edition' do
+    expect{dsc_xazuresqldatabase[:dsc_edition] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_edition' do
+    expect{dsc_xazuresqldatabase[:dsc_edition] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_edition' do
+    expect{dsc_xazuresqldatabase[:dsc_edition] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_servercredential' do
+    expect{dsc_xazuresqldatabase[:dsc_servercredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_servercredential' do
+    expect{dsc_xazuresqldatabase[:dsc_servercredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_servercredential' do
+    expect{dsc_xazuresqldatabase[:dsc_servercredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_servercredential' do
+    expect{dsc_xazuresqldatabase[:dsc_servercredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_servername' do
+    expect{dsc_xazuresqldatabase[:dsc_servername] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_servername' do
+    expect{dsc_xazuresqldatabase[:dsc_servername] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_servername' do
+    expect{dsc_xazuresqldatabase[:dsc_servername] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_servername' do
+    expect{dsc_xazuresqldatabase[:dsc_servername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresqldatabase[:dsc_azuresubscriptionname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresqldatabase[:dsc_azuresubscriptionname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresqldatabase[:dsc_azuresubscriptionname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresqldatabase[:dsc_azuresubscriptionname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresqldatabase[:dsc_azurepublishsettingsfile] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresqldatabase[:dsc_azurepublishsettingsfile] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresqldatabase[:dsc_azurepublishsettingsfile] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresqldatabase[:dsc_azurepublishsettingsfile] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazuresqldatabase[:dsc_ensure] = 'Present'
+    expect(dsc_xazuresqldatabase[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazuresqldatabase[:dsc_ensure] = 'present'
+    expect(dsc_xazuresqldatabase[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazuresqldatabase[:dsc_ensure] = 'present'
+    expect(dsc_xazuresqldatabase[:ensure]).to eq(dsc_xazuresqldatabase[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazuresqldatabase[:dsc_ensure] = 'Absent'
+    expect(dsc_xazuresqldatabase[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazuresqldatabase[:dsc_ensure] = 'absent'
+    expect(dsc_xazuresqldatabase[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazuresqldatabase[:dsc_ensure] = 'absent'
+    expect(dsc_xazuresqldatabase[:ensure]).to eq(dsc_xazuresqldatabase[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazuresqldatabase[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazuresqldatabase[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazuresqldatabase[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazuresqldatabase[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazuresqldatabase[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazuresqldatabase)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazuresqldatabase)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazuresqldatabase[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazuresqldatabase[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazuresqldatabase.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazuresqldatabase[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresqldatabase)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazuresqldatabase[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazuresqldatabase.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazuresqldatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresqldatabase)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazuresqldatabase[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazuresqldatabase)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazuresqldatabase)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureSqlDatabase as $MSFT_xAzureSqlDatabase1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureSqlDatabase/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazuresqldatabase[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazuresqldatabase)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazuresqldatabase[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazuresqldatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazuresqldatabase)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazuresqldatabase[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazuresqldatabaseserverfirewallrule_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazuresqldatabaseserverfirewallrule_spec.rb
@@ -1,0 +1,327 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazuresqldatabaseserverfirewallrule) do
+
+  let :dsc_xazuresqldatabaseserverfirewallrule do
+    Puppet::Type.type(:dsc_xazuresqldatabaseserverfirewallrule).new(
+      :name     => 'foo',
+      :dsc_rulename => 'foo',
+      :dsc_servername => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazuresqldatabaseserverfirewallrule.to_s).to eq("Dsc_xazuresqldatabaseserverfirewallrule[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazuresqldatabaseserverfirewallrule[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_rulename is specified' do
+    #dsc_xazuresqldatabaseserverfirewallrule[:dsc_rulename]
+    expect { Puppet::Type.type(:dsc_xazuresqldatabaseserverfirewallrule).new(
+      :name     => 'foo',
+      :dsc_servername => 'foo',
+      :dsc_startipaddress => 'foo',
+      :dsc_endipaddress => 'foo',
+      :dsc_azuresubscriptionname => 'foo',
+      :dsc_azurepublishsettingsfile => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_rulename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_rulename' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_rulename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_rulename' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_rulename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_rulename' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_rulename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_rulename' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_rulename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_servername is specified' do
+    #dsc_xazuresqldatabaseserverfirewallrule[:dsc_servername]
+    expect { Puppet::Type.type(:dsc_xazuresqldatabaseserverfirewallrule).new(
+      :name     => 'foo',
+      :dsc_rulename => 'foo',
+      :dsc_startipaddress => 'foo',
+      :dsc_endipaddress => 'foo',
+      :dsc_azuresubscriptionname => 'foo',
+      :dsc_azurepublishsettingsfile => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_servername is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_servername' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_servername] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_servername' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_servername] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_servername' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_servername] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_servername' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_servername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_startipaddress' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_startipaddress] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_startipaddress' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_startipaddress] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_startipaddress' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_startipaddress] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_startipaddress' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_startipaddress] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_endipaddress' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_endipaddress] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_endipaddress' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_endipaddress] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_endipaddress' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_endipaddress] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_endipaddress' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_endipaddress] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_azuresubscriptionname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_azuresubscriptionname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_azuresubscriptionname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_azuresubscriptionname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_azurepublishsettingsfile] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_azurepublishsettingsfile] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_azurepublishsettingsfile] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_azurepublishsettingsfile] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'Present'
+    expect(dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'present'
+    expect(dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'present'
+    expect(dsc_xazuresqldatabaseserverfirewallrule[:ensure]).to eq(dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'Absent'
+    expect(dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'absent'
+    expect(dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'absent'
+    expect(dsc_xazuresqldatabaseserverfirewallrule[:ensure]).to eq(dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazuresqldatabaseserverfirewallrule)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazuresqldatabaseserverfirewallrule)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazuresqldatabaseserverfirewallrule[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazuresqldatabaseserverfirewallrule[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazuresqldatabaseserverfirewallrule.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresqldatabaseserverfirewallrule)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazuresqldatabaseserverfirewallrule[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazuresqldatabaseserverfirewallrule.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresqldatabaseserverfirewallrule)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazuresqldatabaseserverfirewallrule[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazuresqldatabaseserverfirewallrule)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazuresqldatabaseserverfirewallrule)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureSqlDatabaseServerFirewallRule as $MSFT_xAzureSqlDatabaseServerFirewallRule1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureSqlDatabaseServerFirewallRule/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazuresqldatabaseserverfirewallrule)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazuresqldatabaseserverfirewallrule[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazuresqldatabaseserverfirewallrule)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazuresqldatabaseserverfirewallrule[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazurestorageaccount_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurestorageaccount_spec.rb
@@ -1,0 +1,296 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazurestorageaccount) do
+
+  let :dsc_xazurestorageaccount do
+    Puppet::Type.type(:dsc_xazurestorageaccount).new(
+      :name     => 'foo',
+      :dsc_storageaccountname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazurestorageaccount.to_s).to eq("Dsc_xazurestorageaccount[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazurestorageaccount[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_storageaccountname is specified' do
+    #dsc_xazurestorageaccount[:dsc_storageaccountname]
+    expect { Puppet::Type.type(:dsc_xazurestorageaccount).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_affinitygroup => 'foo',
+      :dsc_container => 'foo',
+      :dsc_folder => 'foo',
+      :dsc_label => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_storageaccountname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_storageaccountname' do
+    expect{dsc_xazurestorageaccount[:dsc_storageaccountname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_storageaccountname' do
+    expect{dsc_xazurestorageaccount[:dsc_storageaccountname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_storageaccountname' do
+    expect{dsc_xazurestorageaccount[:dsc_storageaccountname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_storageaccountname' do
+    expect{dsc_xazurestorageaccount[:dsc_storageaccountname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazurestorageaccount[:dsc_ensure] = 'Present'
+    expect(dsc_xazurestorageaccount[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazurestorageaccount[:dsc_ensure] = 'present'
+    expect(dsc_xazurestorageaccount[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazurestorageaccount[:dsc_ensure] = 'present'
+    expect(dsc_xazurestorageaccount[:ensure]).to eq(dsc_xazurestorageaccount[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazurestorageaccount[:dsc_ensure] = 'Absent'
+    expect(dsc_xazurestorageaccount[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazurestorageaccount[:dsc_ensure] = 'absent'
+    expect(dsc_xazurestorageaccount[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazurestorageaccount[:dsc_ensure] = 'absent'
+    expect(dsc_xazurestorageaccount[:ensure]).to eq(dsc_xazurestorageaccount[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazurestorageaccount[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazurestorageaccount[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazurestorageaccount[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazurestorageaccount[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazurestorageaccount[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_affinitygroup' do
+    expect{dsc_xazurestorageaccount[:dsc_affinitygroup] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_affinitygroup' do
+    expect{dsc_xazurestorageaccount[:dsc_affinitygroup] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_affinitygroup' do
+    expect{dsc_xazurestorageaccount[:dsc_affinitygroup] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_affinitygroup' do
+    expect{dsc_xazurestorageaccount[:dsc_affinitygroup] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_container' do
+    expect{dsc_xazurestorageaccount[:dsc_container] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_container' do
+    expect{dsc_xazurestorageaccount[:dsc_container] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_container' do
+    expect{dsc_xazurestorageaccount[:dsc_container] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_container' do
+    expect{dsc_xazurestorageaccount[:dsc_container] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_folder' do
+    expect{dsc_xazurestorageaccount[:dsc_folder] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_folder' do
+    expect{dsc_xazurestorageaccount[:dsc_folder] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_folder' do
+    expect{dsc_xazurestorageaccount[:dsc_folder] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_folder' do
+    expect{dsc_xazurestorageaccount[:dsc_folder] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_label' do
+    expect{dsc_xazurestorageaccount[:dsc_label] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_label' do
+    expect{dsc_xazurestorageaccount[:dsc_label] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_label' do
+    expect{dsc_xazurestorageaccount[:dsc_label] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_label' do
+    expect{dsc_xazurestorageaccount[:dsc_label] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazurestorageaccount)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazurestorageaccount)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazurestorageaccount[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazurestorageaccount[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazurestorageaccount.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazurestorageaccount[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazurestorageaccount)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazurestorageaccount[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazurestorageaccount.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazurestorageaccount[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazurestorageaccount)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazurestorageaccount[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazurestorageaccount)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazurestorageaccount)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureStorageAccount as $MSFT_xAzureStorageAccount1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureStorageAccount/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazurestorageaccount[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazurestorageaccount)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazurestorageaccount[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazurestorageaccount[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazurestorageaccount)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazurestorageaccount[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazuresubscription_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazuresubscription_spec.rb
@@ -1,0 +1,245 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazuresubscription) do
+
+  let :dsc_xazuresubscription do
+    Puppet::Type.type(:dsc_xazuresubscription).new(
+      :name     => 'foo',
+      :dsc_azuresubscriptionname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazuresubscription.to_s).to eq("Dsc_xazuresubscription[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazuresubscription[:ensure]).to eq :present
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazuresubscription[:dsc_ensure] = 'Present'
+    expect(dsc_xazuresubscription[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazuresubscription[:dsc_ensure] = 'present'
+    expect(dsc_xazuresubscription[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazuresubscription[:dsc_ensure] = 'present'
+    expect(dsc_xazuresubscription[:ensure]).to eq(dsc_xazuresubscription[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazuresubscription[:dsc_ensure] = 'Absent'
+    expect(dsc_xazuresubscription[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazuresubscription[:dsc_ensure] = 'absent'
+    expect(dsc_xazuresubscription[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazuresubscription[:dsc_ensure] = 'absent'
+    expect(dsc_xazuresubscription[:ensure]).to eq(dsc_xazuresubscription[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazuresubscription[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazuresubscription[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazuresubscription[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazuresubscription[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazuresubscription[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_azuresubscriptionname is specified' do
+    #dsc_xazuresubscription[:dsc_azuresubscriptionname]
+    expect { Puppet::Type.type(:dsc_xazuresubscription).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_azurepublishsettingsfile => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_azuresubscriptionname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresubscription[:dsc_azuresubscriptionname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresubscription[:dsc_azuresubscriptionname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresubscription[:dsc_azuresubscriptionname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_azuresubscriptionname' do
+    expect{dsc_xazuresubscription[:dsc_azuresubscriptionname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresubscription[:dsc_azurepublishsettingsfile] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresubscription[:dsc_azurepublishsettingsfile] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresubscription[:dsc_azurepublishsettingsfile] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_azurepublishsettingsfile' do
+    expect{dsc_xazuresubscription[:dsc_azurepublishsettingsfile] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazuresubscription)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazuresubscription)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazuresubscription[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazuresubscription[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazuresubscription.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazuresubscription[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresubscription)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazuresubscription[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazuresubscription.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazuresubscription[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresubscription)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazuresubscription[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazuresubscription)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazuresubscription)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureSubscription as $MSFT_xAzureSubscription1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureSubscription/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazuresubscription[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazuresubscription)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazuresubscription[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazuresubscription[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazuresubscription)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazuresubscription[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazurevm_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurevm_spec.rb
@@ -1,0 +1,460 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazurevm) do
+
+  let :dsc_xazurevm do
+    Puppet::Type.type(:dsc_xazurevm).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazurevm.to_s).to eq("Dsc_xazurevm[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazurevm[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xazurevm[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xazurevm).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_imagename => 'foo',
+      :dsc_servicename => 'foo',
+      :dsc_storageaccountname => 'foo',
+      :dsc_instancesize => 'foo',
+      :dsc_linux => true,
+      :dsc_windows => true,
+      :dsc_credential => 'foo',
+      :dsc_extensioncontainername => 'foo',
+      :dsc_extensionfilelist => 'foo',
+      :dsc_extensionscriptname => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xazurevm[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xazurevm[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xazurevm[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xazurevm[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazurevm[:dsc_ensure] = 'Present'
+    expect(dsc_xazurevm[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazurevm[:dsc_ensure] = 'present'
+    expect(dsc_xazurevm[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazurevm[:dsc_ensure] = 'present'
+    expect(dsc_xazurevm[:ensure]).to eq(dsc_xazurevm[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazurevm[:dsc_ensure] = 'Absent'
+    expect(dsc_xazurevm[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazurevm[:dsc_ensure] = 'absent'
+    expect(dsc_xazurevm[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazurevm[:dsc_ensure] = 'absent'
+    expect(dsc_xazurevm[:ensure]).to eq(dsc_xazurevm[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazurevm[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazurevm[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazurevm[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazurevm[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazurevm[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_imagename' do
+    expect{dsc_xazurevm[:dsc_imagename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_imagename' do
+    expect{dsc_xazurevm[:dsc_imagename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_imagename' do
+    expect{dsc_xazurevm[:dsc_imagename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_imagename' do
+    expect{dsc_xazurevm[:dsc_imagename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_servicename' do
+    expect{dsc_xazurevm[:dsc_servicename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_servicename' do
+    expect{dsc_xazurevm[:dsc_servicename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_servicename' do
+    expect{dsc_xazurevm[:dsc_servicename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_servicename' do
+    expect{dsc_xazurevm[:dsc_servicename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_storageaccountname' do
+    expect{dsc_xazurevm[:dsc_storageaccountname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_storageaccountname' do
+    expect{dsc_xazurevm[:dsc_storageaccountname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_storageaccountname' do
+    expect{dsc_xazurevm[:dsc_storageaccountname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_storageaccountname' do
+    expect{dsc_xazurevm[:dsc_storageaccountname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_instancesize' do
+    expect{dsc_xazurevm[:dsc_instancesize] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_instancesize' do
+    expect{dsc_xazurevm[:dsc_instancesize] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_instancesize' do
+    expect{dsc_xazurevm[:dsc_instancesize] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_instancesize' do
+    expect{dsc_xazurevm[:dsc_instancesize] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_linux' do
+    expect{dsc_xazurevm[:dsc_linux] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_linux' do
+    dsc_xazurevm[:dsc_linux] = true
+    expect(dsc_xazurevm[:dsc_linux]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_linux" do
+    dsc_xazurevm[:dsc_linux] = 'true'
+    expect(dsc_xazurevm[:dsc_linux]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_linux" do
+    dsc_xazurevm[:dsc_linux] = 'false'
+    expect(dsc_xazurevm[:dsc_linux]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_linux" do
+    dsc_xazurevm[:dsc_linux] = 'True'
+    expect(dsc_xazurevm[:dsc_linux]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_linux" do
+    dsc_xazurevm[:dsc_linux] = 'False'
+    expect(dsc_xazurevm[:dsc_linux]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_linux" do
+    dsc_xazurevm[:dsc_linux] = :true
+    expect(dsc_xazurevm[:dsc_linux]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_linux" do
+    dsc_xazurevm[:dsc_linux] = :false
+    expect(dsc_xazurevm[:dsc_linux]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_linux' do
+    expect{dsc_xazurevm[:dsc_linux] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_linux' do
+    expect{dsc_xazurevm[:dsc_linux] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_windows' do
+    expect{dsc_xazurevm[:dsc_windows] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_windows' do
+    dsc_xazurevm[:dsc_windows] = true
+    expect(dsc_xazurevm[:dsc_windows]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_windows" do
+    dsc_xazurevm[:dsc_windows] = 'true'
+    expect(dsc_xazurevm[:dsc_windows]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_windows" do
+    dsc_xazurevm[:dsc_windows] = 'false'
+    expect(dsc_xazurevm[:dsc_windows]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_windows" do
+    dsc_xazurevm[:dsc_windows] = 'True'
+    expect(dsc_xazurevm[:dsc_windows]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_windows" do
+    dsc_xazurevm[:dsc_windows] = 'False'
+    expect(dsc_xazurevm[:dsc_windows]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_windows" do
+    dsc_xazurevm[:dsc_windows] = :true
+    expect(dsc_xazurevm[:dsc_windows]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_windows" do
+    dsc_xazurevm[:dsc_windows] = :false
+    expect(dsc_xazurevm[:dsc_windows]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_windows' do
+    expect{dsc_xazurevm[:dsc_windows] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_windows' do
+    expect{dsc_xazurevm[:dsc_windows] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_xazurevm[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_xazurevm[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_xazurevm[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_xazurevm[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_extensioncontainername' do
+    expect{dsc_xazurevm[:dsc_extensioncontainername] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_extensioncontainername' do
+    expect{dsc_xazurevm[:dsc_extensioncontainername] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_extensioncontainername' do
+    expect{dsc_xazurevm[:dsc_extensioncontainername] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_extensioncontainername' do
+    expect{dsc_xazurevm[:dsc_extensioncontainername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_extensionfilelist' do
+    expect{dsc_xazurevm[:dsc_extensionfilelist] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_extensionfilelist' do
+    expect{dsc_xazurevm[:dsc_extensionfilelist] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_extensionfilelist' do
+    expect{dsc_xazurevm[:dsc_extensionfilelist] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_extensionfilelist' do
+    expect{dsc_xazurevm[:dsc_extensionfilelist] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_extensionscriptname' do
+    expect{dsc_xazurevm[:dsc_extensionscriptname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_extensionscriptname' do
+    expect{dsc_xazurevm[:dsc_extensionscriptname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_extensionscriptname' do
+    expect{dsc_xazurevm[:dsc_extensionscriptname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_extensionscriptname' do
+    expect{dsc_xazurevm[:dsc_extensionscriptname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazurevm)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazurevm)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazurevm[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazurevm[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazurevm.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazurevm[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazurevm)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazurevm[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazurevm.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazurevm[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazurevm)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazurevm[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazurevm)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazurevm)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureVM as $MSFT_xAzureVM1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureVM/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazurevm[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazurevm)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazurevm[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazurevm[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazurevm)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazurevm[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xazurevmdscconfiguration_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurevmdscconfiguration_spec.rb
@@ -1,0 +1,313 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xazurevmdscconfiguration) do
+
+  let :dsc_xazurevmdscconfiguration do
+    Puppet::Type.type(:dsc_xazurevmdscconfiguration).new(
+      :name     => 'foo',
+      :dsc_storageaccountname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xazurevmdscconfiguration.to_s).to eq("Dsc_xazurevmdscconfiguration[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xazurevmdscconfiguration[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_storageaccountname is specified' do
+    #dsc_xazurevmdscconfiguration[:dsc_storageaccountname]
+    expect { Puppet::Type.type(:dsc_xazurevmdscconfiguration).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_containername => 'foo',
+      :dsc_configurationpath => 'foo',
+      :dsc_azuresubscriptionname => 'foo',
+      :dsc_azurepublishsettingspath => 'foo',
+      :dsc_bloburi => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_storageaccountname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_storageaccountname' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_storageaccountname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_storageaccountname' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_storageaccountname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_storageaccountname' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_storageaccountname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_storageaccountname' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_storageaccountname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xazurevmdscconfiguration[:dsc_ensure] = 'Present'
+    expect(dsc_xazurevmdscconfiguration[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xazurevmdscconfiguration[:dsc_ensure] = 'present'
+    expect(dsc_xazurevmdscconfiguration[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazurevmdscconfiguration[:dsc_ensure] = 'present'
+    expect(dsc_xazurevmdscconfiguration[:ensure]).to eq(dsc_xazurevmdscconfiguration[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xazurevmdscconfiguration[:dsc_ensure] = 'Absent'
+    expect(dsc_xazurevmdscconfiguration[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xazurevmdscconfiguration[:dsc_ensure] = 'absent'
+    expect(dsc_xazurevmdscconfiguration[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xazurevmdscconfiguration[:dsc_ensure] = 'absent'
+    expect(dsc_xazurevmdscconfiguration[:ensure]).to eq(dsc_xazurevmdscconfiguration[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_containername' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_containername] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_containername' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_containername] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_containername' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_containername] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_containername' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_containername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_configurationpath' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_configurationpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_configurationpath' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_configurationpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_configurationpath' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_configurationpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_configurationpath' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_configurationpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_azuresubscriptionname' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_azuresubscriptionname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_azuresubscriptionname' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_azuresubscriptionname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_azuresubscriptionname' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_azuresubscriptionname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_azuresubscriptionname' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_azuresubscriptionname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_azurepublishsettingspath' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_azurepublishsettingspath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_azurepublishsettingspath' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_azurepublishsettingspath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_azurepublishsettingspath' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_azurepublishsettingspath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_azurepublishsettingspath' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_azurepublishsettingspath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_bloburi' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_bloburi] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_bloburi' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_bloburi] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_bloburi' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_bloburi] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_bloburi' do
+    expect{dsc_xazurevmdscconfiguration[:dsc_bloburi] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xazurevmdscconfiguration)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xazurevmdscconfiguration)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xazurevmdscconfiguration[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xazurevmdscconfiguration[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazurevmdscconfiguration.original_parameters[:dsc_ensure] = 'present'
+        dsc_xazurevmdscconfiguration[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xazurevmdscconfiguration)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazurevmdscconfiguration[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazurevmdscconfiguration.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazurevmdscconfiguration[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazurevmdscconfiguration)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazurevmdscconfiguration[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xazurevmdscconfiguration)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xazurevmdscconfiguration)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureVMDscConfiguration as $MSFT_xAzureVMDscConfiguration1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xAzureVMDscConfiguration/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xazurevmdscconfiguration[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xazurevmdscconfiguration)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xazurevmdscconfiguration[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xazurevmdscconfiguration[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xazurevmdscconfiguration)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xazurevmdscconfiguration[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xcluster_spec.rb
+++ b/spec/unit/puppet/type/dsc_xcluster_spec.rb
@@ -1,0 +1,133 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xcluster) do
+
+  let :dsc_xcluster do
+    Puppet::Type.type(:dsc_xcluster).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xcluster.to_s).to eq("Dsc_xcluster[foo]")
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xcluster[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xcluster).new(
+      :name     => 'foo',
+      :dsc_staticipaddress => 'foo',
+      :dsc_domainadministratorcredential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xcluster[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xcluster[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xcluster[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xcluster[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_staticipaddress' do
+    expect{dsc_xcluster[:dsc_staticipaddress] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_staticipaddress' do
+    expect{dsc_xcluster[:dsc_staticipaddress] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_staticipaddress' do
+    expect{dsc_xcluster[:dsc_staticipaddress] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_staticipaddress' do
+    expect{dsc_xcluster[:dsc_staticipaddress] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_domainadministratorcredential' do
+    expect{dsc_xcluster[:dsc_domainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainadministratorcredential' do
+    expect{dsc_xcluster[:dsc_domainadministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainadministratorcredential' do
+    expect{dsc_xcluster[:dsc_domainadministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainadministratorcredential' do
+    expect{dsc_xcluster[:dsc_domainadministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xcluster)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xcluster)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xcluster[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xcluster[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xcluster)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xcluster)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xCluster as $MSFT_xCluster1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xCluster/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xcomputer_spec.rb
+++ b/spec/unit/puppet/type/dsc_xcomputer_spec.rb
@@ -1,0 +1,167 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xcomputer) do
+
+  let :dsc_xcomputer do
+    Puppet::Type.type(:dsc_xcomputer).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xcomputer.to_s).to eq("Dsc_xcomputer[foo]")
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xcomputer[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xcomputer).new(
+      :name     => 'foo',
+      :dsc_domainname => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_unjoincredential => 'foo',
+      :dsc_workgroupname => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xcomputer[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xcomputer[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xcomputer[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xcomputer[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_domainname' do
+    expect{dsc_xcomputer[:dsc_domainname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainname' do
+    expect{dsc_xcomputer[:dsc_domainname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainname' do
+    expect{dsc_xcomputer[:dsc_domainname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainname' do
+    expect{dsc_xcomputer[:dsc_domainname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_xcomputer[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_xcomputer[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_xcomputer[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_xcomputer[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_unjoincredential' do
+    expect{dsc_xcomputer[:dsc_unjoincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_unjoincredential' do
+    expect{dsc_xcomputer[:dsc_unjoincredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_unjoincredential' do
+    expect{dsc_xcomputer[:dsc_unjoincredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_unjoincredential' do
+    expect{dsc_xcomputer[:dsc_unjoincredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_workgroupname' do
+    expect{dsc_xcomputer[:dsc_workgroupname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_workgroupname' do
+    expect{dsc_xcomputer[:dsc_workgroupname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_workgroupname' do
+    expect{dsc_xcomputer[:dsc_workgroupname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_workgroupname' do
+    expect{dsc_xcomputer[:dsc_workgroupname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xcomputer)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xcomputer)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xcomputer[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xcomputer[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xcomputer)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xcomputer)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xComputer as $MSFT_xComputer1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xComputer/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdatabase_spec.rb
@@ -1,0 +1,381 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdatabase) do
+
+  let :dsc_xdatabase do
+    Puppet::Type.type(:dsc_xdatabase).new(
+      :name     => 'foo',
+      :dsc_databasename => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdatabase.to_s).to eq("Dsc_xdatabase[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xdatabase[:ensure]).to eq :present
+  end
+
+  it 'should not accept array for dsc_credentials' do
+    expect{dsc_xdatabase[:dsc_credentials] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credentials' do
+    expect{dsc_xdatabase[:dsc_credentials] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credentials' do
+    expect{dsc_xdatabase[:dsc_credentials] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credentials' do
+    expect{dsc_xdatabase[:dsc_credentials] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xdatabase[:dsc_ensure] = 'Present'
+    expect(dsc_xdatabase[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xdatabase[:dsc_ensure] = 'present'
+    expect(dsc_xdatabase[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdatabase[:dsc_ensure] = 'present'
+    expect(dsc_xdatabase[:ensure]).to eq(dsc_xdatabase[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xdatabase[:dsc_ensure] = 'Absent'
+    expect(dsc_xdatabase[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xdatabase[:dsc_ensure] = 'absent'
+    expect(dsc_xdatabase[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdatabase[:dsc_ensure] = 'absent'
+    expect(dsc_xdatabase[:ensure]).to eq(dsc_xdatabase[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdatabase[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xdatabase[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xdatabase[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xdatabase[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xdatabase[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sqlserver' do
+    expect{dsc_xdatabase[:dsc_sqlserver] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sqlserver' do
+    expect{dsc_xdatabase[:dsc_sqlserver] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sqlserver' do
+    expect{dsc_xdatabase[:dsc_sqlserver] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sqlserver' do
+    expect{dsc_xdatabase[:dsc_sqlserver] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2008-R2' do
+    dsc_xdatabase[:dsc_sqlserverversion] = '2008-R2'
+    expect(dsc_xdatabase[:dsc_sqlserverversion]).to eq('2008-R2')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2008-r2' do
+    dsc_xdatabase[:dsc_sqlserverversion] = '2008-r2'
+    expect(dsc_xdatabase[:dsc_sqlserverversion]).to eq('2008-r2')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2012' do
+    dsc_xdatabase[:dsc_sqlserverversion] = '2012'
+    expect(dsc_xdatabase[:dsc_sqlserverversion]).to eq('2012')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2012' do
+    dsc_xdatabase[:dsc_sqlserverversion] = '2012'
+    expect(dsc_xdatabase[:dsc_sqlserverversion]).to eq('2012')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2014' do
+    dsc_xdatabase[:dsc_sqlserverversion] = '2014'
+    expect(dsc_xdatabase[:dsc_sqlserverversion]).to eq('2014')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2014' do
+    dsc_xdatabase[:dsc_sqlserverversion] = '2014'
+    expect(dsc_xdatabase[:dsc_sqlserverversion]).to eq('2014')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdatabase[:dsc_sqlserverversion] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sqlserverversion' do
+    expect{dsc_xdatabase[:dsc_sqlserverversion] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sqlserverversion' do
+    expect{dsc_xdatabase[:dsc_sqlserverversion] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sqlserverversion' do
+    expect{dsc_xdatabase[:dsc_sqlserverversion] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sqlserverversion' do
+    expect{dsc_xdatabase[:dsc_sqlserverversion] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_bacpacpath' do
+    expect{dsc_xdatabase[:dsc_bacpacpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_bacpacpath' do
+    expect{dsc_xdatabase[:dsc_bacpacpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_bacpacpath' do
+    expect{dsc_xdatabase[:dsc_bacpacpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_bacpacpath' do
+    expect{dsc_xdatabase[:dsc_bacpacpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_databasename is specified' do
+    #dsc_xdatabase[:dsc_databasename]
+    expect { Puppet::Type.type(:dsc_xdatabase).new(
+      :name     => 'foo',
+      :dsc_credentials => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_sqlserver => 'foo',
+      :dsc_sqlserverversion => '2008-R2',
+      :dsc_bacpacpath => 'foo',
+      :dsc_dacpacpath => 'foo',
+      :dsc_dacpacapplicationname => 'foo',
+      :dsc_dacpacapplicationversion => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_databasename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_databasename' do
+    expect{dsc_xdatabase[:dsc_databasename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_databasename' do
+    expect{dsc_xdatabase[:dsc_databasename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_databasename' do
+    expect{dsc_xdatabase[:dsc_databasename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_databasename' do
+    expect{dsc_xdatabase[:dsc_databasename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_dacpacpath' do
+    expect{dsc_xdatabase[:dsc_dacpacpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_dacpacpath' do
+    expect{dsc_xdatabase[:dsc_dacpacpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dacpacpath' do
+    expect{dsc_xdatabase[:dsc_dacpacpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dacpacpath' do
+    expect{dsc_xdatabase[:dsc_dacpacpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_dacpacapplicationname' do
+    expect{dsc_xdatabase[:dsc_dacpacapplicationname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_dacpacapplicationname' do
+    expect{dsc_xdatabase[:dsc_dacpacapplicationname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dacpacapplicationname' do
+    expect{dsc_xdatabase[:dsc_dacpacapplicationname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dacpacapplicationname' do
+    expect{dsc_xdatabase[:dsc_dacpacapplicationname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_dacpacapplicationversion' do
+    expect{dsc_xdatabase[:dsc_dacpacapplicationversion] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_dacpacapplicationversion' do
+    expect{dsc_xdatabase[:dsc_dacpacapplicationversion] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dacpacapplicationversion' do
+    expect{dsc_xdatabase[:dsc_dacpacapplicationversion] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dacpacapplicationversion' do
+    expect{dsc_xdatabase[:dsc_dacpacapplicationversion] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdatabase)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdatabase)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdatabase[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdatabase[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdatabase.original_parameters[:dsc_ensure] = 'present'
+        dsc_xdatabase[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xdatabase)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdatabase[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdatabase.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdatabase)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdatabase[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdatabase)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdatabase)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDatabase as $MSFT_xDatabase1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDatabase/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdatabase[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xdatabase)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdatabase[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xdatabase)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdatabase[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdbpackage_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdbpackage_spec.rb
@@ -1,0 +1,242 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdbpackage) do
+
+  let :dsc_xdbpackage do
+    Puppet::Type.type(:dsc_xdbpackage).new(
+      :name     => 'foo',
+      :dsc_databasename => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdbpackage.to_s).to eq("Dsc_xdbpackage[foo]")
+  end
+
+  it 'should not accept array for dsc_credentials' do
+    expect{dsc_xdbpackage[:dsc_credentials] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credentials' do
+    expect{dsc_xdbpackage[:dsc_credentials] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credentials' do
+    expect{dsc_xdbpackage[:dsc_credentials] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credentials' do
+    expect{dsc_xdbpackage[:dsc_credentials] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_databasename is specified' do
+    #dsc_xdbpackage[:dsc_databasename]
+    expect { Puppet::Type.type(:dsc_xdbpackage).new(
+      :name     => 'foo',
+      :dsc_credentials => 'foo',
+      :dsc_sqlserver => 'foo',
+      :dsc_path => 'foo',
+      :dsc_type => 'DACPAC',
+      :dsc_sqlserverversion => '2008-R2',
+    )}.to raise_error(Puppet::Error, /dsc_databasename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_databasename' do
+    expect{dsc_xdbpackage[:dsc_databasename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_databasename' do
+    expect{dsc_xdbpackage[:dsc_databasename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_databasename' do
+    expect{dsc_xdbpackage[:dsc_databasename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_databasename' do
+    expect{dsc_xdbpackage[:dsc_databasename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sqlserver' do
+    expect{dsc_xdbpackage[:dsc_sqlserver] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sqlserver' do
+    expect{dsc_xdbpackage[:dsc_sqlserver] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sqlserver' do
+    expect{dsc_xdbpackage[:dsc_sqlserver] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sqlserver' do
+    expect{dsc_xdbpackage[:dsc_sqlserver] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_xdbpackage[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xdbpackage[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xdbpackage[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xdbpackage[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_type predefined value DACPAC' do
+    dsc_xdbpackage[:dsc_type] = 'DACPAC'
+    expect(dsc_xdbpackage[:dsc_type]).to eq('DACPAC')
+  end
+
+  it 'should accept dsc_type predefined value dacpac' do
+    dsc_xdbpackage[:dsc_type] = 'dacpac'
+    expect(dsc_xdbpackage[:dsc_type]).to eq('dacpac')
+  end
+
+  it 'should accept dsc_type predefined value BACPAC' do
+    dsc_xdbpackage[:dsc_type] = 'BACPAC'
+    expect(dsc_xdbpackage[:dsc_type]).to eq('BACPAC')
+  end
+
+  it 'should accept dsc_type predefined value bacpac' do
+    dsc_xdbpackage[:dsc_type] = 'bacpac'
+    expect(dsc_xdbpackage[:dsc_type]).to eq('bacpac')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdbpackage[:dsc_type] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_type' do
+    expect{dsc_xdbpackage[:dsc_type] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_type' do
+    expect{dsc_xdbpackage[:dsc_type] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_type' do
+    expect{dsc_xdbpackage[:dsc_type] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_type' do
+    expect{dsc_xdbpackage[:dsc_type] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2008-R2' do
+    dsc_xdbpackage[:dsc_sqlserverversion] = '2008-R2'
+    expect(dsc_xdbpackage[:dsc_sqlserverversion]).to eq('2008-R2')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2008-r2' do
+    dsc_xdbpackage[:dsc_sqlserverversion] = '2008-r2'
+    expect(dsc_xdbpackage[:dsc_sqlserverversion]).to eq('2008-r2')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2012' do
+    dsc_xdbpackage[:dsc_sqlserverversion] = '2012'
+    expect(dsc_xdbpackage[:dsc_sqlserverversion]).to eq('2012')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2012' do
+    dsc_xdbpackage[:dsc_sqlserverversion] = '2012'
+    expect(dsc_xdbpackage[:dsc_sqlserverversion]).to eq('2012')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2014' do
+    dsc_xdbpackage[:dsc_sqlserverversion] = '2014'
+    expect(dsc_xdbpackage[:dsc_sqlserverversion]).to eq('2014')
+  end
+
+  it 'should accept dsc_sqlserverversion predefined value 2014' do
+    dsc_xdbpackage[:dsc_sqlserverversion] = '2014'
+    expect(dsc_xdbpackage[:dsc_sqlserverversion]).to eq('2014')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdbpackage[:dsc_sqlserverversion] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sqlserverversion' do
+    expect{dsc_xdbpackage[:dsc_sqlserverversion] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sqlserverversion' do
+    expect{dsc_xdbpackage[:dsc_sqlserverversion] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sqlserverversion' do
+    expect{dsc_xdbpackage[:dsc_sqlserverversion] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sqlserverversion' do
+    expect{dsc_xdbpackage[:dsc_sqlserverversion] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdbpackage)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdbpackage)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdbpackage[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdbpackage[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdbpackage)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdbpackage)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDBPackage as $MSFT_xDBPackage1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDBPackage/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdhcpserveroption_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdhcpserveroption_spec.rb
@@ -1,0 +1,294 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdhcpserveroption) do
+
+  let :dsc_xdhcpserveroption do
+    Puppet::Type.type(:dsc_xdhcpserveroption).new(
+      :name     => 'foo',
+      :dsc_scopeid => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdhcpserveroption.to_s).to eq("Dsc_xdhcpserveroption[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xdhcpserveroption[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_scopeid is specified' do
+    #dsc_xdhcpserveroption[:dsc_scopeid]
+    expect { Puppet::Type.type(:dsc_xdhcpserveroption).new(
+      :name     => 'foo',
+      :dsc_dnsserveripaddress => ["foo", "bar", "spec"],
+      :dsc_dnsdomain => 'foo',
+      :dsc_addressfamily => 'IPv4',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_scopeid is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_scopeid' do
+    expect{dsc_xdhcpserveroption[:dsc_scopeid] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_scopeid' do
+    expect{dsc_xdhcpserveroption[:dsc_scopeid] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_scopeid' do
+    expect{dsc_xdhcpserveroption[:dsc_scopeid] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_scopeid' do
+    expect{dsc_xdhcpserveroption[:dsc_scopeid] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_dnsserveripaddress' do
+    dsc_xdhcpserveroption[:dsc_dnsserveripaddress] = ["foo", "bar", "spec"]
+    expect(dsc_xdhcpserveroption[:dsc_dnsserveripaddress]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_dnsserveripaddress' do
+    expect{dsc_xdhcpserveroption[:dsc_dnsserveripaddress] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dnsserveripaddress' do
+    expect{dsc_xdhcpserveroption[:dsc_dnsserveripaddress] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dnsserveripaddress' do
+    expect{dsc_xdhcpserveroption[:dsc_dnsserveripaddress] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_dnsdomain' do
+    expect{dsc_xdhcpserveroption[:dsc_dnsdomain] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_dnsdomain' do
+    expect{dsc_xdhcpserveroption[:dsc_dnsdomain] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dnsdomain' do
+    expect{dsc_xdhcpserveroption[:dsc_dnsdomain] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dnsdomain' do
+    expect{dsc_xdhcpserveroption[:dsc_dnsdomain] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_addressfamily predefined value IPv4' do
+    dsc_xdhcpserveroption[:dsc_addressfamily] = 'IPv4'
+    expect(dsc_xdhcpserveroption[:dsc_addressfamily]).to eq('IPv4')
+  end
+
+  it 'should accept dsc_addressfamily predefined value ipv4' do
+    dsc_xdhcpserveroption[:dsc_addressfamily] = 'ipv4'
+    expect(dsc_xdhcpserveroption[:dsc_addressfamily]).to eq('ipv4')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdhcpserveroption[:dsc_addressfamily] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_addressfamily' do
+    expect{dsc_xdhcpserveroption[:dsc_addressfamily] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_addressfamily' do
+    expect{dsc_xdhcpserveroption[:dsc_addressfamily] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_addressfamily' do
+    expect{dsc_xdhcpserveroption[:dsc_addressfamily] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_addressfamily' do
+    expect{dsc_xdhcpserveroption[:dsc_addressfamily] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xdhcpserveroption[:dsc_ensure] = 'Present'
+    expect(dsc_xdhcpserveroption[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xdhcpserveroption[:dsc_ensure] = 'present'
+    expect(dsc_xdhcpserveroption[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdhcpserveroption[:dsc_ensure] = 'present'
+    expect(dsc_xdhcpserveroption[:ensure]).to eq(dsc_xdhcpserveroption[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xdhcpserveroption[:dsc_ensure] = 'Absent'
+    expect(dsc_xdhcpserveroption[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xdhcpserveroption[:dsc_ensure] = 'absent'
+    expect(dsc_xdhcpserveroption[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdhcpserveroption[:dsc_ensure] = 'absent'
+    expect(dsc_xdhcpserveroption[:ensure]).to eq(dsc_xdhcpserveroption[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdhcpserveroption[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xdhcpserveroption[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xdhcpserveroption[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xdhcpserveroption[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xdhcpserveroption[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdhcpserveroption)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdhcpserveroption)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdhcpserveroption[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdhcpserveroption[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdhcpserveroption.original_parameters[:dsc_ensure] = 'present'
+        dsc_xdhcpserveroption[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserveroption)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdhcpserveroption[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdhcpserveroption.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdhcpserveroption[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserveroption)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdhcpserveroption[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdhcpserveroption)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdhcpserveroption)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDhcpServerOption as $MSFT_xDhcpServerOption1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDhcpServerOption/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdhcpserveroption[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xdhcpserveroption)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdhcpserveroption[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdhcpserveroption[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xdhcpserveroption)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdhcpserveroption[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdhcpserverreservation_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdhcpserverreservation_spec.rb
@@ -1,0 +1,323 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdhcpserverreservation) do
+
+  let :dsc_xdhcpserverreservation do
+    Puppet::Type.type(:dsc_xdhcpserverreservation).new(
+      :name     => 'foo',
+      :dsc_scopeid => 'foo',
+      :dsc_ipaddress => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdhcpserverreservation.to_s).to eq("Dsc_xdhcpserverreservation[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xdhcpserverreservation[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_scopeid is specified' do
+    #dsc_xdhcpserverreservation[:dsc_scopeid]
+    expect { Puppet::Type.type(:dsc_xdhcpserverreservation).new(
+      :name     => 'foo',
+      :dsc_ipaddress => 'foo',
+      :dsc_clientmacaddress => 'foo',
+      :dsc_name => 'foo',
+      :dsc_addressfamily => 'IPv4',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_scopeid is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_scopeid' do
+    expect{dsc_xdhcpserverreservation[:dsc_scopeid] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_scopeid' do
+    expect{dsc_xdhcpserverreservation[:dsc_scopeid] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_scopeid' do
+    expect{dsc_xdhcpserverreservation[:dsc_scopeid] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_scopeid' do
+    expect{dsc_xdhcpserverreservation[:dsc_scopeid] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_ipaddress is specified' do
+    #dsc_xdhcpserverreservation[:dsc_ipaddress]
+    expect { Puppet::Type.type(:dsc_xdhcpserverreservation).new(
+      :name     => 'foo',
+      :dsc_scopeid => 'foo',
+      :dsc_clientmacaddress => 'foo',
+      :dsc_name => 'foo',
+      :dsc_addressfamily => 'IPv4',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_ipaddress is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_ipaddress' do
+    expect{dsc_xdhcpserverreservation[:dsc_ipaddress] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ipaddress' do
+    expect{dsc_xdhcpserverreservation[:dsc_ipaddress] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ipaddress' do
+    expect{dsc_xdhcpserverreservation[:dsc_ipaddress] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ipaddress' do
+    expect{dsc_xdhcpserverreservation[:dsc_ipaddress] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_clientmacaddress' do
+    expect{dsc_xdhcpserverreservation[:dsc_clientmacaddress] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_clientmacaddress' do
+    expect{dsc_xdhcpserverreservation[:dsc_clientmacaddress] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_clientmacaddress' do
+    expect{dsc_xdhcpserverreservation[:dsc_clientmacaddress] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_clientmacaddress' do
+    expect{dsc_xdhcpserverreservation[:dsc_clientmacaddress] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xdhcpserverreservation[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xdhcpserverreservation[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xdhcpserverreservation[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xdhcpserverreservation[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_addressfamily predefined value IPv4' do
+    dsc_xdhcpserverreservation[:dsc_addressfamily] = 'IPv4'
+    expect(dsc_xdhcpserverreservation[:dsc_addressfamily]).to eq('IPv4')
+  end
+
+  it 'should accept dsc_addressfamily predefined value ipv4' do
+    dsc_xdhcpserverreservation[:dsc_addressfamily] = 'ipv4'
+    expect(dsc_xdhcpserverreservation[:dsc_addressfamily]).to eq('ipv4')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdhcpserverreservation[:dsc_addressfamily] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_addressfamily' do
+    expect{dsc_xdhcpserverreservation[:dsc_addressfamily] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_addressfamily' do
+    expect{dsc_xdhcpserverreservation[:dsc_addressfamily] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_addressfamily' do
+    expect{dsc_xdhcpserverreservation[:dsc_addressfamily] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_addressfamily' do
+    expect{dsc_xdhcpserverreservation[:dsc_addressfamily] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xdhcpserverreservation[:dsc_ensure] = 'Present'
+    expect(dsc_xdhcpserverreservation[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xdhcpserverreservation[:dsc_ensure] = 'present'
+    expect(dsc_xdhcpserverreservation[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdhcpserverreservation[:dsc_ensure] = 'present'
+    expect(dsc_xdhcpserverreservation[:ensure]).to eq(dsc_xdhcpserverreservation[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xdhcpserverreservation[:dsc_ensure] = 'Absent'
+    expect(dsc_xdhcpserverreservation[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xdhcpserverreservation[:dsc_ensure] = 'absent'
+    expect(dsc_xdhcpserverreservation[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdhcpserverreservation[:dsc_ensure] = 'absent'
+    expect(dsc_xdhcpserverreservation[:ensure]).to eq(dsc_xdhcpserverreservation[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdhcpserverreservation[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xdhcpserverreservation[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xdhcpserverreservation[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xdhcpserverreservation[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xdhcpserverreservation[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdhcpserverreservation)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdhcpserverreservation)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdhcpserverreservation[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdhcpserverreservation[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdhcpserverreservation.original_parameters[:dsc_ensure] = 'present'
+        dsc_xdhcpserverreservation[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserverreservation)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdhcpserverreservation[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdhcpserverreservation.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdhcpserverreservation[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserverreservation)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdhcpserverreservation[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdhcpserverreservation)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdhcpserverreservation)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDhcpServerReservation as $MSFT_xDhcpServerReservation1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDhcpServerReservation/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdhcpserverreservation[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xdhcpserverreservation)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdhcpserverreservation[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdhcpserverreservation[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xdhcpserverreservation)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdhcpserverreservation[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdhcpserverscope_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdhcpserverscope_spec.rb
@@ -1,0 +1,401 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdhcpserverscope) do
+
+  let :dsc_xdhcpserverscope do
+    Puppet::Type.type(:dsc_xdhcpserverscope).new(
+      :name     => 'foo',
+      :dsc_ipstartrange => 'foo',
+      :dsc_ipendrange => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdhcpserverscope.to_s).to eq("Dsc_xdhcpserverscope[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xdhcpserverscope[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_ipstartrange is specified' do
+    #dsc_xdhcpserverscope[:dsc_ipstartrange]
+    expect { Puppet::Type.type(:dsc_xdhcpserverscope).new(
+      :name     => 'foo',
+      :dsc_ipendrange => 'foo',
+      :dsc_name => 'foo',
+      :dsc_subnetmask => 'foo',
+      :dsc_leaseduration => 'foo',
+      :dsc_state => 'Active',
+      :dsc_addressfamily => 'IPv4',
+      :dsc_ensure => 'Present',
+      :dsc_scopeid => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_ipstartrange is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_ipstartrange' do
+    expect{dsc_xdhcpserverscope[:dsc_ipstartrange] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ipstartrange' do
+    expect{dsc_xdhcpserverscope[:dsc_ipstartrange] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ipstartrange' do
+    expect{dsc_xdhcpserverscope[:dsc_ipstartrange] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ipstartrange' do
+    expect{dsc_xdhcpserverscope[:dsc_ipstartrange] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_ipendrange is specified' do
+    #dsc_xdhcpserverscope[:dsc_ipendrange]
+    expect { Puppet::Type.type(:dsc_xdhcpserverscope).new(
+      :name     => 'foo',
+      :dsc_ipstartrange => 'foo',
+      :dsc_name => 'foo',
+      :dsc_subnetmask => 'foo',
+      :dsc_leaseduration => 'foo',
+      :dsc_state => 'Active',
+      :dsc_addressfamily => 'IPv4',
+      :dsc_ensure => 'Present',
+      :dsc_scopeid => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_ipendrange is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_ipendrange' do
+    expect{dsc_xdhcpserverscope[:dsc_ipendrange] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ipendrange' do
+    expect{dsc_xdhcpserverscope[:dsc_ipendrange] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ipendrange' do
+    expect{dsc_xdhcpserverscope[:dsc_ipendrange] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ipendrange' do
+    expect{dsc_xdhcpserverscope[:dsc_ipendrange] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xdhcpserverscope[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xdhcpserverscope[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xdhcpserverscope[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xdhcpserverscope[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_subnetmask' do
+    expect{dsc_xdhcpserverscope[:dsc_subnetmask] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_subnetmask' do
+    expect{dsc_xdhcpserverscope[:dsc_subnetmask] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_subnetmask' do
+    expect{dsc_xdhcpserverscope[:dsc_subnetmask] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_subnetmask' do
+    expect{dsc_xdhcpserverscope[:dsc_subnetmask] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_leaseduration' do
+    expect{dsc_xdhcpserverscope[:dsc_leaseduration] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_leaseduration' do
+    expect{dsc_xdhcpserverscope[:dsc_leaseduration] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_leaseduration' do
+    expect{dsc_xdhcpserverscope[:dsc_leaseduration] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_leaseduration' do
+    expect{dsc_xdhcpserverscope[:dsc_leaseduration] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_state predefined value Active' do
+    dsc_xdhcpserverscope[:dsc_state] = 'Active'
+    expect(dsc_xdhcpserverscope[:dsc_state]).to eq('Active')
+  end
+
+  it 'should accept dsc_state predefined value active' do
+    dsc_xdhcpserverscope[:dsc_state] = 'active'
+    expect(dsc_xdhcpserverscope[:dsc_state]).to eq('active')
+  end
+
+  it 'should accept dsc_state predefined value Inactive' do
+    dsc_xdhcpserverscope[:dsc_state] = 'Inactive'
+    expect(dsc_xdhcpserverscope[:dsc_state]).to eq('Inactive')
+  end
+
+  it 'should accept dsc_state predefined value inactive' do
+    dsc_xdhcpserverscope[:dsc_state] = 'inactive'
+    expect(dsc_xdhcpserverscope[:dsc_state]).to eq('inactive')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdhcpserverscope[:dsc_state] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_state' do
+    expect{dsc_xdhcpserverscope[:dsc_state] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_state' do
+    expect{dsc_xdhcpserverscope[:dsc_state] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_state' do
+    expect{dsc_xdhcpserverscope[:dsc_state] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_state' do
+    expect{dsc_xdhcpserverscope[:dsc_state] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_addressfamily predefined value IPv4' do
+    dsc_xdhcpserverscope[:dsc_addressfamily] = 'IPv4'
+    expect(dsc_xdhcpserverscope[:dsc_addressfamily]).to eq('IPv4')
+  end
+
+  it 'should accept dsc_addressfamily predefined value ipv4' do
+    dsc_xdhcpserverscope[:dsc_addressfamily] = 'ipv4'
+    expect(dsc_xdhcpserverscope[:dsc_addressfamily]).to eq('ipv4')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdhcpserverscope[:dsc_addressfamily] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_addressfamily' do
+    expect{dsc_xdhcpserverscope[:dsc_addressfamily] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_addressfamily' do
+    expect{dsc_xdhcpserverscope[:dsc_addressfamily] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_addressfamily' do
+    expect{dsc_xdhcpserverscope[:dsc_addressfamily] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_addressfamily' do
+    expect{dsc_xdhcpserverscope[:dsc_addressfamily] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xdhcpserverscope[:dsc_ensure] = 'Present'
+    expect(dsc_xdhcpserverscope[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xdhcpserverscope[:dsc_ensure] = 'present'
+    expect(dsc_xdhcpserverscope[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdhcpserverscope[:dsc_ensure] = 'present'
+    expect(dsc_xdhcpserverscope[:ensure]).to eq(dsc_xdhcpserverscope[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xdhcpserverscope[:dsc_ensure] = 'Absent'
+    expect(dsc_xdhcpserverscope[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xdhcpserverscope[:dsc_ensure] = 'absent'
+    expect(dsc_xdhcpserverscope[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdhcpserverscope[:dsc_ensure] = 'absent'
+    expect(dsc_xdhcpserverscope[:ensure]).to eq(dsc_xdhcpserverscope[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdhcpserverscope[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xdhcpserverscope[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xdhcpserverscope[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xdhcpserverscope[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xdhcpserverscope[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_scopeid' do
+    expect{dsc_xdhcpserverscope[:dsc_scopeid] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_scopeid' do
+    expect{dsc_xdhcpserverscope[:dsc_scopeid] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_scopeid' do
+    expect{dsc_xdhcpserverscope[:dsc_scopeid] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_scopeid' do
+    expect{dsc_xdhcpserverscope[:dsc_scopeid] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdhcpserverscope)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdhcpserverscope)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdhcpserverscope[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdhcpserverscope[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdhcpserverscope.original_parameters[:dsc_ensure] = 'present'
+        dsc_xdhcpserverscope[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserverscope)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdhcpserverscope[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdhcpserverscope.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdhcpserverscope[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserverscope)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdhcpserverscope[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdhcpserverscope)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdhcpserverscope)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDhcpServerScope as $MSFT_xDhcpServerScope1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDhcpServerScope/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdhcpserverscope[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xdhcpserverscope)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdhcpserverscope[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdhcpserverscope[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xdhcpserverscope)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdhcpserverscope[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdnsserveraddress_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdnsserveraddress_spec.rb
@@ -1,0 +1,158 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdnsserveraddress) do
+
+  let :dsc_xdnsserveraddress do
+    Puppet::Type.type(:dsc_xdnsserveraddress).new(
+      :name     => 'foo',
+      :dsc_interfacealias => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdnsserveraddress.to_s).to eq("Dsc_xdnsserveraddress[foo]")
+  end
+
+  it 'should accept array for dsc_address' do
+    dsc_xdnsserveraddress[:dsc_address] = ["foo", "bar", "spec"]
+    expect(dsc_xdnsserveraddress[:dsc_address]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_address' do
+    expect{dsc_xdnsserveraddress[:dsc_address] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_address' do
+    expect{dsc_xdnsserveraddress[:dsc_address] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_address' do
+    expect{dsc_xdnsserveraddress[:dsc_address] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_interfacealias is specified' do
+    #dsc_xdnsserveraddress[:dsc_interfacealias]
+    expect { Puppet::Type.type(:dsc_xdnsserveraddress).new(
+      :name     => 'foo',
+      :dsc_address => ["foo", "bar", "spec"],
+      :dsc_addressfamily => 'IPv4',
+    )}.to raise_error(Puppet::Error, /dsc_interfacealias is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_interfacealias' do
+    expect{dsc_xdnsserveraddress[:dsc_interfacealias] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_interfacealias' do
+    expect{dsc_xdnsserveraddress[:dsc_interfacealias] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_interfacealias' do
+    expect{dsc_xdnsserveraddress[:dsc_interfacealias] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_interfacealias' do
+    expect{dsc_xdnsserveraddress[:dsc_interfacealias] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_addressfamily predefined value IPv4' do
+    dsc_xdnsserveraddress[:dsc_addressfamily] = 'IPv4'
+    expect(dsc_xdnsserveraddress[:dsc_addressfamily]).to eq('IPv4')
+  end
+
+  it 'should accept dsc_addressfamily predefined value ipv4' do
+    dsc_xdnsserveraddress[:dsc_addressfamily] = 'ipv4'
+    expect(dsc_xdnsserveraddress[:dsc_addressfamily]).to eq('ipv4')
+  end
+
+  it 'should accept dsc_addressfamily predefined value IPv6' do
+    dsc_xdnsserveraddress[:dsc_addressfamily] = 'IPv6'
+    expect(dsc_xdnsserveraddress[:dsc_addressfamily]).to eq('IPv6')
+  end
+
+  it 'should accept dsc_addressfamily predefined value ipv6' do
+    dsc_xdnsserveraddress[:dsc_addressfamily] = 'ipv6'
+    expect(dsc_xdnsserveraddress[:dsc_addressfamily]).to eq('ipv6')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdnsserveraddress[:dsc_addressfamily] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_addressfamily' do
+    expect{dsc_xdnsserveraddress[:dsc_addressfamily] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_addressfamily' do
+    expect{dsc_xdnsserveraddress[:dsc_addressfamily] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_addressfamily' do
+    expect{dsc_xdnsserveraddress[:dsc_addressfamily] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_addressfamily' do
+    expect{dsc_xdnsserveraddress[:dsc_addressfamily] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdnsserveraddress)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdnsserveraddress)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdnsserveraddress[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdnsserveraddress[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdnsserveraddress)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdnsserveraddress)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDNSServerAddress as $MSFT_xDNSServerAddress1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDNSServerAddress/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdnsserversecondaryzone_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdnsserversecondaryzone_spec.rb
@@ -1,0 +1,263 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdnsserversecondaryzone) do
+
+  let :dsc_xdnsserversecondaryzone do
+    Puppet::Type.type(:dsc_xdnsserversecondaryzone).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdnsserversecondaryzone.to_s).to eq("Dsc_xdnsserversecondaryzone[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xdnsserversecondaryzone[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xdnsserversecondaryzone[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xdnsserversecondaryzone).new(
+      :name     => 'foo',
+      :dsc_masterservers => ["foo", "bar", "spec"],
+      :dsc_ensure => 'Present',
+      :dsc_type => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_masterservers' do
+    dsc_xdnsserversecondaryzone[:dsc_masterservers] = ["foo", "bar", "spec"]
+    expect(dsc_xdnsserversecondaryzone[:dsc_masterservers]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_masterservers' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_masterservers] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_masterservers' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_masterservers] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_masterservers' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_masterservers] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xdnsserversecondaryzone[:dsc_ensure] = 'Present'
+    expect(dsc_xdnsserversecondaryzone[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xdnsserversecondaryzone[:dsc_ensure] = 'present'
+    expect(dsc_xdnsserversecondaryzone[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdnsserversecondaryzone[:dsc_ensure] = 'present'
+    expect(dsc_xdnsserversecondaryzone[:ensure]).to eq(dsc_xdnsserversecondaryzone[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xdnsserversecondaryzone[:dsc_ensure] = 'Absent'
+    expect(dsc_xdnsserversecondaryzone[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xdnsserversecondaryzone[:dsc_ensure] = 'absent'
+    expect(dsc_xdnsserversecondaryzone[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdnsserversecondaryzone[:dsc_ensure] = 'absent'
+    expect(dsc_xdnsserversecondaryzone[:ensure]).to eq(dsc_xdnsserversecondaryzone[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_type' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_type] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_type' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_type] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_type' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_type] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_type' do
+    expect{dsc_xdnsserversecondaryzone[:dsc_type] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdnsserversecondaryzone)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdnsserversecondaryzone)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdnsserversecondaryzone[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdnsserversecondaryzone[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdnsserversecondaryzone.original_parameters[:dsc_ensure] = 'present'
+        dsc_xdnsserversecondaryzone[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xdnsserversecondaryzone)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdnsserversecondaryzone[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdnsserversecondaryzone.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdnsserversecondaryzone[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdnsserversecondaryzone)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdnsserversecondaryzone[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdnsserversecondaryzone)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdnsserversecondaryzone)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDnsServerSecondaryZone as $MSFT_xDnsServerSecondaryZone1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDnsServerSecondaryZone/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdnsserversecondaryzone[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xdnsserversecondaryzone)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdnsserversecondaryzone[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdnsserversecondaryzone[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xdnsserversecondaryzone)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdnsserversecondaryzone[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdnsserverzonetransfer_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdnsserverzonetransfer_spec.rb
@@ -1,0 +1,178 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdnsserverzonetransfer) do
+
+  let :dsc_xdnsserverzonetransfer do
+    Puppet::Type.type(:dsc_xdnsserverzonetransfer).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdnsserverzonetransfer.to_s).to eq("Dsc_xdnsserverzonetransfer[foo]")
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xdnsserverzonetransfer[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xdnsserverzonetransfer).new(
+      :name     => 'foo',
+      :dsc_type => 'None',
+      :dsc_secondaryserver => ["foo", "bar", "spec"],
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_type predefined value None' do
+    dsc_xdnsserverzonetransfer[:dsc_type] = 'None'
+    expect(dsc_xdnsserverzonetransfer[:dsc_type]).to eq('None')
+  end
+
+  it 'should accept dsc_type predefined value none' do
+    dsc_xdnsserverzonetransfer[:dsc_type] = 'none'
+    expect(dsc_xdnsserverzonetransfer[:dsc_type]).to eq('none')
+  end
+
+  it 'should accept dsc_type predefined value Any' do
+    dsc_xdnsserverzonetransfer[:dsc_type] = 'Any'
+    expect(dsc_xdnsserverzonetransfer[:dsc_type]).to eq('Any')
+  end
+
+  it 'should accept dsc_type predefined value any' do
+    dsc_xdnsserverzonetransfer[:dsc_type] = 'any'
+    expect(dsc_xdnsserverzonetransfer[:dsc_type]).to eq('any')
+  end
+
+  it 'should accept dsc_type predefined value Named' do
+    dsc_xdnsserverzonetransfer[:dsc_type] = 'Named'
+    expect(dsc_xdnsserverzonetransfer[:dsc_type]).to eq('Named')
+  end
+
+  it 'should accept dsc_type predefined value named' do
+    dsc_xdnsserverzonetransfer[:dsc_type] = 'named'
+    expect(dsc_xdnsserverzonetransfer[:dsc_type]).to eq('named')
+  end
+
+  it 'should accept dsc_type predefined value Specific' do
+    dsc_xdnsserverzonetransfer[:dsc_type] = 'Specific'
+    expect(dsc_xdnsserverzonetransfer[:dsc_type]).to eq('Specific')
+  end
+
+  it 'should accept dsc_type predefined value specific' do
+    dsc_xdnsserverzonetransfer[:dsc_type] = 'specific'
+    expect(dsc_xdnsserverzonetransfer[:dsc_type]).to eq('specific')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_type] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_type' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_type] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_type' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_type] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_type' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_type] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_type' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_type] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_secondaryserver' do
+    dsc_xdnsserverzonetransfer[:dsc_secondaryserver] = ["foo", "bar", "spec"]
+    expect(dsc_xdnsserverzonetransfer[:dsc_secondaryserver]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_secondaryserver' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_secondaryserver] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_secondaryserver' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_secondaryserver] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_secondaryserver' do
+    expect{dsc_xdnsserverzonetransfer[:dsc_secondaryserver] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdnsserverzonetransfer)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdnsserverzonetransfer)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdnsserverzonetransfer[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdnsserverzonetransfer[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdnsserverzonetransfer)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdnsserverzonetransfer)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDnsServerZoneTransfer as $MSFT_xDnsServerZoneTransfer1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDnsServerZoneTransfer/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xdscwebservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdscwebservice_spec.rb
@@ -1,0 +1,438 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xdscwebservice) do
+
+  let :dsc_xdscwebservice do
+    Puppet::Type.type(:dsc_xdscwebservice).new(
+      :name     => 'foo',
+      :dsc_endpointname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xdscwebservice.to_s).to eq("Dsc_xdscwebservice[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xdscwebservice[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_endpointname is specified' do
+    #dsc_xdscwebservice[:dsc_endpointname]
+    expect { Puppet::Type.type(:dsc_xdscwebservice).new(
+      :name     => 'foo',
+      :dsc_certificatethumbprint => 'foo',
+      :dsc_port => 32,
+      :dsc_physicalpath => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_state => 'Started',
+      :dsc_modulepath => 'foo',
+      :dsc_configurationpath => 'foo',
+      :dsc_iscomplianceserver => true,
+      :dsc_dscserverurl => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_endpointname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_endpointname' do
+    expect{dsc_xdscwebservice[:dsc_endpointname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_endpointname' do
+    expect{dsc_xdscwebservice[:dsc_endpointname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_endpointname' do
+    expect{dsc_xdscwebservice[:dsc_endpointname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_endpointname' do
+    expect{dsc_xdscwebservice[:dsc_endpointname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_certificatethumbprint' do
+    expect{dsc_xdscwebservice[:dsc_certificatethumbprint] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_certificatethumbprint' do
+    expect{dsc_xdscwebservice[:dsc_certificatethumbprint] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_certificatethumbprint' do
+    expect{dsc_xdscwebservice[:dsc_certificatethumbprint] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_certificatethumbprint' do
+    expect{dsc_xdscwebservice[:dsc_certificatethumbprint] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_port' do
+    expect{dsc_xdscwebservice[:dsc_port] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_port' do
+    expect{dsc_xdscwebservice[:dsc_port] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_port' do
+    expect{dsc_xdscwebservice[:dsc_port] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_port' do
+    dsc_xdscwebservice[:dsc_port] = 32
+    expect(dsc_xdscwebservice[:dsc_port]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_port' do
+    dsc_xdscwebservice[:dsc_port] = '16'
+    expect(dsc_xdscwebservice[:dsc_port]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_port' do
+    dsc_xdscwebservice[:dsc_port] = '32'
+    expect(dsc_xdscwebservice[:dsc_port]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_port' do
+    dsc_xdscwebservice[:dsc_port] = '64'
+    expect(dsc_xdscwebservice[:dsc_port]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_physicalpath' do
+    expect{dsc_xdscwebservice[:dsc_physicalpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_physicalpath' do
+    expect{dsc_xdscwebservice[:dsc_physicalpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_physicalpath' do
+    expect{dsc_xdscwebservice[:dsc_physicalpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_physicalpath' do
+    expect{dsc_xdscwebservice[:dsc_physicalpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xdscwebservice[:dsc_ensure] = 'Present'
+    expect(dsc_xdscwebservice[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xdscwebservice[:dsc_ensure] = 'present'
+    expect(dsc_xdscwebservice[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdscwebservice[:dsc_ensure] = 'present'
+    expect(dsc_xdscwebservice[:ensure]).to eq(dsc_xdscwebservice[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xdscwebservice[:dsc_ensure] = 'Absent'
+    expect(dsc_xdscwebservice[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xdscwebservice[:dsc_ensure] = 'absent'
+    expect(dsc_xdscwebservice[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xdscwebservice[:dsc_ensure] = 'absent'
+    expect(dsc_xdscwebservice[:ensure]).to eq(dsc_xdscwebservice[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdscwebservice[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xdscwebservice[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xdscwebservice[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xdscwebservice[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xdscwebservice[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_state predefined value Started' do
+    dsc_xdscwebservice[:dsc_state] = 'Started'
+    expect(dsc_xdscwebservice[:dsc_state]).to eq('Started')
+  end
+
+  it 'should accept dsc_state predefined value started' do
+    dsc_xdscwebservice[:dsc_state] = 'started'
+    expect(dsc_xdscwebservice[:dsc_state]).to eq('started')
+  end
+
+  it 'should accept dsc_state predefined value Stopped' do
+    dsc_xdscwebservice[:dsc_state] = 'Stopped'
+    expect(dsc_xdscwebservice[:dsc_state]).to eq('Stopped')
+  end
+
+  it 'should accept dsc_state predefined value stopped' do
+    dsc_xdscwebservice[:dsc_state] = 'stopped'
+    expect(dsc_xdscwebservice[:dsc_state]).to eq('stopped')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xdscwebservice[:dsc_state] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_state' do
+    expect{dsc_xdscwebservice[:dsc_state] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_state' do
+    expect{dsc_xdscwebservice[:dsc_state] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_state' do
+    expect{dsc_xdscwebservice[:dsc_state] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_state' do
+    expect{dsc_xdscwebservice[:dsc_state] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_modulepath' do
+    expect{dsc_xdscwebservice[:dsc_modulepath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_modulepath' do
+    expect{dsc_xdscwebservice[:dsc_modulepath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_modulepath' do
+    expect{dsc_xdscwebservice[:dsc_modulepath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_modulepath' do
+    expect{dsc_xdscwebservice[:dsc_modulepath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_configurationpath' do
+    expect{dsc_xdscwebservice[:dsc_configurationpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_configurationpath' do
+    expect{dsc_xdscwebservice[:dsc_configurationpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_configurationpath' do
+    expect{dsc_xdscwebservice[:dsc_configurationpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_configurationpath' do
+    expect{dsc_xdscwebservice[:dsc_configurationpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_iscomplianceserver' do
+    expect{dsc_xdscwebservice[:dsc_iscomplianceserver] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_iscomplianceserver' do
+    dsc_xdscwebservice[:dsc_iscomplianceserver] = true
+    expect(dsc_xdscwebservice[:dsc_iscomplianceserver]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_iscomplianceserver" do
+    dsc_xdscwebservice[:dsc_iscomplianceserver] = 'true'
+    expect(dsc_xdscwebservice[:dsc_iscomplianceserver]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_iscomplianceserver" do
+    dsc_xdscwebservice[:dsc_iscomplianceserver] = 'false'
+    expect(dsc_xdscwebservice[:dsc_iscomplianceserver]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_iscomplianceserver" do
+    dsc_xdscwebservice[:dsc_iscomplianceserver] = 'True'
+    expect(dsc_xdscwebservice[:dsc_iscomplianceserver]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_iscomplianceserver" do
+    dsc_xdscwebservice[:dsc_iscomplianceserver] = 'False'
+    expect(dsc_xdscwebservice[:dsc_iscomplianceserver]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_iscomplianceserver" do
+    dsc_xdscwebservice[:dsc_iscomplianceserver] = :true
+    expect(dsc_xdscwebservice[:dsc_iscomplianceserver]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_iscomplianceserver" do
+    dsc_xdscwebservice[:dsc_iscomplianceserver] = :false
+    expect(dsc_xdscwebservice[:dsc_iscomplianceserver]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_iscomplianceserver' do
+    expect{dsc_xdscwebservice[:dsc_iscomplianceserver] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_iscomplianceserver' do
+    expect{dsc_xdscwebservice[:dsc_iscomplianceserver] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_dscserverurl' do
+    expect{dsc_xdscwebservice[:dsc_dscserverurl] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_dscserverurl' do
+    expect{dsc_xdscwebservice[:dsc_dscserverurl] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dscserverurl' do
+    expect{dsc_xdscwebservice[:dsc_dscserverurl] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dscserverurl' do
+    expect{dsc_xdscwebservice[:dsc_dscserverurl] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xdscwebservice)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xdscwebservice)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xdscwebservice[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xdscwebservice[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdscwebservice.original_parameters[:dsc_ensure] = 'present'
+        dsc_xdscwebservice[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xdscwebservice)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdscwebservice[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdscwebservice.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdscwebservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdscwebservice)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdscwebservice[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xdscwebservice)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xdscwebservice)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xDSCWebService as $MSFT_xDSCWebService1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xDSCWebService/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xdscwebservice[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xdscwebservice)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xdscwebservice[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xdscwebservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xdscwebservice)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xdscwebservice[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xfirewall_spec.rb
+++ b/spec/unit/puppet/type/dsc_xfirewall_spec.rb
@@ -1,0 +1,561 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xfirewall) do
+
+  let :dsc_xfirewall do
+    Puppet::Type.type(:dsc_xfirewall).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xfirewall.to_s).to eq("Dsc_xfirewall[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xfirewall[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xfirewall[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xfirewall).new(
+      :name     => 'foo',
+      :dsc_displayname => 'foo',
+      :dsc_displaygroup => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_access => 'NotConfigured',
+      :dsc_state => 'Enabled',
+      :dsc_profile => 'Any',
+      :dsc_direction => 'Inbound',
+      :dsc_remoteport => ["foo", "bar", "spec"],
+      :dsc_localport => ["foo", "bar", "spec"],
+      :dsc_protocol => 'foo',
+      :dsc_description => 'foo',
+      :dsc_applicationpath => 'foo',
+      :dsc_service => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xfirewall[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xfirewall[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xfirewall[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xfirewall[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_displayname' do
+    expect{dsc_xfirewall[:dsc_displayname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_displayname' do
+    expect{dsc_xfirewall[:dsc_displayname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_displayname' do
+    expect{dsc_xfirewall[:dsc_displayname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_displayname' do
+    expect{dsc_xfirewall[:dsc_displayname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_displaygroup' do
+    expect{dsc_xfirewall[:dsc_displaygroup] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_displaygroup' do
+    expect{dsc_xfirewall[:dsc_displaygroup] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_displaygroup' do
+    expect{dsc_xfirewall[:dsc_displaygroup] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_displaygroup' do
+    expect{dsc_xfirewall[:dsc_displaygroup] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xfirewall[:dsc_ensure] = 'Present'
+    expect(dsc_xfirewall[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xfirewall[:dsc_ensure] = 'present'
+    expect(dsc_xfirewall[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xfirewall[:dsc_ensure] = 'present'
+    expect(dsc_xfirewall[:ensure]).to eq(dsc_xfirewall[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xfirewall[:dsc_ensure] = 'Absent'
+    expect(dsc_xfirewall[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xfirewall[:dsc_ensure] = 'absent'
+    expect(dsc_xfirewall[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xfirewall[:dsc_ensure] = 'absent'
+    expect(dsc_xfirewall[:ensure]).to eq(dsc_xfirewall[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xfirewall[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xfirewall[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xfirewall[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xfirewall[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xfirewall[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_access predefined value NotConfigured' do
+    dsc_xfirewall[:dsc_access] = 'NotConfigured'
+    expect(dsc_xfirewall[:dsc_access]).to eq('NotConfigured')
+  end
+
+  it 'should accept dsc_access predefined value notconfigured' do
+    dsc_xfirewall[:dsc_access] = 'notconfigured'
+    expect(dsc_xfirewall[:dsc_access]).to eq('notconfigured')
+  end
+
+  it 'should accept dsc_access predefined value Allow' do
+    dsc_xfirewall[:dsc_access] = 'Allow'
+    expect(dsc_xfirewall[:dsc_access]).to eq('Allow')
+  end
+
+  it 'should accept dsc_access predefined value allow' do
+    dsc_xfirewall[:dsc_access] = 'allow'
+    expect(dsc_xfirewall[:dsc_access]).to eq('allow')
+  end
+
+  it 'should accept dsc_access predefined value Block' do
+    dsc_xfirewall[:dsc_access] = 'Block'
+    expect(dsc_xfirewall[:dsc_access]).to eq('Block')
+  end
+
+  it 'should accept dsc_access predefined value block' do
+    dsc_xfirewall[:dsc_access] = 'block'
+    expect(dsc_xfirewall[:dsc_access]).to eq('block')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xfirewall[:dsc_access] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_access' do
+    expect{dsc_xfirewall[:dsc_access] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_access' do
+    expect{dsc_xfirewall[:dsc_access] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_access' do
+    expect{dsc_xfirewall[:dsc_access] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_access' do
+    expect{dsc_xfirewall[:dsc_access] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_state predefined value Enabled' do
+    dsc_xfirewall[:dsc_state] = 'Enabled'
+    expect(dsc_xfirewall[:dsc_state]).to eq('Enabled')
+  end
+
+  it 'should accept dsc_state predefined value enabled' do
+    dsc_xfirewall[:dsc_state] = 'enabled'
+    expect(dsc_xfirewall[:dsc_state]).to eq('enabled')
+  end
+
+  it 'should accept dsc_state predefined value Disabled' do
+    dsc_xfirewall[:dsc_state] = 'Disabled'
+    expect(dsc_xfirewall[:dsc_state]).to eq('Disabled')
+  end
+
+  it 'should accept dsc_state predefined value disabled' do
+    dsc_xfirewall[:dsc_state] = 'disabled'
+    expect(dsc_xfirewall[:dsc_state]).to eq('disabled')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xfirewall[:dsc_state] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_state' do
+    expect{dsc_xfirewall[:dsc_state] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_state' do
+    expect{dsc_xfirewall[:dsc_state] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_state' do
+    expect{dsc_xfirewall[:dsc_state] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_state' do
+    expect{dsc_xfirewall[:dsc_state] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_profile predefined value Any' do
+    dsc_xfirewall[:dsc_profile] = 'Any'
+    expect(dsc_xfirewall[:dsc_profile]).to eq('Any')
+  end
+
+  it 'should accept dsc_profile predefined value any' do
+    dsc_xfirewall[:dsc_profile] = 'any'
+    expect(dsc_xfirewall[:dsc_profile]).to eq('any')
+  end
+
+  it 'should accept dsc_profile predefined value Public' do
+    dsc_xfirewall[:dsc_profile] = 'Public'
+    expect(dsc_xfirewall[:dsc_profile]).to eq('Public')
+  end
+
+  it 'should accept dsc_profile predefined value public' do
+    dsc_xfirewall[:dsc_profile] = 'public'
+    expect(dsc_xfirewall[:dsc_profile]).to eq('public')
+  end
+
+  it 'should accept dsc_profile predefined value Private' do
+    dsc_xfirewall[:dsc_profile] = 'Private'
+    expect(dsc_xfirewall[:dsc_profile]).to eq('Private')
+  end
+
+  it 'should accept dsc_profile predefined value private' do
+    dsc_xfirewall[:dsc_profile] = 'private'
+    expect(dsc_xfirewall[:dsc_profile]).to eq('private')
+  end
+
+  it 'should accept dsc_profile predefined value Domain' do
+    dsc_xfirewall[:dsc_profile] = 'Domain'
+    expect(dsc_xfirewall[:dsc_profile]).to eq('Domain')
+  end
+
+  it 'should accept dsc_profile predefined value domain' do
+    dsc_xfirewall[:dsc_profile] = 'domain'
+    expect(dsc_xfirewall[:dsc_profile]).to eq('domain')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xfirewall[:dsc_profile] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array of predefined values for dsc_profile' do
+    dsc_xfirewall[:dsc_profile] = ["Any", "Public", "Private", "Domain"]
+    expect(dsc_xfirewall[:dsc_profile]).to eq(["Any", "Public", "Private", "Domain"])
+  end
+
+  it 'should not accept boolean for dsc_profile' do
+    expect{dsc_xfirewall[:dsc_profile] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_profile' do
+    expect{dsc_xfirewall[:dsc_profile] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_profile' do
+    expect{dsc_xfirewall[:dsc_profile] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_direction predefined value Inbound' do
+    dsc_xfirewall[:dsc_direction] = 'Inbound'
+    expect(dsc_xfirewall[:dsc_direction]).to eq('Inbound')
+  end
+
+  it 'should accept dsc_direction predefined value inbound' do
+    dsc_xfirewall[:dsc_direction] = 'inbound'
+    expect(dsc_xfirewall[:dsc_direction]).to eq('inbound')
+  end
+
+  it 'should accept dsc_direction predefined value Outbound' do
+    dsc_xfirewall[:dsc_direction] = 'Outbound'
+    expect(dsc_xfirewall[:dsc_direction]).to eq('Outbound')
+  end
+
+  it 'should accept dsc_direction predefined value outbound' do
+    dsc_xfirewall[:dsc_direction] = 'outbound'
+    expect(dsc_xfirewall[:dsc_direction]).to eq('outbound')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xfirewall[:dsc_direction] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_direction' do
+    expect{dsc_xfirewall[:dsc_direction] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_direction' do
+    expect{dsc_xfirewall[:dsc_direction] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_direction' do
+    expect{dsc_xfirewall[:dsc_direction] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_direction' do
+    expect{dsc_xfirewall[:dsc_direction] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_remoteport' do
+    dsc_xfirewall[:dsc_remoteport] = ["foo", "bar", "spec"]
+    expect(dsc_xfirewall[:dsc_remoteport]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_remoteport' do
+    expect{dsc_xfirewall[:dsc_remoteport] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_remoteport' do
+    expect{dsc_xfirewall[:dsc_remoteport] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_remoteport' do
+    expect{dsc_xfirewall[:dsc_remoteport] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_localport' do
+    dsc_xfirewall[:dsc_localport] = ["foo", "bar", "spec"]
+    expect(dsc_xfirewall[:dsc_localport]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_localport' do
+    expect{dsc_xfirewall[:dsc_localport] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_localport' do
+    expect{dsc_xfirewall[:dsc_localport] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_localport' do
+    expect{dsc_xfirewall[:dsc_localport] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_protocol' do
+    expect{dsc_xfirewall[:dsc_protocol] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_protocol' do
+    expect{dsc_xfirewall[:dsc_protocol] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_protocol' do
+    expect{dsc_xfirewall[:dsc_protocol] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_protocol' do
+    expect{dsc_xfirewall[:dsc_protocol] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_xfirewall[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_xfirewall[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_xfirewall[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_xfirewall[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_applicationpath' do
+    expect{dsc_xfirewall[:dsc_applicationpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_applicationpath' do
+    expect{dsc_xfirewall[:dsc_applicationpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_applicationpath' do
+    expect{dsc_xfirewall[:dsc_applicationpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_applicationpath' do
+    expect{dsc_xfirewall[:dsc_applicationpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_service' do
+    expect{dsc_xfirewall[:dsc_service] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_service' do
+    expect{dsc_xfirewall[:dsc_service] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_service' do
+    expect{dsc_xfirewall[:dsc_service] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_service' do
+    expect{dsc_xfirewall[:dsc_service] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xfirewall)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xfirewall)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xfirewall[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xfirewall[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xfirewall.original_parameters[:dsc_ensure] = 'present'
+        dsc_xfirewall[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xfirewall)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xfirewall[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xfirewall.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xfirewall[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xfirewall)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xfirewall[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xfirewall)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xfirewall)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xFirewall as $MSFT_xFirewall1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xFirewall/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xfirewall[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xfirewall)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xfirewall[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xfirewall[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xfirewall)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xfirewall[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xgroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xgroup_spec.rb
@@ -1,0 +1,316 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xgroup) do
+
+  let :dsc_xgroup do
+    Puppet::Type.type(:dsc_xgroup).new(
+      :name     => 'foo',
+      :dsc_groupname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xgroup.to_s).to eq("Dsc_xgroup[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xgroup[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_groupname is specified' do
+    #dsc_xgroup[:dsc_groupname]
+    expect { Puppet::Type.type(:dsc_xgroup).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_description => 'foo',
+      :dsc_members => ["foo", "bar", "spec"],
+      :dsc_memberstoinclude => ["foo", "bar", "spec"],
+      :dsc_memberstoexclude => ["foo", "bar", "spec"],
+      :dsc_credential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_groupname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_groupname' do
+    expect{dsc_xgroup[:dsc_groupname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_groupname' do
+    expect{dsc_xgroup[:dsc_groupname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_groupname' do
+    expect{dsc_xgroup[:dsc_groupname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_groupname' do
+    expect{dsc_xgroup[:dsc_groupname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xgroup[:dsc_ensure] = 'Present'
+    expect(dsc_xgroup[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xgroup[:dsc_ensure] = 'present'
+    expect(dsc_xgroup[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xgroup[:dsc_ensure] = 'present'
+    expect(dsc_xgroup[:ensure]).to eq(dsc_xgroup[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xgroup[:dsc_ensure] = 'Absent'
+    expect(dsc_xgroup[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xgroup[:dsc_ensure] = 'absent'
+    expect(dsc_xgroup[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xgroup[:dsc_ensure] = 'absent'
+    expect(dsc_xgroup[:ensure]).to eq(dsc_xgroup[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xgroup[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xgroup[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xgroup[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xgroup[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xgroup[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_xgroup[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_xgroup[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_xgroup[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_xgroup[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_members' do
+    dsc_xgroup[:dsc_members] = ["foo", "bar", "spec"]
+    expect(dsc_xgroup[:dsc_members]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_members' do
+    expect{dsc_xgroup[:dsc_members] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_members' do
+    expect{dsc_xgroup[:dsc_members] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_members' do
+    expect{dsc_xgroup[:dsc_members] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_memberstoinclude' do
+    dsc_xgroup[:dsc_memberstoinclude] = ["foo", "bar", "spec"]
+    expect(dsc_xgroup[:dsc_memberstoinclude]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_memberstoinclude' do
+    expect{dsc_xgroup[:dsc_memberstoinclude] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_memberstoinclude' do
+    expect{dsc_xgroup[:dsc_memberstoinclude] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_memberstoinclude' do
+    expect{dsc_xgroup[:dsc_memberstoinclude] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_memberstoexclude' do
+    dsc_xgroup[:dsc_memberstoexclude] = ["foo", "bar", "spec"]
+    expect(dsc_xgroup[:dsc_memberstoexclude]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_memberstoexclude' do
+    expect{dsc_xgroup[:dsc_memberstoexclude] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_memberstoexclude' do
+    expect{dsc_xgroup[:dsc_memberstoexclude] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_memberstoexclude' do
+    expect{dsc_xgroup[:dsc_memberstoexclude] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_xgroup[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_xgroup[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_xgroup[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_xgroup[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xgroup)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xgroup)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xgroup[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xgroup[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xgroup.original_parameters[:dsc_ensure] = 'present'
+        dsc_xgroup[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xgroup)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xgroup[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xgroup.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xgroup[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xgroup)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xgroup[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xgroup)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xgroup)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xGroupResource as $MSFT_xGroupResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xGroupResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xgroup[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xgroup)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xgroup[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xgroup[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xgroup)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xgroup[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xiismodule_spec.rb
+++ b/spec/unit/puppet/type/dsc_xiismodule_spec.rb
@@ -1,0 +1,376 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xiismodule) do
+
+  let :dsc_xiismodule do
+    Puppet::Type.type(:dsc_xiismodule).new(
+      :name     => 'foo',
+      :dsc_path => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xiismodule.to_s).to eq("Dsc_xiismodule[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xiismodule[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_path is specified' do
+    #dsc_xiismodule[:dsc_path]
+    expect { Puppet::Type.type(:dsc_xiismodule).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_requestpath => 'foo',
+      :dsc_verb => ["foo", "bar", "spec"],
+      :dsc_sitename => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_moduletype => 'FastCgiModule',
+      :dsc_endpointsetup => true,
+    )}.to raise_error(Puppet::Error, /dsc_path is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_xiismodule[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xiismodule[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xiismodule[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xiismodule[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xiismodule[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xiismodule[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xiismodule[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xiismodule[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_requestpath' do
+    expect{dsc_xiismodule[:dsc_requestpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_requestpath' do
+    expect{dsc_xiismodule[:dsc_requestpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_requestpath' do
+    expect{dsc_xiismodule[:dsc_requestpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_requestpath' do
+    expect{dsc_xiismodule[:dsc_requestpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_verb' do
+    dsc_xiismodule[:dsc_verb] = ["foo", "bar", "spec"]
+    expect(dsc_xiismodule[:dsc_verb]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_verb' do
+    expect{dsc_xiismodule[:dsc_verb] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_verb' do
+    expect{dsc_xiismodule[:dsc_verb] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_verb' do
+    expect{dsc_xiismodule[:dsc_verb] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sitename' do
+    expect{dsc_xiismodule[:dsc_sitename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sitename' do
+    expect{dsc_xiismodule[:dsc_sitename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sitename' do
+    expect{dsc_xiismodule[:dsc_sitename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sitename' do
+    expect{dsc_xiismodule[:dsc_sitename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xiismodule[:dsc_ensure] = 'Present'
+    expect(dsc_xiismodule[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xiismodule[:dsc_ensure] = 'present'
+    expect(dsc_xiismodule[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xiismodule[:dsc_ensure] = 'present'
+    expect(dsc_xiismodule[:ensure]).to eq(dsc_xiismodule[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xiismodule[:dsc_ensure] = 'Absent'
+    expect(dsc_xiismodule[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xiismodule[:dsc_ensure] = 'absent'
+    expect(dsc_xiismodule[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xiismodule[:dsc_ensure] = 'absent'
+    expect(dsc_xiismodule[:ensure]).to eq(dsc_xiismodule[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xiismodule[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xiismodule[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xiismodule[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xiismodule[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xiismodule[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_moduletype predefined value FastCgiModule' do
+    dsc_xiismodule[:dsc_moduletype] = 'FastCgiModule'
+    expect(dsc_xiismodule[:dsc_moduletype]).to eq('FastCgiModule')
+  end
+
+  it 'should accept dsc_moduletype predefined value fastcgimodule' do
+    dsc_xiismodule[:dsc_moduletype] = 'fastcgimodule'
+    expect(dsc_xiismodule[:dsc_moduletype]).to eq('fastcgimodule')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xiismodule[:dsc_moduletype] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_moduletype' do
+    expect{dsc_xiismodule[:dsc_moduletype] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_moduletype' do
+    expect{dsc_xiismodule[:dsc_moduletype] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_moduletype' do
+    expect{dsc_xiismodule[:dsc_moduletype] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_moduletype' do
+    expect{dsc_xiismodule[:dsc_moduletype] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_endpointsetup' do
+    expect{dsc_xiismodule[:dsc_endpointsetup] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_endpointsetup' do
+    dsc_xiismodule[:dsc_endpointsetup] = true
+    expect(dsc_xiismodule[:dsc_endpointsetup]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_endpointsetup" do
+    dsc_xiismodule[:dsc_endpointsetup] = 'true'
+    expect(dsc_xiismodule[:dsc_endpointsetup]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_endpointsetup" do
+    dsc_xiismodule[:dsc_endpointsetup] = 'false'
+    expect(dsc_xiismodule[:dsc_endpointsetup]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_endpointsetup" do
+    dsc_xiismodule[:dsc_endpointsetup] = 'True'
+    expect(dsc_xiismodule[:dsc_endpointsetup]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_endpointsetup" do
+    dsc_xiismodule[:dsc_endpointsetup] = 'False'
+    expect(dsc_xiismodule[:dsc_endpointsetup]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_endpointsetup" do
+    dsc_xiismodule[:dsc_endpointsetup] = :true
+    expect(dsc_xiismodule[:dsc_endpointsetup]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_endpointsetup" do
+    dsc_xiismodule[:dsc_endpointsetup] = :false
+    expect(dsc_xiismodule[:dsc_endpointsetup]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_endpointsetup' do
+    expect{dsc_xiismodule[:dsc_endpointsetup] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_endpointsetup' do
+    expect{dsc_xiismodule[:dsc_endpointsetup] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xiismodule)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xiismodule)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xiismodule[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xiismodule[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xiismodule.original_parameters[:dsc_ensure] = 'present'
+        dsc_xiismodule[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xiismodule)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xiismodule[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xiismodule.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xiismodule[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xiismodule)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xiismodule[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xiismodule)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xiismodule)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xIisModule as $MSFT_xIisModule1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xIisModule/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xiismodule[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xiismodule)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xiismodule[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xiismodule[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xiismodule)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xiismodule[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xiiswordpresssite_spec.rb
+++ b/spec/unit/puppet/type/dsc_xiiswordpresssite_spec.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xiiswordpresssite) do
+
+  let :dsc_xiiswordpresssite do
+    Puppet::Type.type(:dsc_xiiswordpresssite).new(
+      :name     => 'foo',
+      :dsc_destinationpath => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xiiswordpresssite.to_s).to eq("Dsc_xiiswordpresssite[foo]")
+  end
+
+  it 'should require that dsc_destinationpath is specified' do
+    #dsc_xiiswordpresssite[:dsc_destinationpath]
+    expect { Puppet::Type.type(:dsc_xiiswordpresssite).new(
+      :name     => 'foo',
+      :dsc_downloaduri => 'foo',
+      :dsc_packagefolder => 'foo',
+      :dsc_configuration => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_destinationpath is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_destinationpath' do
+    expect{dsc_xiiswordpresssite[:dsc_destinationpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_destinationpath' do
+    expect{dsc_xiiswordpresssite[:dsc_destinationpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_destinationpath' do
+    expect{dsc_xiiswordpresssite[:dsc_destinationpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_destinationpath' do
+    expect{dsc_xiiswordpresssite[:dsc_destinationpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_downloaduri' do
+    expect{dsc_xiiswordpresssite[:dsc_downloaduri] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_downloaduri' do
+    expect{dsc_xiiswordpresssite[:dsc_downloaduri] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_downloaduri' do
+    expect{dsc_xiiswordpresssite[:dsc_downloaduri] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_downloaduri' do
+    expect{dsc_xiiswordpresssite[:dsc_downloaduri] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_packagefolder' do
+    expect{dsc_xiiswordpresssite[:dsc_packagefolder] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_packagefolder' do
+    expect{dsc_xiiswordpresssite[:dsc_packagefolder] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_packagefolder' do
+    expect{dsc_xiiswordpresssite[:dsc_packagefolder] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_packagefolder' do
+    expect{dsc_xiiswordpresssite[:dsc_packagefolder] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_configuration' do
+    expect{dsc_xiiswordpresssite[:dsc_configuration] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_configuration' do
+    expect{dsc_xiiswordpresssite[:dsc_configuration] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_configuration' do
+    expect{dsc_xiiswordpresssite[:dsc_configuration] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_configuration' do
+    expect{dsc_xiiswordpresssite[:dsc_configuration] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xiiswordpresssite)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xiiswordpresssite)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xiiswordpresssite[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xiiswordpresssite[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xiiswordpresssite)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xiiswordpresssite)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of xIisWordPressSite as $xIisWordPressSite1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of xIisWordPressSite/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xipaddress_spec.rb
+++ b/spec/unit/puppet/type/dsc_xipaddress_spec.rb
@@ -1,0 +1,222 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xipaddress) do
+
+  let :dsc_xipaddress do
+    Puppet::Type.type(:dsc_xipaddress).new(
+      :name     => 'foo',
+      :dsc_ipaddress => 'foo',
+      :dsc_interfacealias => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xipaddress.to_s).to eq("Dsc_xipaddress[foo]")
+  end
+
+  it 'should require that dsc_ipaddress is specified' do
+    #dsc_xipaddress[:dsc_ipaddress]
+    expect { Puppet::Type.type(:dsc_xipaddress).new(
+      :name     => 'foo',
+      :dsc_interfacealias => 'foo',
+      :dsc_defaultgateway => 'foo',
+      :dsc_subnetmask => 32,
+      :dsc_addressfamily => 'IPv4',
+    )}.to raise_error(Puppet::Error, /dsc_ipaddress is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_ipaddress' do
+    expect{dsc_xipaddress[:dsc_ipaddress] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ipaddress' do
+    expect{dsc_xipaddress[:dsc_ipaddress] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ipaddress' do
+    expect{dsc_xipaddress[:dsc_ipaddress] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ipaddress' do
+    expect{dsc_xipaddress[:dsc_ipaddress] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_interfacealias is specified' do
+    #dsc_xipaddress[:dsc_interfacealias]
+    expect { Puppet::Type.type(:dsc_xipaddress).new(
+      :name     => 'foo',
+      :dsc_ipaddress => 'foo',
+      :dsc_defaultgateway => 'foo',
+      :dsc_subnetmask => 32,
+      :dsc_addressfamily => 'IPv4',
+    )}.to raise_error(Puppet::Error, /dsc_interfacealias is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_interfacealias' do
+    expect{dsc_xipaddress[:dsc_interfacealias] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_interfacealias' do
+    expect{dsc_xipaddress[:dsc_interfacealias] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_interfacealias' do
+    expect{dsc_xipaddress[:dsc_interfacealias] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_interfacealias' do
+    expect{dsc_xipaddress[:dsc_interfacealias] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_defaultgateway' do
+    expect{dsc_xipaddress[:dsc_defaultgateway] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_defaultgateway' do
+    expect{dsc_xipaddress[:dsc_defaultgateway] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_defaultgateway' do
+    expect{dsc_xipaddress[:dsc_defaultgateway] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_defaultgateway' do
+    expect{dsc_xipaddress[:dsc_defaultgateway] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_subnetmask' do
+    expect{dsc_xipaddress[:dsc_subnetmask] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_subnetmask' do
+    expect{dsc_xipaddress[:dsc_subnetmask] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_subnetmask' do
+    expect{dsc_xipaddress[:dsc_subnetmask] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_subnetmask' do
+    dsc_xipaddress[:dsc_subnetmask] = 32
+    expect(dsc_xipaddress[:dsc_subnetmask]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_subnetmask' do
+    dsc_xipaddress[:dsc_subnetmask] = '16'
+    expect(dsc_xipaddress[:dsc_subnetmask]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_subnetmask' do
+    dsc_xipaddress[:dsc_subnetmask] = '32'
+    expect(dsc_xipaddress[:dsc_subnetmask]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_subnetmask' do
+    dsc_xipaddress[:dsc_subnetmask] = '64'
+    expect(dsc_xipaddress[:dsc_subnetmask]).to eq(64)
+  end
+
+  it 'should accept dsc_addressfamily predefined value IPv4' do
+    dsc_xipaddress[:dsc_addressfamily] = 'IPv4'
+    expect(dsc_xipaddress[:dsc_addressfamily]).to eq('IPv4')
+  end
+
+  it 'should accept dsc_addressfamily predefined value ipv4' do
+    dsc_xipaddress[:dsc_addressfamily] = 'ipv4'
+    expect(dsc_xipaddress[:dsc_addressfamily]).to eq('ipv4')
+  end
+
+  it 'should accept dsc_addressfamily predefined value IPv6' do
+    dsc_xipaddress[:dsc_addressfamily] = 'IPv6'
+    expect(dsc_xipaddress[:dsc_addressfamily]).to eq('IPv6')
+  end
+
+  it 'should accept dsc_addressfamily predefined value ipv6' do
+    dsc_xipaddress[:dsc_addressfamily] = 'ipv6'
+    expect(dsc_xipaddress[:dsc_addressfamily]).to eq('ipv6')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xipaddress[:dsc_addressfamily] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_addressfamily' do
+    expect{dsc_xipaddress[:dsc_addressfamily] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_addressfamily' do
+    expect{dsc_xipaddress[:dsc_addressfamily] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_addressfamily' do
+    expect{dsc_xipaddress[:dsc_addressfamily] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_addressfamily' do
+    expect{dsc_xipaddress[:dsc_addressfamily] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xipaddress)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xipaddress)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xipaddress[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xipaddress[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xipaddress)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xipaddress)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xIPAddress as $MSFT_xIPAddress1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xIPAddress/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xjeaendpoint_spec.rb
+++ b/spec/unit/puppet/type/dsc_xjeaendpoint_spec.rb
@@ -1,0 +1,329 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xjeaendpoint) do
+
+  let :dsc_xjeaendpoint do
+    Puppet::Type.type(:dsc_xjeaendpoint).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xjeaendpoint.to_s).to eq("Dsc_xjeaendpoint[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xjeaendpoint[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xjeaendpoint[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xjeaendpoint).new(
+      :name     => 'foo',
+      :dsc_toolkit => ["foo", "bar", "spec"],
+      :dsc_securitydescriptorsddl => 'foo',
+      :dsc_group => ["foo", "bar", "spec"],
+      :dsc_ensure => 'Present',
+      :dsc_cleanall => true,
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xjeaendpoint[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xjeaendpoint[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xjeaendpoint[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xjeaendpoint[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_toolkit' do
+    dsc_xjeaendpoint[:dsc_toolkit] = ["foo", "bar", "spec"]
+    expect(dsc_xjeaendpoint[:dsc_toolkit]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_toolkit' do
+    expect{dsc_xjeaendpoint[:dsc_toolkit] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_toolkit' do
+    expect{dsc_xjeaendpoint[:dsc_toolkit] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_toolkit' do
+    expect{dsc_xjeaendpoint[:dsc_toolkit] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_securitydescriptorsddl' do
+    expect{dsc_xjeaendpoint[:dsc_securitydescriptorsddl] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_securitydescriptorsddl' do
+    expect{dsc_xjeaendpoint[:dsc_securitydescriptorsddl] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_securitydescriptorsddl' do
+    expect{dsc_xjeaendpoint[:dsc_securitydescriptorsddl] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_securitydescriptorsddl' do
+    expect{dsc_xjeaendpoint[:dsc_securitydescriptorsddl] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_group' do
+    dsc_xjeaendpoint[:dsc_group] = ["foo", "bar", "spec"]
+    expect(dsc_xjeaendpoint[:dsc_group]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_group' do
+    expect{dsc_xjeaendpoint[:dsc_group] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_group' do
+    expect{dsc_xjeaendpoint[:dsc_group] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_group' do
+    expect{dsc_xjeaendpoint[:dsc_group] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xjeaendpoint[:dsc_ensure] = 'Present'
+    expect(dsc_xjeaendpoint[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xjeaendpoint[:dsc_ensure] = 'present'
+    expect(dsc_xjeaendpoint[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xjeaendpoint[:dsc_ensure] = 'present'
+    expect(dsc_xjeaendpoint[:ensure]).to eq(dsc_xjeaendpoint[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xjeaendpoint[:dsc_ensure] = 'Absent'
+    expect(dsc_xjeaendpoint[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xjeaendpoint[:dsc_ensure] = 'absent'
+    expect(dsc_xjeaendpoint[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xjeaendpoint[:dsc_ensure] = 'absent'
+    expect(dsc_xjeaendpoint[:ensure]).to eq(dsc_xjeaendpoint[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xjeaendpoint[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xjeaendpoint[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xjeaendpoint[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xjeaendpoint[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xjeaendpoint[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_cleanall' do
+    expect{dsc_xjeaendpoint[:dsc_cleanall] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_cleanall' do
+    dsc_xjeaendpoint[:dsc_cleanall] = true
+    expect(dsc_xjeaendpoint[:dsc_cleanall]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_cleanall" do
+    dsc_xjeaendpoint[:dsc_cleanall] = 'true'
+    expect(dsc_xjeaendpoint[:dsc_cleanall]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_cleanall" do
+    dsc_xjeaendpoint[:dsc_cleanall] = 'false'
+    expect(dsc_xjeaendpoint[:dsc_cleanall]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_cleanall" do
+    dsc_xjeaendpoint[:dsc_cleanall] = 'True'
+    expect(dsc_xjeaendpoint[:dsc_cleanall]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_cleanall" do
+    dsc_xjeaendpoint[:dsc_cleanall] = 'False'
+    expect(dsc_xjeaendpoint[:dsc_cleanall]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_cleanall" do
+    dsc_xjeaendpoint[:dsc_cleanall] = :true
+    expect(dsc_xjeaendpoint[:dsc_cleanall]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_cleanall" do
+    dsc_xjeaendpoint[:dsc_cleanall] = :false
+    expect(dsc_xjeaendpoint[:dsc_cleanall]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_cleanall' do
+    expect{dsc_xjeaendpoint[:dsc_cleanall] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_cleanall' do
+    expect{dsc_xjeaendpoint[:dsc_cleanall] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xjeaendpoint)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xjeaendpoint)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xjeaendpoint[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xjeaendpoint[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xjeaendpoint.original_parameters[:dsc_ensure] = 'present'
+        dsc_xjeaendpoint[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xjeaendpoint)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xjeaendpoint[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xjeaendpoint.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xjeaendpoint[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xjeaendpoint)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xjeaendpoint[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xjeaendpoint)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xjeaendpoint)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xJeaEndpoint as $MSFT_xJeaEndpoint1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xJeaEndpoint/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xjeaendpoint[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xjeaendpoint)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xjeaendpoint[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xjeaendpoint[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xjeaendpoint)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xjeaendpoint[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xjeatoolkit_spec.rb
+++ b/spec/unit/puppet/type/dsc_xjeatoolkit_spec.rb
@@ -1,0 +1,281 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xjeatoolkit) do
+
+  let :dsc_xjeatoolkit do
+    Puppet::Type.type(:dsc_xjeatoolkit).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xjeatoolkit.to_s).to eq("Dsc_xjeatoolkit[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xjeatoolkit[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xjeatoolkit[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xjeatoolkit).new(
+      :name     => 'foo',
+      :dsc_commandspecs => 'foo',
+      :dsc_scriptdirectory => ["foo", "bar", "spec"],
+      :dsc_applications => ["foo", "bar", "spec"],
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xjeatoolkit[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xjeatoolkit[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xjeatoolkit[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xjeatoolkit[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_commandspecs' do
+    expect{dsc_xjeatoolkit[:dsc_commandspecs] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_commandspecs' do
+    expect{dsc_xjeatoolkit[:dsc_commandspecs] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_commandspecs' do
+    expect{dsc_xjeatoolkit[:dsc_commandspecs] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_commandspecs' do
+    expect{dsc_xjeatoolkit[:dsc_commandspecs] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_scriptdirectory' do
+    dsc_xjeatoolkit[:dsc_scriptdirectory] = ["foo", "bar", "spec"]
+    expect(dsc_xjeatoolkit[:dsc_scriptdirectory]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_scriptdirectory' do
+    expect{dsc_xjeatoolkit[:dsc_scriptdirectory] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_scriptdirectory' do
+    expect{dsc_xjeatoolkit[:dsc_scriptdirectory] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_scriptdirectory' do
+    expect{dsc_xjeatoolkit[:dsc_scriptdirectory] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_applications' do
+    dsc_xjeatoolkit[:dsc_applications] = ["foo", "bar", "spec"]
+    expect(dsc_xjeatoolkit[:dsc_applications]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_applications' do
+    expect{dsc_xjeatoolkit[:dsc_applications] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_applications' do
+    expect{dsc_xjeatoolkit[:dsc_applications] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_applications' do
+    expect{dsc_xjeatoolkit[:dsc_applications] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xjeatoolkit[:dsc_ensure] = 'Present'
+    expect(dsc_xjeatoolkit[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xjeatoolkit[:dsc_ensure] = 'present'
+    expect(dsc_xjeatoolkit[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xjeatoolkit[:dsc_ensure] = 'present'
+    expect(dsc_xjeatoolkit[:ensure]).to eq(dsc_xjeatoolkit[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xjeatoolkit[:dsc_ensure] = 'Absent'
+    expect(dsc_xjeatoolkit[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xjeatoolkit[:dsc_ensure] = 'absent'
+    expect(dsc_xjeatoolkit[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xjeatoolkit[:dsc_ensure] = 'absent'
+    expect(dsc_xjeatoolkit[:ensure]).to eq(dsc_xjeatoolkit[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xjeatoolkit[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xjeatoolkit[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xjeatoolkit[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xjeatoolkit[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xjeatoolkit[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xjeatoolkit)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xjeatoolkit)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xjeatoolkit[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xjeatoolkit[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xjeatoolkit.original_parameters[:dsc_ensure] = 'present'
+        dsc_xjeatoolkit[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xjeatoolkit)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xjeatoolkit[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xjeatoolkit.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xjeatoolkit[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xjeatoolkit)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xjeatoolkit[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xjeatoolkit)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xjeatoolkit)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xJeaToolkit as $MSFT_xJeaToolkit1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xJeaToolkit/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xjeatoolkit[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xjeatoolkit)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xjeatoolkit[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xjeatoolkit[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xjeatoolkit)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xjeatoolkit[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xmysqldatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqldatabase_spec.rb
@@ -1,0 +1,245 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xmysqldatabase) do
+
+  let :dsc_xmysqldatabase do
+    Puppet::Type.type(:dsc_xmysqldatabase).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xmysqldatabase.to_s).to eq("Dsc_xmysqldatabase[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xmysqldatabase[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xmysqldatabase[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xmysqldatabase).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_connectioncredential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xmysqldatabase[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xmysqldatabase[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xmysqldatabase[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xmysqldatabase[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xmysqldatabase[:dsc_ensure] = 'Present'
+    expect(dsc_xmysqldatabase[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xmysqldatabase[:dsc_ensure] = 'present'
+    expect(dsc_xmysqldatabase[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xmysqldatabase[:dsc_ensure] = 'present'
+    expect(dsc_xmysqldatabase[:ensure]).to eq(dsc_xmysqldatabase[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xmysqldatabase[:dsc_ensure] = 'Absent'
+    expect(dsc_xmysqldatabase[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xmysqldatabase[:dsc_ensure] = 'absent'
+    expect(dsc_xmysqldatabase[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xmysqldatabase[:dsc_ensure] = 'absent'
+    expect(dsc_xmysqldatabase[:ensure]).to eq(dsc_xmysqldatabase[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xmysqldatabase[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xmysqldatabase[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xmysqldatabase[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xmysqldatabase[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xmysqldatabase[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_connectioncredential' do
+    expect{dsc_xmysqldatabase[:dsc_connectioncredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_connectioncredential' do
+    expect{dsc_xmysqldatabase[:dsc_connectioncredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_connectioncredential' do
+    expect{dsc_xmysqldatabase[:dsc_connectioncredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_connectioncredential' do
+    expect{dsc_xmysqldatabase[:dsc_connectioncredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xmysqldatabase)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xmysqldatabase)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xmysqldatabase[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xmysqldatabase[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xmysqldatabase.original_parameters[:dsc_ensure] = 'present'
+        dsc_xmysqldatabase[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqldatabase)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xmysqldatabase[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xmysqldatabase.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xmysqldatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqldatabase)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xmysqldatabase[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xmysqldatabase)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xmysqldatabase)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xMySqlDatabase as $MSFT_xMySqlDatabase1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xMySqlDatabase/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xmysqldatabase[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xmysqldatabase)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xmysqldatabase[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xmysqldatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xmysqldatabase)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xmysqldatabase[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xmysqlgrant_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqlgrant_spec.rb
@@ -1,0 +1,375 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xmysqlgrant) do
+
+  let :dsc_xmysqlgrant do
+    Puppet::Type.type(:dsc_xmysqlgrant).new(
+      :name     => 'foo',
+      :dsc_username => 'foo',
+      :dsc_databasename => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xmysqlgrant.to_s).to eq("Dsc_xmysqlgrant[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xmysqlgrant[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_username is specified' do
+    #dsc_xmysqlgrant[:dsc_username]
+    expect { Puppet::Type.type(:dsc_xmysqlgrant).new(
+      :name     => 'foo',
+      :dsc_databasename => 'foo',
+      :dsc_connectioncredential => 'foo',
+      :dsc_permissiontype => 'ALL PRIVILEGES',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_username is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_username' do
+    expect{dsc_xmysqlgrant[:dsc_username] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_username' do
+    expect{dsc_xmysqlgrant[:dsc_username] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_username' do
+    expect{dsc_xmysqlgrant[:dsc_username] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_username' do
+    expect{dsc_xmysqlgrant[:dsc_username] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_databasename is specified' do
+    #dsc_xmysqlgrant[:dsc_databasename]
+    expect { Puppet::Type.type(:dsc_xmysqlgrant).new(
+      :name     => 'foo',
+      :dsc_username => 'foo',
+      :dsc_connectioncredential => 'foo',
+      :dsc_permissiontype => 'ALL PRIVILEGES',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_databasename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_databasename' do
+    expect{dsc_xmysqlgrant[:dsc_databasename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_databasename' do
+    expect{dsc_xmysqlgrant[:dsc_databasename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_databasename' do
+    expect{dsc_xmysqlgrant[:dsc_databasename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_databasename' do
+    expect{dsc_xmysqlgrant[:dsc_databasename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_connectioncredential' do
+    expect{dsc_xmysqlgrant[:dsc_connectioncredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_connectioncredential' do
+    expect{dsc_xmysqlgrant[:dsc_connectioncredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_connectioncredential' do
+    expect{dsc_xmysqlgrant[:dsc_connectioncredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_connectioncredential' do
+    expect{dsc_xmysqlgrant[:dsc_connectioncredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_permissiontype predefined value ALL PRIVILEGES' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'ALL PRIVILEGES'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('ALL PRIVILEGES')
+  end
+
+  it 'should accept dsc_permissiontype predefined value all privileges' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'all privileges'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('all privileges')
+  end
+
+  it 'should accept dsc_permissiontype predefined value CREATE' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'CREATE'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('CREATE')
+  end
+
+  it 'should accept dsc_permissiontype predefined value create' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'create'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('create')
+  end
+
+  it 'should accept dsc_permissiontype predefined value DROP' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'DROP'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('DROP')
+  end
+
+  it 'should accept dsc_permissiontype predefined value drop' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'drop'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('drop')
+  end
+
+  it 'should accept dsc_permissiontype predefined value DELETE' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'DELETE'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('DELETE')
+  end
+
+  it 'should accept dsc_permissiontype predefined value delete' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'delete'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('delete')
+  end
+
+  it 'should accept dsc_permissiontype predefined value INSERT' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'INSERT'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('INSERT')
+  end
+
+  it 'should accept dsc_permissiontype predefined value insert' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'insert'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('insert')
+  end
+
+  it 'should accept dsc_permissiontype predefined value SELECT' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'SELECT'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('SELECT')
+  end
+
+  it 'should accept dsc_permissiontype predefined value select' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'select'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('select')
+  end
+
+  it 'should accept dsc_permissiontype predefined value UPDATE' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'UPDATE'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('UPDATE')
+  end
+
+  it 'should accept dsc_permissiontype predefined value update' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'update'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('update')
+  end
+
+  it 'should accept dsc_permissiontype predefined value EXECUTE' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'EXECUTE'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('EXECUTE')
+  end
+
+  it 'should accept dsc_permissiontype predefined value execute' do
+    dsc_xmysqlgrant[:dsc_permissiontype] = 'execute'
+    expect(dsc_xmysqlgrant[:dsc_permissiontype]).to eq('execute')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xmysqlgrant[:dsc_permissiontype] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_permissiontype' do
+    expect{dsc_xmysqlgrant[:dsc_permissiontype] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_permissiontype' do
+    expect{dsc_xmysqlgrant[:dsc_permissiontype] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_permissiontype' do
+    expect{dsc_xmysqlgrant[:dsc_permissiontype] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_permissiontype' do
+    expect{dsc_xmysqlgrant[:dsc_permissiontype] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xmysqlgrant[:dsc_ensure] = 'Present'
+    expect(dsc_xmysqlgrant[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xmysqlgrant[:dsc_ensure] = 'present'
+    expect(dsc_xmysqlgrant[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xmysqlgrant[:dsc_ensure] = 'present'
+    expect(dsc_xmysqlgrant[:ensure]).to eq(dsc_xmysqlgrant[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xmysqlgrant[:dsc_ensure] = 'Absent'
+    expect(dsc_xmysqlgrant[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xmysqlgrant[:dsc_ensure] = 'absent'
+    expect(dsc_xmysqlgrant[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xmysqlgrant[:dsc_ensure] = 'absent'
+    expect(dsc_xmysqlgrant[:ensure]).to eq(dsc_xmysqlgrant[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xmysqlgrant[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xmysqlgrant[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xmysqlgrant[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xmysqlgrant[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xmysqlgrant[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xmysqlgrant)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xmysqlgrant)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xmysqlgrant[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xmysqlgrant[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xmysqlgrant.original_parameters[:dsc_ensure] = 'present'
+        dsc_xmysqlgrant[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqlgrant)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xmysqlgrant[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xmysqlgrant.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xmysqlgrant[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqlgrant)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xmysqlgrant[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xmysqlgrant)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xmysqlgrant)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xMySqlGrant as $MSFT_xMySqlGrant1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xMySqlGrant/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xmysqlgrant[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xmysqlgrant)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xmysqlgrant[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xmysqlgrant[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xmysqlgrant)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xmysqlgrant[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xmysqlserver_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqlserver_spec.rb
@@ -1,0 +1,245 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xmysqlserver) do
+
+  let :dsc_xmysqlserver do
+    Puppet::Type.type(:dsc_xmysqlserver).new(
+      :name     => 'foo',
+      :dsc_servicename => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xmysqlserver.to_s).to eq("Dsc_xmysqlserver[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xmysqlserver[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_servicename is specified' do
+    #dsc_xmysqlserver[:dsc_servicename]
+    expect { Puppet::Type.type(:dsc_xmysqlserver).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_rootpassword => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_servicename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_servicename' do
+    expect{dsc_xmysqlserver[:dsc_servicename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_servicename' do
+    expect{dsc_xmysqlserver[:dsc_servicename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_servicename' do
+    expect{dsc_xmysqlserver[:dsc_servicename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_servicename' do
+    expect{dsc_xmysqlserver[:dsc_servicename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xmysqlserver[:dsc_ensure] = 'Present'
+    expect(dsc_xmysqlserver[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xmysqlserver[:dsc_ensure] = 'present'
+    expect(dsc_xmysqlserver[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xmysqlserver[:dsc_ensure] = 'present'
+    expect(dsc_xmysqlserver[:ensure]).to eq(dsc_xmysqlserver[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xmysqlserver[:dsc_ensure] = 'Absent'
+    expect(dsc_xmysqlserver[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xmysqlserver[:dsc_ensure] = 'absent'
+    expect(dsc_xmysqlserver[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xmysqlserver[:dsc_ensure] = 'absent'
+    expect(dsc_xmysqlserver[:ensure]).to eq(dsc_xmysqlserver[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xmysqlserver[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xmysqlserver[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xmysqlserver[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xmysqlserver[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xmysqlserver[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_rootpassword' do
+    expect{dsc_xmysqlserver[:dsc_rootpassword] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_rootpassword' do
+    expect{dsc_xmysqlserver[:dsc_rootpassword] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_rootpassword' do
+    expect{dsc_xmysqlserver[:dsc_rootpassword] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_rootpassword' do
+    expect{dsc_xmysqlserver[:dsc_rootpassword] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xmysqlserver)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xmysqlserver)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xmysqlserver[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xmysqlserver[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xmysqlserver.original_parameters[:dsc_ensure] = 'present'
+        dsc_xmysqlserver[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqlserver)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xmysqlserver[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xmysqlserver.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xmysqlserver[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqlserver)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xmysqlserver[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xmysqlserver)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xmysqlserver)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xMySqlServer as $MSFT_xMySqlServer1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xMySqlServer/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xmysqlserver[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xmysqlserver)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xmysqlserver[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xmysqlserver[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xmysqlserver)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xmysqlserver[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xmysqluser_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqluser_spec.rb
@@ -1,0 +1,262 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xmysqluser) do
+
+  let :dsc_xmysqluser do
+    Puppet::Type.type(:dsc_xmysqluser).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xmysqluser.to_s).to eq("Dsc_xmysqluser[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xmysqluser[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xmysqluser[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xmysqluser).new(
+      :name     => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_connectioncredential => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xmysqluser[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xmysqluser[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xmysqluser[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xmysqluser[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_xmysqluser[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_xmysqluser[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_xmysqluser[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_xmysqluser[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_connectioncredential' do
+    expect{dsc_xmysqluser[:dsc_connectioncredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_connectioncredential' do
+    expect{dsc_xmysqluser[:dsc_connectioncredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_connectioncredential' do
+    expect{dsc_xmysqluser[:dsc_connectioncredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_connectioncredential' do
+    expect{dsc_xmysqluser[:dsc_connectioncredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xmysqluser[:dsc_ensure] = 'Present'
+    expect(dsc_xmysqluser[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xmysqluser[:dsc_ensure] = 'present'
+    expect(dsc_xmysqluser[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xmysqluser[:dsc_ensure] = 'present'
+    expect(dsc_xmysqluser[:ensure]).to eq(dsc_xmysqluser[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xmysqluser[:dsc_ensure] = 'Absent'
+    expect(dsc_xmysqluser[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xmysqluser[:dsc_ensure] = 'absent'
+    expect(dsc_xmysqluser[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xmysqluser[:dsc_ensure] = 'absent'
+    expect(dsc_xmysqluser[:ensure]).to eq(dsc_xmysqluser[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xmysqluser[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xmysqluser[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xmysqluser[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xmysqluser[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xmysqluser[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xmysqluser)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xmysqluser)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xmysqluser[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xmysqluser[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xmysqluser.original_parameters[:dsc_ensure] = 'present'
+        dsc_xmysqluser[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqluser)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xmysqluser[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xmysqluser.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xmysqluser[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqluser)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xmysqluser[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xmysqluser)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xmysqluser)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xMySqlUser as $MSFT_xMySqlUser1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xMySqlUser/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xmysqluser[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xmysqluser)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xmysqluser[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xmysqluser[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xmysqluser)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xmysqluser[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xpackage_spec.rb
+++ b/spec/unit/puppet/type/dsc_xpackage_spec.rb
@@ -1,0 +1,576 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xpackage) do
+
+  let :dsc_xpackage do
+    Puppet::Type.type(:dsc_xpackage).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_productid => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xpackage.to_s).to eq("Dsc_xpackage[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xpackage[:ensure]).to eq :present
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xpackage[:dsc_ensure] = 'Present'
+    expect(dsc_xpackage[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xpackage[:dsc_ensure] = 'present'
+    expect(dsc_xpackage[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xpackage[:dsc_ensure] = 'present'
+    expect(dsc_xpackage[:ensure]).to eq(dsc_xpackage[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xpackage[:dsc_ensure] = 'Absent'
+    expect(dsc_xpackage[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xpackage[:dsc_ensure] = 'absent'
+    expect(dsc_xpackage[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xpackage[:dsc_ensure] = 'absent'
+    expect(dsc_xpackage[:ensure]).to eq(dsc_xpackage[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xpackage[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xpackage[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xpackage[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xpackage[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xpackage[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xpackage[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xpackage).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_path => 'foo',
+      :dsc_productid => 'foo',
+      :dsc_arguments => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_returncode => [32, 64, 128],
+      :dsc_logpath => 'foo',
+      :dsc_packagedescription => 'foo',
+      :dsc_publisher => 'foo',
+      :dsc_installedon => 'foo',
+      :dsc_size => 32,
+      :dsc_version => 'foo',
+      :dsc_installed => true,
+      :dsc_runascredential => 'foo',
+      :dsc_installedcheckregkey => 'foo',
+      :dsc_installedcheckregvaluename => 'foo',
+      :dsc_installedcheckregvaluedata => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xpackage[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xpackage[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xpackage[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xpackage[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_xpackage[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xpackage[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xpackage[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xpackage[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_productid is specified' do
+    #dsc_xpackage[:dsc_productid]
+    expect { Puppet::Type.type(:dsc_xpackage).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_name => 'foo',
+      :dsc_path => 'foo',
+      :dsc_arguments => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_returncode => [32, 64, 128],
+      :dsc_logpath => 'foo',
+      :dsc_packagedescription => 'foo',
+      :dsc_publisher => 'foo',
+      :dsc_installedon => 'foo',
+      :dsc_size => 32,
+      :dsc_version => 'foo',
+      :dsc_installed => true,
+      :dsc_runascredential => 'foo',
+      :dsc_installedcheckregkey => 'foo',
+      :dsc_installedcheckregvaluename => 'foo',
+      :dsc_installedcheckregvaluedata => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_productid is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_productid' do
+    expect{dsc_xpackage[:dsc_productid] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_productid' do
+    expect{dsc_xpackage[:dsc_productid] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_productid' do
+    expect{dsc_xpackage[:dsc_productid] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_productid' do
+    expect{dsc_xpackage[:dsc_productid] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_arguments' do
+    expect{dsc_xpackage[:dsc_arguments] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_arguments' do
+    expect{dsc_xpackage[:dsc_arguments] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_arguments' do
+    expect{dsc_xpackage[:dsc_arguments] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_arguments' do
+    expect{dsc_xpackage[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_xpackage[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_xpackage[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_xpackage[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_xpackage[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_returncode' do
+    dsc_xpackage[:dsc_returncode] = [32, 64, 128]
+    expect(dsc_xpackage[:dsc_returncode]).to eq([32, 64, 128])
+  end
+
+  it 'should not accept boolean for dsc_returncode' do
+    expect{dsc_xpackage[:dsc_returncode] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_returncode' do
+    expect{dsc_xpackage[:dsc_returncode] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_returncode' do
+    expect{dsc_xpackage[:dsc_returncode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_logpath' do
+    expect{dsc_xpackage[:dsc_logpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_logpath' do
+    expect{dsc_xpackage[:dsc_logpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_logpath' do
+    expect{dsc_xpackage[:dsc_logpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_logpath' do
+    expect{dsc_xpackage[:dsc_logpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_packagedescription' do
+    expect{dsc_xpackage[:dsc_packagedescription] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_packagedescription' do
+    expect{dsc_xpackage[:dsc_packagedescription] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_packagedescription' do
+    expect{dsc_xpackage[:dsc_packagedescription] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_packagedescription' do
+    expect{dsc_xpackage[:dsc_packagedescription] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_publisher' do
+    expect{dsc_xpackage[:dsc_publisher] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_publisher' do
+    expect{dsc_xpackage[:dsc_publisher] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_publisher' do
+    expect{dsc_xpackage[:dsc_publisher] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_publisher' do
+    expect{dsc_xpackage[:dsc_publisher] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_installedon' do
+    expect{dsc_xpackage[:dsc_installedon] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_installedon' do
+    expect{dsc_xpackage[:dsc_installedon] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_installedon' do
+    expect{dsc_xpackage[:dsc_installedon] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_installedon' do
+    expect{dsc_xpackage[:dsc_installedon] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_size' do
+    expect{dsc_xpackage[:dsc_size] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_size' do
+    expect{dsc_xpackage[:dsc_size] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_size' do
+    expect{dsc_xpackage[:dsc_size] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_size' do
+    dsc_xpackage[:dsc_size] = 32
+    expect(dsc_xpackage[:dsc_size]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_xpackage[:dsc_size] = '16'
+    expect(dsc_xpackage[:dsc_size]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_xpackage[:dsc_size] = '32'
+    expect(dsc_xpackage[:dsc_size]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_size' do
+    dsc_xpackage[:dsc_size] = '64'
+    expect(dsc_xpackage[:dsc_size]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_version' do
+    expect{dsc_xpackage[:dsc_version] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_version' do
+    expect{dsc_xpackage[:dsc_version] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_version' do
+    expect{dsc_xpackage[:dsc_version] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_version' do
+    expect{dsc_xpackage[:dsc_version] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_installed' do
+    expect{dsc_xpackage[:dsc_installed] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_installed' do
+    dsc_xpackage[:dsc_installed] = true
+    expect(dsc_xpackage[:dsc_installed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_installed" do
+    dsc_xpackage[:dsc_installed] = 'true'
+    expect(dsc_xpackage[:dsc_installed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_installed" do
+    dsc_xpackage[:dsc_installed] = 'false'
+    expect(dsc_xpackage[:dsc_installed]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_installed" do
+    dsc_xpackage[:dsc_installed] = 'True'
+    expect(dsc_xpackage[:dsc_installed]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_installed" do
+    dsc_xpackage[:dsc_installed] = 'False'
+    expect(dsc_xpackage[:dsc_installed]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_installed" do
+    dsc_xpackage[:dsc_installed] = :true
+    expect(dsc_xpackage[:dsc_installed]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_installed" do
+    dsc_xpackage[:dsc_installed] = :false
+    expect(dsc_xpackage[:dsc_installed]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_installed' do
+    expect{dsc_xpackage[:dsc_installed] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_installed' do
+    expect{dsc_xpackage[:dsc_installed] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_runascredential' do
+    expect{dsc_xpackage[:dsc_runascredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_runascredential' do
+    expect{dsc_xpackage[:dsc_runascredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_runascredential' do
+    expect{dsc_xpackage[:dsc_runascredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_runascredential' do
+    expect{dsc_xpackage[:dsc_runascredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_installedcheckregkey' do
+    expect{dsc_xpackage[:dsc_installedcheckregkey] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_installedcheckregkey' do
+    expect{dsc_xpackage[:dsc_installedcheckregkey] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_installedcheckregkey' do
+    expect{dsc_xpackage[:dsc_installedcheckregkey] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_installedcheckregkey' do
+    expect{dsc_xpackage[:dsc_installedcheckregkey] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_installedcheckregvaluename' do
+    expect{dsc_xpackage[:dsc_installedcheckregvaluename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_installedcheckregvaluename' do
+    expect{dsc_xpackage[:dsc_installedcheckregvaluename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_installedcheckregvaluename' do
+    expect{dsc_xpackage[:dsc_installedcheckregvaluename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_installedcheckregvaluename' do
+    expect{dsc_xpackage[:dsc_installedcheckregvaluename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_installedcheckregvaluedata' do
+    expect{dsc_xpackage[:dsc_installedcheckregvaluedata] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_installedcheckregvaluedata' do
+    expect{dsc_xpackage[:dsc_installedcheckregvaluedata] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_installedcheckregvaluedata' do
+    expect{dsc_xpackage[:dsc_installedcheckregvaluedata] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_installedcheckregvaluedata' do
+    expect{dsc_xpackage[:dsc_installedcheckregvaluedata] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xpackage)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xpackage)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xpackage[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xpackage[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xpackage.original_parameters[:dsc_ensure] = 'present'
+        dsc_xpackage[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xpackage)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xpackage[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xpackage.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xpackage[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xpackage)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xpackage[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xpackage)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xpackage)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xPackageResource as $MSFT_xPackageResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xPackageResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xpackage[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xpackage)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xpackage[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xpackage[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xpackage)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xpackage[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xpsendpoint_spec.rb
+++ b/spec/unit/puppet/type/dsc_xpsendpoint_spec.rb
@@ -1,0 +1,330 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xpsendpoint) do
+
+  let :dsc_xpsendpoint do
+    Puppet::Type.type(:dsc_xpsendpoint).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xpsendpoint.to_s).to eq("Dsc_xpsendpoint[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xpsendpoint[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xpsendpoint[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xpsendpoint).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_startupscript => 'foo',
+      :dsc_runascredential => 'foo',
+      :dsc_securitydescriptorsddl => 'foo',
+      :dsc_accessmode => 'Local',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xpsendpoint[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xpsendpoint[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xpsendpoint[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xpsendpoint[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xpsendpoint[:dsc_ensure] = 'Present'
+    expect(dsc_xpsendpoint[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xpsendpoint[:dsc_ensure] = 'present'
+    expect(dsc_xpsendpoint[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xpsendpoint[:dsc_ensure] = 'present'
+    expect(dsc_xpsendpoint[:ensure]).to eq(dsc_xpsendpoint[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xpsendpoint[:dsc_ensure] = 'Absent'
+    expect(dsc_xpsendpoint[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xpsendpoint[:dsc_ensure] = 'absent'
+    expect(dsc_xpsendpoint[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xpsendpoint[:dsc_ensure] = 'absent'
+    expect(dsc_xpsendpoint[:ensure]).to eq(dsc_xpsendpoint[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xpsendpoint[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xpsendpoint[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xpsendpoint[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xpsendpoint[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xpsendpoint[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_startupscript' do
+    expect{dsc_xpsendpoint[:dsc_startupscript] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_startupscript' do
+    expect{dsc_xpsendpoint[:dsc_startupscript] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_startupscript' do
+    expect{dsc_xpsendpoint[:dsc_startupscript] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_startupscript' do
+    expect{dsc_xpsendpoint[:dsc_startupscript] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_runascredential' do
+    expect{dsc_xpsendpoint[:dsc_runascredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_runascredential' do
+    expect{dsc_xpsendpoint[:dsc_runascredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_runascredential' do
+    expect{dsc_xpsendpoint[:dsc_runascredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_runascredential' do
+    expect{dsc_xpsendpoint[:dsc_runascredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_securitydescriptorsddl' do
+    expect{dsc_xpsendpoint[:dsc_securitydescriptorsddl] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_securitydescriptorsddl' do
+    expect{dsc_xpsendpoint[:dsc_securitydescriptorsddl] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_securitydescriptorsddl' do
+    expect{dsc_xpsendpoint[:dsc_securitydescriptorsddl] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_securitydescriptorsddl' do
+    expect{dsc_xpsendpoint[:dsc_securitydescriptorsddl] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_accessmode predefined value Local' do
+    dsc_xpsendpoint[:dsc_accessmode] = 'Local'
+    expect(dsc_xpsendpoint[:dsc_accessmode]).to eq('Local')
+  end
+
+  it 'should accept dsc_accessmode predefined value local' do
+    dsc_xpsendpoint[:dsc_accessmode] = 'local'
+    expect(dsc_xpsendpoint[:dsc_accessmode]).to eq('local')
+  end
+
+  it 'should accept dsc_accessmode predefined value Remote' do
+    dsc_xpsendpoint[:dsc_accessmode] = 'Remote'
+    expect(dsc_xpsendpoint[:dsc_accessmode]).to eq('Remote')
+  end
+
+  it 'should accept dsc_accessmode predefined value remote' do
+    dsc_xpsendpoint[:dsc_accessmode] = 'remote'
+    expect(dsc_xpsendpoint[:dsc_accessmode]).to eq('remote')
+  end
+
+  it 'should accept dsc_accessmode predefined value Disabled' do
+    dsc_xpsendpoint[:dsc_accessmode] = 'Disabled'
+    expect(dsc_xpsendpoint[:dsc_accessmode]).to eq('Disabled')
+  end
+
+  it 'should accept dsc_accessmode predefined value disabled' do
+    dsc_xpsendpoint[:dsc_accessmode] = 'disabled'
+    expect(dsc_xpsendpoint[:dsc_accessmode]).to eq('disabled')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xpsendpoint[:dsc_accessmode] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_accessmode' do
+    expect{dsc_xpsendpoint[:dsc_accessmode] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_accessmode' do
+    expect{dsc_xpsendpoint[:dsc_accessmode] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_accessmode' do
+    expect{dsc_xpsendpoint[:dsc_accessmode] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_accessmode' do
+    expect{dsc_xpsendpoint[:dsc_accessmode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xpsendpoint)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xpsendpoint)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xpsendpoint[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xpsendpoint[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xpsendpoint.original_parameters[:dsc_ensure] = 'present'
+        dsc_xpsendpoint[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xpsendpoint)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xpsendpoint[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xpsendpoint.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xpsendpoint[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xpsendpoint)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xpsendpoint[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xpsendpoint)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xpsendpoint)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xPSSessionConfiguration as $MSFT_xPSSessionConfiguration1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xPSSessionConfiguration/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xpsendpoint[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xpsendpoint)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xpsendpoint[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xpsendpoint[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xpsendpoint)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xpsendpoint[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xrdsessioncollection_spec.rb
+++ b/spec/unit/puppet/type/dsc_xrdsessioncollection_spec.rb
@@ -1,0 +1,161 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xrdsessioncollection) do
+
+  let :dsc_xrdsessioncollection do
+    Puppet::Type.type(:dsc_xrdsessioncollection).new(
+      :name     => 'foo',
+      :dsc_collectionname => 'foo',
+      :dsc_sessionhost => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xrdsessioncollection.to_s).to eq("Dsc_xrdsessioncollection[foo]")
+  end
+
+  it 'should require that dsc_collectionname is specified' do
+    #dsc_xrdsessioncollection[:dsc_collectionname]
+    expect { Puppet::Type.type(:dsc_xrdsessioncollection).new(
+      :name     => 'foo',
+      :dsc_sessionhost => 'foo',
+      :dsc_collectiondescription => 'foo',
+      :dsc_connectionbroker => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_collectionname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_collectionname' do
+    expect{dsc_xrdsessioncollection[:dsc_collectionname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_collectionname' do
+    expect{dsc_xrdsessioncollection[:dsc_collectionname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_collectionname' do
+    expect{dsc_xrdsessioncollection[:dsc_collectionname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_collectionname' do
+    expect{dsc_xrdsessioncollection[:dsc_collectionname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_sessionhost is specified' do
+    #dsc_xrdsessioncollection[:dsc_sessionhost]
+    expect { Puppet::Type.type(:dsc_xrdsessioncollection).new(
+      :name     => 'foo',
+      :dsc_collectionname => 'foo',
+      :dsc_collectiondescription => 'foo',
+      :dsc_connectionbroker => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_sessionhost is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_sessionhost' do
+    expect{dsc_xrdsessioncollection[:dsc_sessionhost] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sessionhost' do
+    expect{dsc_xrdsessioncollection[:dsc_sessionhost] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sessionhost' do
+    expect{dsc_xrdsessioncollection[:dsc_sessionhost] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sessionhost' do
+    expect{dsc_xrdsessioncollection[:dsc_sessionhost] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_collectiondescription' do
+    expect{dsc_xrdsessioncollection[:dsc_collectiondescription] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_collectiondescription' do
+    expect{dsc_xrdsessioncollection[:dsc_collectiondescription] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_collectiondescription' do
+    expect{dsc_xrdsessioncollection[:dsc_collectiondescription] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_collectiondescription' do
+    expect{dsc_xrdsessioncollection[:dsc_collectiondescription] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_connectionbroker' do
+    expect{dsc_xrdsessioncollection[:dsc_connectionbroker] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_connectionbroker' do
+    expect{dsc_xrdsessioncollection[:dsc_connectionbroker] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_connectionbroker' do
+    expect{dsc_xrdsessioncollection[:dsc_connectionbroker] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_connectionbroker' do
+    expect{dsc_xrdsessioncollection[:dsc_connectionbroker] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xrdsessioncollection)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xrdsessioncollection)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xrdsessioncollection[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xrdsessioncollection[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xrdsessioncollection)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xrdsessioncollection)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xRDSessionCollection as $MSFT_xRDSessionCollection1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xRDSessionCollection/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xrdsessioncollectionconfiguration_spec.rb
+++ b/spec/unit/puppet/type/dsc_xrdsessioncollectionconfiguration_spec.rb
@@ -1,0 +1,667 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration) do
+
+  let :dsc_xrdsessioncollectionconfiguration do
+    Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration).new(
+      :name     => 'foo',
+      :dsc_collectionname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xrdsessioncollectionconfiguration.to_s).to eq("Dsc_xrdsessioncollectionconfiguration[foo]")
+  end
+
+  it 'should require that dsc_collectionname is specified' do
+    #dsc_xrdsessioncollectionconfiguration[:dsc_collectionname]
+    expect { Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration).new(
+      :name     => 'foo',
+      :dsc_activesessionlimitmin => 32,
+      :dsc_authenticateusingnla => true,
+      :dsc_automaticreconnectionenabled => true,
+      :dsc_brokenconnectionaction => 'foo',
+      :dsc_clientdeviceredirectionoptions => 'foo',
+      :dsc_clientprinterasdefault => true,
+      :dsc_clientprinterredirected => true,
+      :dsc_collectiondescription => 'foo',
+      :dsc_connectionbroker => 'foo',
+      :dsc_customrdpproperty => 'foo',
+      :dsc_disconnectedsessionlimitmin => 32,
+      :dsc_encryptionlevel => 'foo',
+      :dsc_idlesessionlimitmin => 32,
+      :dsc_maxredirectedmonitors => 32,
+      :dsc_rdeasyprintdriverenabled => true,
+      :dsc_securitylayer => 'foo',
+      :dsc_temporaryfoldersdeletedonexit => true,
+      :dsc_usergroup => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_collectionname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_collectionname' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_collectionname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_collectionname' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_collectionname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_collectionname' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_collectionname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_collectionname' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_collectionname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_activesessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_activesessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_activesessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_activesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = 32
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_activesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = '16'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_activesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = '32'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_activesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = '64'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_authenticateusingnla' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_authenticateusingnla' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_authenticateusingnla" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = 'true'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_authenticateusingnla" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = 'false'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_authenticateusingnla" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = 'True'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_authenticateusingnla" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = 'False'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_authenticateusingnla" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = :true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_authenticateusingnla" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = :false
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_authenticateusingnla' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_authenticateusingnla' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_authenticateusingnla] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_automaticreconnectionenabled' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_automaticreconnectionenabled' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_automaticreconnectionenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = 'true'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_automaticreconnectionenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = 'false'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_automaticreconnectionenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = 'True'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_automaticreconnectionenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = 'False'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_automaticreconnectionenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = :true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_automaticreconnectionenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = :false
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_automaticreconnectionenabled' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_automaticreconnectionenabled' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_automaticreconnectionenabled] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_brokenconnectionaction' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_brokenconnectionaction] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_brokenconnectionaction' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_brokenconnectionaction] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_brokenconnectionaction' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_brokenconnectionaction] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_brokenconnectionaction' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_brokenconnectionaction] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_clientdeviceredirectionoptions' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientdeviceredirectionoptions] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_clientdeviceredirectionoptions' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientdeviceredirectionoptions] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_clientdeviceredirectionoptions' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientdeviceredirectionoptions] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_clientdeviceredirectionoptions' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientdeviceredirectionoptions] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_clientprinterasdefault' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_clientprinterasdefault' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_clientprinterasdefault" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = 'true'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_clientprinterasdefault" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = 'false'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_clientprinterasdefault" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = 'True'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_clientprinterasdefault" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = 'False'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_clientprinterasdefault" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = :true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_clientprinterasdefault" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = :false
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_clientprinterasdefault' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_clientprinterasdefault' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterasdefault] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_clientprinterredirected' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_clientprinterredirected' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_clientprinterredirected" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = 'true'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_clientprinterredirected" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = 'false'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_clientprinterredirected" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = 'True'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_clientprinterredirected" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = 'False'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_clientprinterredirected" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = :true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_clientprinterredirected" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = :false
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_clientprinterredirected' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_clientprinterredirected' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_clientprinterredirected] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_collectiondescription' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_collectiondescription] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_collectiondescription' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_collectiondescription] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_collectiondescription' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_collectiondescription] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_collectiondescription' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_collectiondescription] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_connectionbroker' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_connectionbroker] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_connectionbroker' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_connectionbroker] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_connectionbroker' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_connectionbroker] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_connectionbroker' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_connectionbroker] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_customrdpproperty' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_customrdpproperty] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_customrdpproperty' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_customrdpproperty] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_customrdpproperty' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_customrdpproperty] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_customrdpproperty' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_customrdpproperty] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_disconnectedsessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_disconnectedsessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_disconnectedsessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_disconnectedsessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = 32
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_disconnectedsessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = '16'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_disconnectedsessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = '32'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_disconnectedsessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = '64'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_encryptionlevel' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_encryptionlevel] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_encryptionlevel' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_encryptionlevel] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_encryptionlevel' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_encryptionlevel] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_encryptionlevel' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_encryptionlevel] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_idlesessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_idlesessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_idlesessionlimitmin' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_idlesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = 32
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_idlesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = '16'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_idlesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = '32'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_idlesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = '64'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_maxredirectedmonitors' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_maxredirectedmonitors' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_maxredirectedmonitors' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_maxredirectedmonitors' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = 32
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_maxredirectedmonitors' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = '16'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_maxredirectedmonitors' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = '32'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_maxredirectedmonitors' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = '64'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_rdeasyprintdriverenabled' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_rdeasyprintdriverenabled' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_rdeasyprintdriverenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = 'true'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_rdeasyprintdriverenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = 'false'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_rdeasyprintdriverenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = 'True'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_rdeasyprintdriverenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = 'False'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_rdeasyprintdriverenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = :true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_rdeasyprintdriverenabled" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = :false
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_rdeasyprintdriverenabled' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_rdeasyprintdriverenabled' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_rdeasyprintdriverenabled] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_securitylayer' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_securitylayer] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_securitylayer' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_securitylayer] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_securitylayer' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_securitylayer] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_securitylayer' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_securitylayer] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_temporaryfoldersdeletedonexit' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_temporaryfoldersdeletedonexit' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_temporaryfoldersdeletedonexit" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = 'true'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_temporaryfoldersdeletedonexit" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = 'false'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_temporaryfoldersdeletedonexit" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = 'True'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_temporaryfoldersdeletedonexit" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = 'False'
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_temporaryfoldersdeletedonexit" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = :true
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_temporaryfoldersdeletedonexit" do
+    dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = :false
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_temporaryfoldersdeletedonexit' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_temporaryfoldersdeletedonexit' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_temporaryfoldersdeletedonexit] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_usergroup' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_usergroup] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_usergroup' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_usergroup] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_usergroup' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_usergroup] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_usergroup' do
+    expect{dsc_xrdsessioncollectionconfiguration[:dsc_usergroup] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xrdsessioncollectionconfiguration)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xrdsessioncollectionconfiguration)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xrdsessioncollectionconfiguration[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xrdsessioncollectionconfiguration[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xrdsessioncollectionconfiguration)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xrdsessioncollectionconfiguration)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xRDSessionCollectionConfiguration as $MSFT_xRDSessionCollectionConfiguration1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xRDSessionCollectionConfiguration/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xrdsessiondeployment_spec.rb
+++ b/spec/unit/puppet/type/dsc_xrdsessiondeployment_spec.rb
@@ -1,0 +1,153 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xrdsessiondeployment) do
+
+  let :dsc_xrdsessiondeployment do
+    Puppet::Type.type(:dsc_xrdsessiondeployment).new(
+      :name     => 'foo',
+      :dsc_sessionhost => 'foo',
+      :dsc_connectionbroker => 'foo',
+      :dsc_webaccessserver => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xrdsessiondeployment.to_s).to eq("Dsc_xrdsessiondeployment[foo]")
+  end
+
+  it 'should require that dsc_sessionhost is specified' do
+    #dsc_xrdsessiondeployment[:dsc_sessionhost]
+    expect { Puppet::Type.type(:dsc_xrdsessiondeployment).new(
+      :name     => 'foo',
+      :dsc_connectionbroker => 'foo',
+      :dsc_webaccessserver => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_sessionhost is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_sessionhost' do
+    expect{dsc_xrdsessiondeployment[:dsc_sessionhost] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sessionhost' do
+    expect{dsc_xrdsessiondeployment[:dsc_sessionhost] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sessionhost' do
+    expect{dsc_xrdsessiondeployment[:dsc_sessionhost] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sessionhost' do
+    expect{dsc_xrdsessiondeployment[:dsc_sessionhost] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_connectionbroker is specified' do
+    #dsc_xrdsessiondeployment[:dsc_connectionbroker]
+    expect { Puppet::Type.type(:dsc_xrdsessiondeployment).new(
+      :name     => 'foo',
+      :dsc_sessionhost => 'foo',
+      :dsc_webaccessserver => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_connectionbroker is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_connectionbroker' do
+    expect{dsc_xrdsessiondeployment[:dsc_connectionbroker] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_connectionbroker' do
+    expect{dsc_xrdsessiondeployment[:dsc_connectionbroker] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_connectionbroker' do
+    expect{dsc_xrdsessiondeployment[:dsc_connectionbroker] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_connectionbroker' do
+    expect{dsc_xrdsessiondeployment[:dsc_connectionbroker] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_webaccessserver is specified' do
+    #dsc_xrdsessiondeployment[:dsc_webaccessserver]
+    expect { Puppet::Type.type(:dsc_xrdsessiondeployment).new(
+      :name     => 'foo',
+      :dsc_sessionhost => 'foo',
+      :dsc_connectionbroker => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_webaccessserver is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_webaccessserver' do
+    expect{dsc_xrdsessiondeployment[:dsc_webaccessserver] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_webaccessserver' do
+    expect{dsc_xrdsessiondeployment[:dsc_webaccessserver] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_webaccessserver' do
+    expect{dsc_xrdsessiondeployment[:dsc_webaccessserver] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_webaccessserver' do
+    expect{dsc_xrdsessiondeployment[:dsc_webaccessserver] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xrdsessiondeployment)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xrdsessiondeployment)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xrdsessiondeployment[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xrdsessiondeployment[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xrdsessiondeployment)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xrdsessiondeployment)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xRDSessionDeployment as $MSFT_xRDSessionDeployment1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xRDSessionDeployment/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xremotedesktopadmin_spec.rb
+++ b/spec/unit/puppet/type/dsc_xremotedesktopadmin_spec.rb
@@ -1,0 +1,252 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xremotedesktopadmin) do
+
+  let :dsc_xremotedesktopadmin do
+    Puppet::Type.type(:dsc_xremotedesktopadmin).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xremotedesktopadmin.to_s).to eq("Dsc_xremotedesktopadmin[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xremotedesktopadmin[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_ensure is specified' do
+    #dsc_xremotedesktopadmin[:dsc_ensure]
+    expect { Puppet::Type.type(:dsc_xremotedesktopadmin).new(
+      :name     => 'foo',
+      :dsc_userauthentication => 'Secure',
+    )}.to raise_error(Puppet::Error, /dsc_ensure is a required attribute/)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xremotedesktopadmin[:dsc_ensure] = 'Present'
+    expect(dsc_xremotedesktopadmin[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xremotedesktopadmin[:dsc_ensure] = 'present'
+    expect(dsc_xremotedesktopadmin[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xremotedesktopadmin[:dsc_ensure] = 'present'
+    expect(dsc_xremotedesktopadmin[:ensure]).to eq(dsc_xremotedesktopadmin[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xremotedesktopadmin[:dsc_ensure] = 'Absent'
+    expect(dsc_xremotedesktopadmin[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xremotedesktopadmin[:dsc_ensure] = 'absent'
+    expect(dsc_xremotedesktopadmin[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xremotedesktopadmin[:dsc_ensure] = 'absent'
+    expect(dsc_xremotedesktopadmin[:ensure]).to eq(dsc_xremotedesktopadmin[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xremotedesktopadmin[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xremotedesktopadmin[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xremotedesktopadmin[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xremotedesktopadmin[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xremotedesktopadmin[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_userauthentication predefined value Secure' do
+    dsc_xremotedesktopadmin[:dsc_userauthentication] = 'Secure'
+    expect(dsc_xremotedesktopadmin[:dsc_userauthentication]).to eq('Secure')
+  end
+
+  it 'should accept dsc_userauthentication predefined value secure' do
+    dsc_xremotedesktopadmin[:dsc_userauthentication] = 'secure'
+    expect(dsc_xremotedesktopadmin[:dsc_userauthentication]).to eq('secure')
+  end
+
+  it 'should accept dsc_userauthentication predefined value NonSecure' do
+    dsc_xremotedesktopadmin[:dsc_userauthentication] = 'NonSecure'
+    expect(dsc_xremotedesktopadmin[:dsc_userauthentication]).to eq('NonSecure')
+  end
+
+  it 'should accept dsc_userauthentication predefined value nonsecure' do
+    dsc_xremotedesktopadmin[:dsc_userauthentication] = 'nonsecure'
+    expect(dsc_xremotedesktopadmin[:dsc_userauthentication]).to eq('nonsecure')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xremotedesktopadmin[:dsc_userauthentication] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_userauthentication' do
+    expect{dsc_xremotedesktopadmin[:dsc_userauthentication] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_userauthentication' do
+    expect{dsc_xremotedesktopadmin[:dsc_userauthentication] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_userauthentication' do
+    expect{dsc_xremotedesktopadmin[:dsc_userauthentication] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_userauthentication' do
+    expect{dsc_xremotedesktopadmin[:dsc_userauthentication] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xremotedesktopadmin)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xremotedesktopadmin)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xremotedesktopadmin[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xremotedesktopadmin[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xremotedesktopadmin.original_parameters[:dsc_ensure] = 'present'
+        dsc_xremotedesktopadmin[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xremotedesktopadmin)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xremotedesktopadmin[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xremotedesktopadmin.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xremotedesktopadmin[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xremotedesktopadmin)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xremotedesktopadmin[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xremotedesktopadmin)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xremotedesktopadmin)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xRemoteDesktopAdmin as $MSFT_xRemoteDesktopAdmin1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xRemoteDesktopAdmin/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xremotedesktopadmin[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xremotedesktopadmin)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xremotedesktopadmin[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xremotedesktopadmin[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xremotedesktopadmin)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xremotedesktopadmin[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xremotefile_spec.rb
+++ b/spec/unit/puppet/type/dsc_xremotefile_spec.rb
@@ -1,0 +1,297 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xremotefile) do
+
+  let :dsc_xremotefile do
+    Puppet::Type.type(:dsc_xremotefile).new(
+      :name     => 'foo',
+      :dsc_destinationpath => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xremotefile.to_s).to eq("Dsc_xremotefile[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xremotefile[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_destinationpath is specified' do
+    #dsc_xremotefile[:dsc_destinationpath]
+    expect { Puppet::Type.type(:dsc_xremotefile).new(
+      :name     => 'foo',
+      :dsc_uri => 'foo',
+      :dsc_useragent => 'foo',
+      :dsc_headers => ["foo", "bar", "spec"],
+      :dsc_credential => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_destinationpath is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_destinationpath' do
+    expect{dsc_xremotefile[:dsc_destinationpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_destinationpath' do
+    expect{dsc_xremotefile[:dsc_destinationpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_destinationpath' do
+    expect{dsc_xremotefile[:dsc_destinationpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_destinationpath' do
+    expect{dsc_xremotefile[:dsc_destinationpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_uri' do
+    expect{dsc_xremotefile[:dsc_uri] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_uri' do
+    expect{dsc_xremotefile[:dsc_uri] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_uri' do
+    expect{dsc_xremotefile[:dsc_uri] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_uri' do
+    expect{dsc_xremotefile[:dsc_uri] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_useragent' do
+    expect{dsc_xremotefile[:dsc_useragent] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_useragent' do
+    expect{dsc_xremotefile[:dsc_useragent] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_useragent' do
+    expect{dsc_xremotefile[:dsc_useragent] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_useragent' do
+    expect{dsc_xremotefile[:dsc_useragent] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_headers' do
+    dsc_xremotefile[:dsc_headers] = ["foo", "bar", "spec"]
+    expect(dsc_xremotefile[:dsc_headers]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_headers' do
+    expect{dsc_xremotefile[:dsc_headers] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_headers' do
+    expect{dsc_xremotefile[:dsc_headers] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_headers' do
+    expect{dsc_xremotefile[:dsc_headers] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_xremotefile[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_xremotefile[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_xremotefile[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_xremotefile[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xremotefile[:dsc_ensure] = 'Present'
+    expect(dsc_xremotefile[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xremotefile[:dsc_ensure] = 'present'
+    expect(dsc_xremotefile[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xremotefile[:dsc_ensure] = 'present'
+    expect(dsc_xremotefile[:ensure]).to eq(dsc_xremotefile[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xremotefile[:dsc_ensure] = 'Absent'
+    expect(dsc_xremotefile[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xremotefile[:dsc_ensure] = 'absent'
+    expect(dsc_xremotefile[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xremotefile[:dsc_ensure] = 'absent'
+    expect(dsc_xremotefile[:ensure]).to eq(dsc_xremotefile[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xremotefile[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xremotefile[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xremotefile[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xremotefile[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xremotefile[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xremotefile)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xremotefile)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xremotefile[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xremotefile[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xremotefile.original_parameters[:dsc_ensure] = 'present'
+        dsc_xremotefile[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xremotefile)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xremotefile[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xremotefile.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xremotefile[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xremotefile)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xremotefile[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xremotefile)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xremotefile)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xRemoteFile as $MSFT_xRemoteFile1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xRemoteFile/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xremotefile[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xremotefile)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xremotefile[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xremotefile[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xremotefile)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xremotefile[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xservice_spec.rb
@@ -1,0 +1,474 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xservice) do
+
+  let :dsc_xservice do
+    Puppet::Type.type(:dsc_xservice).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xservice.to_s).to eq("Dsc_xservice[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xservice[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xservice[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xservice).new(
+      :name     => 'foo',
+      :dsc_state => 'Running',
+      :dsc_startuptype => 'Automatic',
+      :dsc_builtinaccount => 'LocalSystem',
+      :dsc_credential => 'foo',
+      :dsc_status => 'foo',
+      :dsc_displayname => 'foo',
+      :dsc_description => 'foo',
+      :dsc_path => 'foo',
+      :dsc_dependencies => ["foo", "bar", "spec"],
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xservice[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xservice[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xservice[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xservice[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_state predefined value Running' do
+    dsc_xservice[:dsc_state] = 'Running'
+    expect(dsc_xservice[:dsc_state]).to eq('Running')
+  end
+
+  it 'should accept dsc_state predefined value running' do
+    dsc_xservice[:dsc_state] = 'running'
+    expect(dsc_xservice[:dsc_state]).to eq('running')
+  end
+
+  it 'should accept dsc_state predefined value Stopped' do
+    dsc_xservice[:dsc_state] = 'Stopped'
+    expect(dsc_xservice[:dsc_state]).to eq('Stopped')
+  end
+
+  it 'should accept dsc_state predefined value stopped' do
+    dsc_xservice[:dsc_state] = 'stopped'
+    expect(dsc_xservice[:dsc_state]).to eq('stopped')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xservice[:dsc_state] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_state' do
+    expect{dsc_xservice[:dsc_state] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_state' do
+    expect{dsc_xservice[:dsc_state] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_state' do
+    expect{dsc_xservice[:dsc_state] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_state' do
+    expect{dsc_xservice[:dsc_state] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_startuptype predefined value Automatic' do
+    dsc_xservice[:dsc_startuptype] = 'Automatic'
+    expect(dsc_xservice[:dsc_startuptype]).to eq('Automatic')
+  end
+
+  it 'should accept dsc_startuptype predefined value automatic' do
+    dsc_xservice[:dsc_startuptype] = 'automatic'
+    expect(dsc_xservice[:dsc_startuptype]).to eq('automatic')
+  end
+
+  it 'should accept dsc_startuptype predefined value Manual' do
+    dsc_xservice[:dsc_startuptype] = 'Manual'
+    expect(dsc_xservice[:dsc_startuptype]).to eq('Manual')
+  end
+
+  it 'should accept dsc_startuptype predefined value manual' do
+    dsc_xservice[:dsc_startuptype] = 'manual'
+    expect(dsc_xservice[:dsc_startuptype]).to eq('manual')
+  end
+
+  it 'should accept dsc_startuptype predefined value Disabled' do
+    dsc_xservice[:dsc_startuptype] = 'Disabled'
+    expect(dsc_xservice[:dsc_startuptype]).to eq('Disabled')
+  end
+
+  it 'should accept dsc_startuptype predefined value disabled' do
+    dsc_xservice[:dsc_startuptype] = 'disabled'
+    expect(dsc_xservice[:dsc_startuptype]).to eq('disabled')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xservice[:dsc_startuptype] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_startuptype' do
+    expect{dsc_xservice[:dsc_startuptype] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_startuptype' do
+    expect{dsc_xservice[:dsc_startuptype] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_startuptype' do
+    expect{dsc_xservice[:dsc_startuptype] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_startuptype' do
+    expect{dsc_xservice[:dsc_startuptype] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_builtinaccount predefined value LocalSystem' do
+    dsc_xservice[:dsc_builtinaccount] = 'LocalSystem'
+    expect(dsc_xservice[:dsc_builtinaccount]).to eq('LocalSystem')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value localsystem' do
+    dsc_xservice[:dsc_builtinaccount] = 'localsystem'
+    expect(dsc_xservice[:dsc_builtinaccount]).to eq('localsystem')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value LocalService' do
+    dsc_xservice[:dsc_builtinaccount] = 'LocalService'
+    expect(dsc_xservice[:dsc_builtinaccount]).to eq('LocalService')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value localservice' do
+    dsc_xservice[:dsc_builtinaccount] = 'localservice'
+    expect(dsc_xservice[:dsc_builtinaccount]).to eq('localservice')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value NetworkService' do
+    dsc_xservice[:dsc_builtinaccount] = 'NetworkService'
+    expect(dsc_xservice[:dsc_builtinaccount]).to eq('NetworkService')
+  end
+
+  it 'should accept dsc_builtinaccount predefined value networkservice' do
+    dsc_xservice[:dsc_builtinaccount] = 'networkservice'
+    expect(dsc_xservice[:dsc_builtinaccount]).to eq('networkservice')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xservice[:dsc_builtinaccount] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_builtinaccount' do
+    expect{dsc_xservice[:dsc_builtinaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_builtinaccount' do
+    expect{dsc_xservice[:dsc_builtinaccount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_builtinaccount' do
+    expect{dsc_xservice[:dsc_builtinaccount] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_builtinaccount' do
+    expect{dsc_xservice[:dsc_builtinaccount] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_xservice[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_xservice[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_xservice[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_xservice[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_status' do
+    expect{dsc_xservice[:dsc_status] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_status' do
+    expect{dsc_xservice[:dsc_status] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_status' do
+    expect{dsc_xservice[:dsc_status] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_status' do
+    expect{dsc_xservice[:dsc_status] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_displayname' do
+    expect{dsc_xservice[:dsc_displayname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_displayname' do
+    expect{dsc_xservice[:dsc_displayname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_displayname' do
+    expect{dsc_xservice[:dsc_displayname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_displayname' do
+    expect{dsc_xservice[:dsc_displayname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_xservice[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_xservice[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_xservice[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_xservice[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_xservice[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xservice[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xservice[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xservice[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_dependencies' do
+    dsc_xservice[:dsc_dependencies] = ["foo", "bar", "spec"]
+    expect(dsc_xservice[:dsc_dependencies]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_dependencies' do
+    expect{dsc_xservice[:dsc_dependencies] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_dependencies' do
+    expect{dsc_xservice[:dsc_dependencies] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_dependencies' do
+    expect{dsc_xservice[:dsc_dependencies] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xservice[:dsc_ensure] = 'Present'
+    expect(dsc_xservice[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xservice[:dsc_ensure] = 'present'
+    expect(dsc_xservice[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xservice[:dsc_ensure] = 'present'
+    expect(dsc_xservice[:ensure]).to eq(dsc_xservice[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xservice[:dsc_ensure] = 'Absent'
+    expect(dsc_xservice[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xservice[:dsc_ensure] = 'absent'
+    expect(dsc_xservice[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xservice[:dsc_ensure] = 'absent'
+    expect(dsc_xservice[:ensure]).to eq(dsc_xservice[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xservice[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xservice[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xservice[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xservice[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xservice[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xservice)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xservice)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xservice[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xservice[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xservice.original_parameters[:dsc_ensure] = 'present'
+        dsc_xservice[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xservice)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xservice[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xservice.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xservice)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xservice[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xservice)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xservice)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xServiceResource as $MSFT_xServiceResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xServiceResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xservice[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xservice)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xservice[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xservice)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xservice[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xsmbshare_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsmbshare_spec.rb
@@ -1,0 +1,527 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xsmbshare) do
+
+  let :dsc_xsmbshare do
+    Puppet::Type.type(:dsc_xsmbshare).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xsmbshare.to_s).to eq("Dsc_xsmbshare[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xsmbshare[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xsmbshare[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xsmbshare).new(
+      :name     => 'foo',
+      :dsc_path => 'foo',
+      :dsc_description => 'foo',
+      :dsc_changeaccess => ["foo", "bar", "spec"],
+      :dsc_concurrentuserlimit => 32,
+      :dsc_encryptdata => true,
+      :dsc_folderenumerationmode => 'AccessBased',
+      :dsc_fullaccess => ["foo", "bar", "spec"],
+      :dsc_noaccess => ["foo", "bar", "spec"],
+      :dsc_readaccess => ["foo", "bar", "spec"],
+      :dsc_ensure => 'Present',
+      :dsc_sharestate => 'foo',
+      :dsc_sharetype => 'foo',
+      :dsc_shadowcopy => 'foo',
+      :dsc_special => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xsmbshare[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xsmbshare[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xsmbshare[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xsmbshare[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_xsmbshare[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xsmbshare[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xsmbshare[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xsmbshare[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_xsmbshare[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_xsmbshare[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_xsmbshare[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_xsmbshare[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_changeaccess' do
+    dsc_xsmbshare[:dsc_changeaccess] = ["foo", "bar", "spec"]
+    expect(dsc_xsmbshare[:dsc_changeaccess]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_changeaccess' do
+    expect{dsc_xsmbshare[:dsc_changeaccess] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_changeaccess' do
+    expect{dsc_xsmbshare[:dsc_changeaccess] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_changeaccess' do
+    expect{dsc_xsmbshare[:dsc_changeaccess] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_concurrentuserlimit' do
+    expect{dsc_xsmbshare[:dsc_concurrentuserlimit] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_concurrentuserlimit' do
+    expect{dsc_xsmbshare[:dsc_concurrentuserlimit] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_concurrentuserlimit' do
+    expect{dsc_xsmbshare[:dsc_concurrentuserlimit] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_concurrentuserlimit' do
+    dsc_xsmbshare[:dsc_concurrentuserlimit] = 32
+    expect(dsc_xsmbshare[:dsc_concurrentuserlimit]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_concurrentuserlimit' do
+    dsc_xsmbshare[:dsc_concurrentuserlimit] = '16'
+    expect(dsc_xsmbshare[:dsc_concurrentuserlimit]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_concurrentuserlimit' do
+    dsc_xsmbshare[:dsc_concurrentuserlimit] = '32'
+    expect(dsc_xsmbshare[:dsc_concurrentuserlimit]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_concurrentuserlimit' do
+    dsc_xsmbshare[:dsc_concurrentuserlimit] = '64'
+    expect(dsc_xsmbshare[:dsc_concurrentuserlimit]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_encryptdata' do
+    expect{dsc_xsmbshare[:dsc_encryptdata] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_encryptdata' do
+    dsc_xsmbshare[:dsc_encryptdata] = true
+    expect(dsc_xsmbshare[:dsc_encryptdata]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_encryptdata" do
+    dsc_xsmbshare[:dsc_encryptdata] = 'true'
+    expect(dsc_xsmbshare[:dsc_encryptdata]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_encryptdata" do
+    dsc_xsmbshare[:dsc_encryptdata] = 'false'
+    expect(dsc_xsmbshare[:dsc_encryptdata]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_encryptdata" do
+    dsc_xsmbshare[:dsc_encryptdata] = 'True'
+    expect(dsc_xsmbshare[:dsc_encryptdata]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_encryptdata" do
+    dsc_xsmbshare[:dsc_encryptdata] = 'False'
+    expect(dsc_xsmbshare[:dsc_encryptdata]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_encryptdata" do
+    dsc_xsmbshare[:dsc_encryptdata] = :true
+    expect(dsc_xsmbshare[:dsc_encryptdata]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_encryptdata" do
+    dsc_xsmbshare[:dsc_encryptdata] = :false
+    expect(dsc_xsmbshare[:dsc_encryptdata]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_encryptdata' do
+    expect{dsc_xsmbshare[:dsc_encryptdata] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_encryptdata' do
+    expect{dsc_xsmbshare[:dsc_encryptdata] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_folderenumerationmode predefined value AccessBased' do
+    dsc_xsmbshare[:dsc_folderenumerationmode] = 'AccessBased'
+    expect(dsc_xsmbshare[:dsc_folderenumerationmode]).to eq('AccessBased')
+  end
+
+  it 'should accept dsc_folderenumerationmode predefined value accessbased' do
+    dsc_xsmbshare[:dsc_folderenumerationmode] = 'accessbased'
+    expect(dsc_xsmbshare[:dsc_folderenumerationmode]).to eq('accessbased')
+  end
+
+  it 'should accept dsc_folderenumerationmode predefined value Unrestricted' do
+    dsc_xsmbshare[:dsc_folderenumerationmode] = 'Unrestricted'
+    expect(dsc_xsmbshare[:dsc_folderenumerationmode]).to eq('Unrestricted')
+  end
+
+  it 'should accept dsc_folderenumerationmode predefined value unrestricted' do
+    dsc_xsmbshare[:dsc_folderenumerationmode] = 'unrestricted'
+    expect(dsc_xsmbshare[:dsc_folderenumerationmode]).to eq('unrestricted')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xsmbshare[:dsc_folderenumerationmode] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_folderenumerationmode' do
+    expect{dsc_xsmbshare[:dsc_folderenumerationmode] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_folderenumerationmode' do
+    expect{dsc_xsmbshare[:dsc_folderenumerationmode] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_folderenumerationmode' do
+    expect{dsc_xsmbshare[:dsc_folderenumerationmode] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_folderenumerationmode' do
+    expect{dsc_xsmbshare[:dsc_folderenumerationmode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_fullaccess' do
+    dsc_xsmbshare[:dsc_fullaccess] = ["foo", "bar", "spec"]
+    expect(dsc_xsmbshare[:dsc_fullaccess]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_fullaccess' do
+    expect{dsc_xsmbshare[:dsc_fullaccess] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_fullaccess' do
+    expect{dsc_xsmbshare[:dsc_fullaccess] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_fullaccess' do
+    expect{dsc_xsmbshare[:dsc_fullaccess] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_noaccess' do
+    dsc_xsmbshare[:dsc_noaccess] = ["foo", "bar", "spec"]
+    expect(dsc_xsmbshare[:dsc_noaccess]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_noaccess' do
+    expect{dsc_xsmbshare[:dsc_noaccess] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_noaccess' do
+    expect{dsc_xsmbshare[:dsc_noaccess] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_noaccess' do
+    expect{dsc_xsmbshare[:dsc_noaccess] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_readaccess' do
+    dsc_xsmbshare[:dsc_readaccess] = ["foo", "bar", "spec"]
+    expect(dsc_xsmbshare[:dsc_readaccess]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_readaccess' do
+    expect{dsc_xsmbshare[:dsc_readaccess] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_readaccess' do
+    expect{dsc_xsmbshare[:dsc_readaccess] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_readaccess' do
+    expect{dsc_xsmbshare[:dsc_readaccess] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xsmbshare[:dsc_ensure] = 'Present'
+    expect(dsc_xsmbshare[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xsmbshare[:dsc_ensure] = 'present'
+    expect(dsc_xsmbshare[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xsmbshare[:dsc_ensure] = 'present'
+    expect(dsc_xsmbshare[:ensure]).to eq(dsc_xsmbshare[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xsmbshare[:dsc_ensure] = 'Absent'
+    expect(dsc_xsmbshare[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xsmbshare[:dsc_ensure] = 'absent'
+    expect(dsc_xsmbshare[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xsmbshare[:dsc_ensure] = 'absent'
+    expect(dsc_xsmbshare[:ensure]).to eq(dsc_xsmbshare[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xsmbshare[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xsmbshare[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xsmbshare[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xsmbshare[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xsmbshare[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sharestate' do
+    expect{dsc_xsmbshare[:dsc_sharestate] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sharestate' do
+    expect{dsc_xsmbshare[:dsc_sharestate] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sharestate' do
+    expect{dsc_xsmbshare[:dsc_sharestate] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sharestate' do
+    expect{dsc_xsmbshare[:dsc_sharestate] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sharetype' do
+    expect{dsc_xsmbshare[:dsc_sharetype] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sharetype' do
+    expect{dsc_xsmbshare[:dsc_sharetype] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sharetype' do
+    expect{dsc_xsmbshare[:dsc_sharetype] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sharetype' do
+    expect{dsc_xsmbshare[:dsc_sharetype] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_shadowcopy' do
+    expect{dsc_xsmbshare[:dsc_shadowcopy] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_shadowcopy' do
+    expect{dsc_xsmbshare[:dsc_shadowcopy] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_shadowcopy' do
+    expect{dsc_xsmbshare[:dsc_shadowcopy] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_shadowcopy' do
+    expect{dsc_xsmbshare[:dsc_shadowcopy] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_special' do
+    expect{dsc_xsmbshare[:dsc_special] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_special' do
+    expect{dsc_xsmbshare[:dsc_special] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_special' do
+    expect{dsc_xsmbshare[:dsc_special] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_special' do
+    expect{dsc_xsmbshare[:dsc_special] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xsmbshare)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xsmbshare)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xsmbshare[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xsmbshare[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xsmbshare.original_parameters[:dsc_ensure] = 'present'
+        dsc_xsmbshare[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xsmbshare)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xsmbshare[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xsmbshare.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xsmbshare[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xsmbshare)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xsmbshare[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xsmbshare)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xsmbshare)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xSmbShare as $MSFT_xSmbShare1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xSmbShare/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xsmbshare[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xsmbshare)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xsmbshare[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xsmbshare[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xsmbshare)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xsmbshare[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xsqlhaendpoint_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlhaendpoint_spec.rb
@@ -1,0 +1,180 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xsqlhaendpoint) do
+
+  let :dsc_xsqlhaendpoint do
+    Puppet::Type.type(:dsc_xsqlhaendpoint).new(
+      :name     => 'foo',
+      :dsc_instancename => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xsqlhaendpoint.to_s).to eq("Dsc_xsqlhaendpoint[foo]")
+  end
+
+  it 'should require that dsc_instancename is specified' do
+    #dsc_xsqlhaendpoint[:dsc_instancename]
+    expect { Puppet::Type.type(:dsc_xsqlhaendpoint).new(
+      :name     => 'foo',
+      :dsc_alloweduser => 'foo',
+      :dsc_name => 'foo',
+      :dsc_portnumber => 32,
+    )}.to raise_error(Puppet::Error, /dsc_instancename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_instancename' do
+    expect{dsc_xsqlhaendpoint[:dsc_instancename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_instancename' do
+    expect{dsc_xsqlhaendpoint[:dsc_instancename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_instancename' do
+    expect{dsc_xsqlhaendpoint[:dsc_instancename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_instancename' do
+    expect{dsc_xsqlhaendpoint[:dsc_instancename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_alloweduser' do
+    expect{dsc_xsqlhaendpoint[:dsc_alloweduser] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_alloweduser' do
+    expect{dsc_xsqlhaendpoint[:dsc_alloweduser] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_alloweduser' do
+    expect{dsc_xsqlhaendpoint[:dsc_alloweduser] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_alloweduser' do
+    expect{dsc_xsqlhaendpoint[:dsc_alloweduser] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xsqlhaendpoint[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xsqlhaendpoint).new(
+      :name     => 'foo',
+      :dsc_instancename => 'foo',
+      :dsc_alloweduser => 'foo',
+      :dsc_portnumber => 32,
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xsqlhaendpoint[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xsqlhaendpoint[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xsqlhaendpoint[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xsqlhaendpoint[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_portnumber' do
+    expect{dsc_xsqlhaendpoint[:dsc_portnumber] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_portnumber' do
+    expect{dsc_xsqlhaendpoint[:dsc_portnumber] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_portnumber' do
+    expect{dsc_xsqlhaendpoint[:dsc_portnumber] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_portnumber' do
+    dsc_xsqlhaendpoint[:dsc_portnumber] = 32
+    expect(dsc_xsqlhaendpoint[:dsc_portnumber]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_portnumber' do
+    dsc_xsqlhaendpoint[:dsc_portnumber] = '16'
+    expect(dsc_xsqlhaendpoint[:dsc_portnumber]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_portnumber' do
+    dsc_xsqlhaendpoint[:dsc_portnumber] = '32'
+    expect(dsc_xsqlhaendpoint[:dsc_portnumber]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_portnumber' do
+    dsc_xsqlhaendpoint[:dsc_portnumber] = '64'
+    expect(dsc_xsqlhaendpoint[:dsc_portnumber]).to eq(64)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xsqlhaendpoint)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xsqlhaendpoint)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xsqlhaendpoint[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xsqlhaendpoint[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xsqlhaendpoint)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xsqlhaendpoint)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xSqlHAEndPoint as $MSFT_xSqlHAEndPoint1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xSqlHAEndPoint/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xsqlhagroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlhagroup_spec.rb
@@ -1,0 +1,219 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xsqlhagroup) do
+
+  let :dsc_xsqlhagroup do
+    Puppet::Type.type(:dsc_xsqlhagroup).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xsqlhagroup.to_s).to eq("Dsc_xsqlhagroup[foo]")
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xsqlhagroup[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xsqlhagroup).new(
+      :name     => 'foo',
+      :dsc_database => ["foo", "bar", "spec"],
+      :dsc_clustername => 'foo',
+      :dsc_databasebackuppath => 'foo',
+      :dsc_instancename => 'foo',
+      :dsc_endpointname => 'foo',
+      :dsc_domaincredential => 'foo',
+      :dsc_sqladministratorcredential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xsqlhagroup[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xsqlhagroup[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xsqlhagroup[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xsqlhagroup[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_database' do
+    dsc_xsqlhagroup[:dsc_database] = ["foo", "bar", "spec"]
+    expect(dsc_xsqlhagroup[:dsc_database]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_database' do
+    expect{dsc_xsqlhagroup[:dsc_database] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_database' do
+    expect{dsc_xsqlhagroup[:dsc_database] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_database' do
+    expect{dsc_xsqlhagroup[:dsc_database] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_clustername' do
+    expect{dsc_xsqlhagroup[:dsc_clustername] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_clustername' do
+    expect{dsc_xsqlhagroup[:dsc_clustername] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_clustername' do
+    expect{dsc_xsqlhagroup[:dsc_clustername] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_clustername' do
+    expect{dsc_xsqlhagroup[:dsc_clustername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_databasebackuppath' do
+    expect{dsc_xsqlhagroup[:dsc_databasebackuppath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_databasebackuppath' do
+    expect{dsc_xsqlhagroup[:dsc_databasebackuppath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_databasebackuppath' do
+    expect{dsc_xsqlhagroup[:dsc_databasebackuppath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_databasebackuppath' do
+    expect{dsc_xsqlhagroup[:dsc_databasebackuppath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_instancename' do
+    expect{dsc_xsqlhagroup[:dsc_instancename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_instancename' do
+    expect{dsc_xsqlhagroup[:dsc_instancename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_instancename' do
+    expect{dsc_xsqlhagroup[:dsc_instancename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_instancename' do
+    expect{dsc_xsqlhagroup[:dsc_instancename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_endpointname' do
+    expect{dsc_xsqlhagroup[:dsc_endpointname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_endpointname' do
+    expect{dsc_xsqlhagroup[:dsc_endpointname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_endpointname' do
+    expect{dsc_xsqlhagroup[:dsc_endpointname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_endpointname' do
+    expect{dsc_xsqlhagroup[:dsc_endpointname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_domaincredential' do
+    expect{dsc_xsqlhagroup[:dsc_domaincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domaincredential' do
+    expect{dsc_xsqlhagroup[:dsc_domaincredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domaincredential' do
+    expect{dsc_xsqlhagroup[:dsc_domaincredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domaincredential' do
+    expect{dsc_xsqlhagroup[:dsc_domaincredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlhagroup[:dsc_sqladministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlhagroup[:dsc_sqladministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlhagroup[:dsc_sqladministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlhagroup[:dsc_sqladministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xsqlhagroup)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xsqlhagroup)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xsqlhagroup[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xsqlhagroup[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xsqlhagroup)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xsqlhagroup)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xSqlHAGroup as $MSFT_xSqlHAGroup1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xSqlHAGroup/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xsqlhaservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlhaservice_spec.rb
@@ -1,0 +1,133 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xsqlhaservice) do
+
+  let :dsc_xsqlhaservice do
+    Puppet::Type.type(:dsc_xsqlhaservice).new(
+      :name     => 'foo',
+      :dsc_instancename => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xsqlhaservice.to_s).to eq("Dsc_xsqlhaservice[foo]")
+  end
+
+  it 'should require that dsc_instancename is specified' do
+    #dsc_xsqlhaservice[:dsc_instancename]
+    expect { Puppet::Type.type(:dsc_xsqlhaservice).new(
+      :name     => 'foo',
+      :dsc_sqladministratorcredential => 'foo',
+      :dsc_servicecredential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_instancename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_instancename' do
+    expect{dsc_xsqlhaservice[:dsc_instancename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_instancename' do
+    expect{dsc_xsqlhaservice[:dsc_instancename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_instancename' do
+    expect{dsc_xsqlhaservice[:dsc_instancename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_instancename' do
+    expect{dsc_xsqlhaservice[:dsc_instancename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlhaservice[:dsc_sqladministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlhaservice[:dsc_sqladministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlhaservice[:dsc_sqladministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlhaservice[:dsc_sqladministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_servicecredential' do
+    expect{dsc_xsqlhaservice[:dsc_servicecredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_servicecredential' do
+    expect{dsc_xsqlhaservice[:dsc_servicecredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_servicecredential' do
+    expect{dsc_xsqlhaservice[:dsc_servicecredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_servicecredential' do
+    expect{dsc_xsqlhaservice[:dsc_servicecredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xsqlhaservice)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xsqlhaservice)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xsqlhaservice[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xsqlhaservice[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xsqlhaservice)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xsqlhaservice)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xSqlHAService as $MSFT_xSqlHAService1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xSqlHAService/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xsqlserverinstall_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlserverinstall_spec.rb
@@ -1,0 +1,266 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xsqlserverinstall) do
+
+  let :dsc_xsqlserverinstall do
+    Puppet::Type.type(:dsc_xsqlserverinstall).new(
+      :name     => 'foo',
+      :dsc_instancename => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xsqlserverinstall.to_s).to eq("Dsc_xsqlserverinstall[foo]")
+  end
+
+  it 'should require that dsc_instancename is specified' do
+    #dsc_xsqlserverinstall[:dsc_instancename]
+    expect { Puppet::Type.type(:dsc_xsqlserverinstall).new(
+      :name     => 'foo',
+      :dsc_sourcepath => 'foo',
+      :dsc_sourcepathcredential => 'foo',
+      :dsc_features => 'foo',
+      :dsc_sqladministratorcredential => 'foo',
+      :dsc_updateenabled => true,
+      :dsc_svcaccount => 'foo',
+      :dsc_sysadminaccounts => 'foo',
+      :dsc_agentsvcaccount => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_instancename is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_instancename' do
+    expect{dsc_xsqlserverinstall[:dsc_instancename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_instancename' do
+    expect{dsc_xsqlserverinstall[:dsc_instancename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_instancename' do
+    expect{dsc_xsqlserverinstall[:dsc_instancename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_instancename' do
+    expect{dsc_xsqlserverinstall[:dsc_instancename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sourcepath' do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sourcepath' do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sourcepath' do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sourcepath' do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sourcepathcredential' do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepathcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sourcepathcredential' do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepathcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sourcepathcredential' do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepathcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sourcepathcredential' do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepathcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_features' do
+    expect{dsc_xsqlserverinstall[:dsc_features] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_features' do
+    expect{dsc_xsqlserverinstall[:dsc_features] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_features' do
+    expect{dsc_xsqlserverinstall[:dsc_features] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_features' do
+    expect{dsc_xsqlserverinstall[:dsc_features] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlserverinstall[:dsc_sqladministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlserverinstall[:dsc_sqladministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlserverinstall[:dsc_sqladministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sqladministratorcredential' do
+    expect{dsc_xsqlserverinstall[:dsc_sqladministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_updateenabled' do
+    expect{dsc_xsqlserverinstall[:dsc_updateenabled] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_updateenabled' do
+    dsc_xsqlserverinstall[:dsc_updateenabled] = true
+    expect(dsc_xsqlserverinstall[:dsc_updateenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_updateenabled" do
+    dsc_xsqlserverinstall[:dsc_updateenabled] = 'true'
+    expect(dsc_xsqlserverinstall[:dsc_updateenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_updateenabled" do
+    dsc_xsqlserverinstall[:dsc_updateenabled] = 'false'
+    expect(dsc_xsqlserverinstall[:dsc_updateenabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_updateenabled" do
+    dsc_xsqlserverinstall[:dsc_updateenabled] = 'True'
+    expect(dsc_xsqlserverinstall[:dsc_updateenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_updateenabled" do
+    dsc_xsqlserverinstall[:dsc_updateenabled] = 'False'
+    expect(dsc_xsqlserverinstall[:dsc_updateenabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_updateenabled" do
+    dsc_xsqlserverinstall[:dsc_updateenabled] = :true
+    expect(dsc_xsqlserverinstall[:dsc_updateenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_updateenabled" do
+    dsc_xsqlserverinstall[:dsc_updateenabled] = :false
+    expect(dsc_xsqlserverinstall[:dsc_updateenabled]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_updateenabled' do
+    expect{dsc_xsqlserverinstall[:dsc_updateenabled] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_updateenabled' do
+    expect{dsc_xsqlserverinstall[:dsc_updateenabled] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_svcaccount' do
+    expect{dsc_xsqlserverinstall[:dsc_svcaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_svcaccount' do
+    expect{dsc_xsqlserverinstall[:dsc_svcaccount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_svcaccount' do
+    expect{dsc_xsqlserverinstall[:dsc_svcaccount] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_svcaccount' do
+    expect{dsc_xsqlserverinstall[:dsc_svcaccount] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sysadminaccounts' do
+    expect{dsc_xsqlserverinstall[:dsc_sysadminaccounts] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sysadminaccounts' do
+    expect{dsc_xsqlserverinstall[:dsc_sysadminaccounts] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sysadminaccounts' do
+    expect{dsc_xsqlserverinstall[:dsc_sysadminaccounts] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sysadminaccounts' do
+    expect{dsc_xsqlserverinstall[:dsc_sysadminaccounts] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_agentsvcaccount' do
+    expect{dsc_xsqlserverinstall[:dsc_agentsvcaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_agentsvcaccount' do
+    expect{dsc_xsqlserverinstall[:dsc_agentsvcaccount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_agentsvcaccount' do
+    expect{dsc_xsqlserverinstall[:dsc_agentsvcaccount] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_agentsvcaccount' do
+    expect{dsc_xsqlserverinstall[:dsc_agentsvcaccount] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xsqlserverinstall)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xsqlserverinstall)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xsqlserverinstall[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xsqlserverinstall[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xsqlserverinstall)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xsqlserverinstall)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xSqlServerInstall as $MSFT_xSqlServerInstall1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xSqlServerInstall/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xvhd_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvhd_spec.rb
@@ -1,0 +1,474 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xvhd) do
+
+  let :dsc_xvhd do
+    Puppet::Type.type(:dsc_xvhd).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_path => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xvhd.to_s).to eq("Dsc_xvhd[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xvhd[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xvhd[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xvhd).new(
+      :name     => 'foo',
+      :dsc_path => 'foo',
+      :dsc_parentpath => 'foo',
+      :dsc_maximumsizebytes => 64,
+      :dsc_generation => 'Vhd',
+      :dsc_ensure => 'Present',
+      :dsc_id => 'foo',
+      :dsc_type => 'foo',
+      :dsc_filesizebytes => 64,
+      :dsc_isattached => true,
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xvhd[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xvhd[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xvhd[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xvhd[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_path is specified' do
+    #dsc_xvhd[:dsc_path]
+    expect { Puppet::Type.type(:dsc_xvhd).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_parentpath => 'foo',
+      :dsc_maximumsizebytes => 64,
+      :dsc_generation => 'Vhd',
+      :dsc_ensure => 'Present',
+      :dsc_id => 'foo',
+      :dsc_type => 'foo',
+      :dsc_filesizebytes => 64,
+      :dsc_isattached => true,
+    )}.to raise_error(Puppet::Error, /dsc_path is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_xvhd[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xvhd[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xvhd[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xvhd[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_parentpath' do
+    expect{dsc_xvhd[:dsc_parentpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_parentpath' do
+    expect{dsc_xvhd[:dsc_parentpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_parentpath' do
+    expect{dsc_xvhd[:dsc_parentpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_parentpath' do
+    expect{dsc_xvhd[:dsc_parentpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_maximumsizebytes' do
+    expect{dsc_xvhd[:dsc_maximumsizebytes] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_maximumsizebytes' do
+    expect{dsc_xvhd[:dsc_maximumsizebytes] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_maximumsizebytes' do
+    expect{dsc_xvhd[:dsc_maximumsizebytes] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_maximumsizebytes' do
+    dsc_xvhd[:dsc_maximumsizebytes] = 64
+    expect(dsc_xvhd[:dsc_maximumsizebytes]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizebytes' do
+    dsc_xvhd[:dsc_maximumsizebytes] = '16'
+    expect(dsc_xvhd[:dsc_maximumsizebytes]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizebytes' do
+    dsc_xvhd[:dsc_maximumsizebytes] = '32'
+    expect(dsc_xvhd[:dsc_maximumsizebytes]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizebytes' do
+    dsc_xvhd[:dsc_maximumsizebytes] = '64'
+    expect(dsc_xvhd[:dsc_maximumsizebytes]).to eq(64)
+  end
+
+  it 'should accept dsc_generation predefined value Vhd' do
+    dsc_xvhd[:dsc_generation] = 'Vhd'
+    expect(dsc_xvhd[:dsc_generation]).to eq('Vhd')
+  end
+
+  it 'should accept dsc_generation predefined value vhd' do
+    dsc_xvhd[:dsc_generation] = 'vhd'
+    expect(dsc_xvhd[:dsc_generation]).to eq('vhd')
+  end
+
+  it 'should accept dsc_generation predefined value Vhdx' do
+    dsc_xvhd[:dsc_generation] = 'Vhdx'
+    expect(dsc_xvhd[:dsc_generation]).to eq('Vhdx')
+  end
+
+  it 'should accept dsc_generation predefined value vhdx' do
+    dsc_xvhd[:dsc_generation] = 'vhdx'
+    expect(dsc_xvhd[:dsc_generation]).to eq('vhdx')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xvhd[:dsc_generation] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_generation' do
+    expect{dsc_xvhd[:dsc_generation] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_generation' do
+    expect{dsc_xvhd[:dsc_generation] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_generation' do
+    expect{dsc_xvhd[:dsc_generation] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_generation' do
+    expect{dsc_xvhd[:dsc_generation] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xvhd[:dsc_ensure] = 'Present'
+    expect(dsc_xvhd[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xvhd[:dsc_ensure] = 'present'
+    expect(dsc_xvhd[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xvhd[:dsc_ensure] = 'present'
+    expect(dsc_xvhd[:ensure]).to eq(dsc_xvhd[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xvhd[:dsc_ensure] = 'Absent'
+    expect(dsc_xvhd[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xvhd[:dsc_ensure] = 'absent'
+    expect(dsc_xvhd[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xvhd[:dsc_ensure] = 'absent'
+    expect(dsc_xvhd[:ensure]).to eq(dsc_xvhd[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xvhd[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xvhd[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xvhd[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xvhd[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xvhd[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_id' do
+    expect{dsc_xvhd[:dsc_id] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_id' do
+    expect{dsc_xvhd[:dsc_id] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_id' do
+    expect{dsc_xvhd[:dsc_id] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_id' do
+    expect{dsc_xvhd[:dsc_id] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_type' do
+    expect{dsc_xvhd[:dsc_type] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_type' do
+    expect{dsc_xvhd[:dsc_type] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_type' do
+    expect{dsc_xvhd[:dsc_type] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_type' do
+    expect{dsc_xvhd[:dsc_type] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_filesizebytes' do
+    expect{dsc_xvhd[:dsc_filesizebytes] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_filesizebytes' do
+    expect{dsc_xvhd[:dsc_filesizebytes] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_filesizebytes' do
+    expect{dsc_xvhd[:dsc_filesizebytes] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_filesizebytes' do
+    dsc_xvhd[:dsc_filesizebytes] = 64
+    expect(dsc_xvhd[:dsc_filesizebytes]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_filesizebytes' do
+    dsc_xvhd[:dsc_filesizebytes] = '16'
+    expect(dsc_xvhd[:dsc_filesizebytes]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_filesizebytes' do
+    dsc_xvhd[:dsc_filesizebytes] = '32'
+    expect(dsc_xvhd[:dsc_filesizebytes]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_filesizebytes' do
+    dsc_xvhd[:dsc_filesizebytes] = '64'
+    expect(dsc_xvhd[:dsc_filesizebytes]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_isattached' do
+    expect{dsc_xvhd[:dsc_isattached] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_isattached' do
+    dsc_xvhd[:dsc_isattached] = true
+    expect(dsc_xvhd[:dsc_isattached]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_isattached" do
+    dsc_xvhd[:dsc_isattached] = 'true'
+    expect(dsc_xvhd[:dsc_isattached]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_isattached" do
+    dsc_xvhd[:dsc_isattached] = 'false'
+    expect(dsc_xvhd[:dsc_isattached]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_isattached" do
+    dsc_xvhd[:dsc_isattached] = 'True'
+    expect(dsc_xvhd[:dsc_isattached]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_isattached" do
+    dsc_xvhd[:dsc_isattached] = 'False'
+    expect(dsc_xvhd[:dsc_isattached]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_isattached" do
+    dsc_xvhd[:dsc_isattached] = :true
+    expect(dsc_xvhd[:dsc_isattached]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_isattached" do
+    dsc_xvhd[:dsc_isattached] = :false
+    expect(dsc_xvhd[:dsc_isattached]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_isattached' do
+    expect{dsc_xvhd[:dsc_isattached] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_isattached' do
+    expect{dsc_xvhd[:dsc_isattached] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xvhd)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xvhd)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xvhd[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xvhd[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xvhd.original_parameters[:dsc_ensure] = 'present'
+        dsc_xvhd[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xvhd)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xvhd[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xvhd.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xvhd[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xvhd)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xvhd[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xvhd)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xvhd)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xVHD as $MSFT_xVHD1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xVHD/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xvhd[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xvhd)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xvhd[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xvhd[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xvhd)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xvhd[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xvhdfile_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvhdfile_spec.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xvhdfile) do
+
+  let :dsc_xvhdfile do
+    Puppet::Type.type(:dsc_xvhdfile).new(
+      :name     => 'foo',
+      :dsc_vhdpath => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xvhdfile.to_s).to eq("Dsc_xvhdfile[foo]")
+  end
+
+  it 'should require that dsc_vhdpath is specified' do
+    #dsc_xvhdfile[:dsc_vhdpath]
+    expect { Puppet::Type.type(:dsc_xvhdfile).new(
+      :name     => 'foo',
+      :dsc_filedirectory => ["foo", "bar", "spec"],
+    )}.to raise_error(Puppet::Error, /dsc_vhdpath is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_vhdpath' do
+    expect{dsc_xvhdfile[:dsc_vhdpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_vhdpath' do
+    expect{dsc_xvhdfile[:dsc_vhdpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_vhdpath' do
+    expect{dsc_xvhdfile[:dsc_vhdpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_vhdpath' do
+    expect{dsc_xvhdfile[:dsc_vhdpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_filedirectory' do
+    dsc_xvhdfile[:dsc_filedirectory] = ["foo", "bar", "spec"]
+    expect(dsc_xvhdfile[:dsc_filedirectory]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_filedirectory' do
+    expect{dsc_xvhdfile[:dsc_filedirectory] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_filedirectory' do
+    expect{dsc_xvhdfile[:dsc_filedirectory] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_filedirectory' do
+    expect{dsc_xvhdfile[:dsc_filedirectory] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xvhdfile)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xvhdfile)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xvhdfile[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xvhdfile[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xvhdfile)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xvhdfile)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xVhdFileDirectory as $MSFT_xVhdFileDirectory1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xVhdFileDirectory/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xvmhyperv_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvmhyperv_spec.rb
@@ -1,0 +1,834 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xvmhyperv) do
+
+  let :dsc_xvmhyperv do
+    Puppet::Type.type(:dsc_xvmhyperv).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xvmhyperv.to_s).to eq("Dsc_xvmhyperv[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xvmhyperv[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xvmhyperv[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xvmhyperv).new(
+      :name     => 'foo',
+      :dsc_vhdpath => 'foo',
+      :dsc_switchname => 'foo',
+      :dsc_state => 'Running',
+      :dsc_path => 'foo',
+      :dsc_generation => 'Vhd',
+      :dsc_startupmemory => 64,
+      :dsc_minimummemory => 64,
+      :dsc_maximummemory => 64,
+      :dsc_macaddress => 'foo',
+      :dsc_processorcount => 32,
+      :dsc_waitforip => true,
+      :dsc_restartifneeded => true,
+      :dsc_ensure => 'Present',
+      :dsc_id => 'foo',
+      :dsc_status => 'foo',
+      :dsc_cpuusage => 32,
+      :dsc_memoryassigned => 64,
+      :dsc_uptime => 'foo',
+      :dsc_creationtime => '20140711',
+      :dsc_hasdynamicmemory => true,
+      :dsc_networkadapters => ["foo", "bar", "spec"],
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xvmhyperv[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xvmhyperv[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xvmhyperv[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xvmhyperv[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_vhdpath' do
+    expect{dsc_xvmhyperv[:dsc_vhdpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_vhdpath' do
+    expect{dsc_xvmhyperv[:dsc_vhdpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_vhdpath' do
+    expect{dsc_xvmhyperv[:dsc_vhdpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_vhdpath' do
+    expect{dsc_xvmhyperv[:dsc_vhdpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_switchname' do
+    expect{dsc_xvmhyperv[:dsc_switchname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_switchname' do
+    expect{dsc_xvmhyperv[:dsc_switchname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_switchname' do
+    expect{dsc_xvmhyperv[:dsc_switchname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_switchname' do
+    expect{dsc_xvmhyperv[:dsc_switchname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_state predefined value Running' do
+    dsc_xvmhyperv[:dsc_state] = 'Running'
+    expect(dsc_xvmhyperv[:dsc_state]).to eq('Running')
+  end
+
+  it 'should accept dsc_state predefined value running' do
+    dsc_xvmhyperv[:dsc_state] = 'running'
+    expect(dsc_xvmhyperv[:dsc_state]).to eq('running')
+  end
+
+  it 'should accept dsc_state predefined value Paused' do
+    dsc_xvmhyperv[:dsc_state] = 'Paused'
+    expect(dsc_xvmhyperv[:dsc_state]).to eq('Paused')
+  end
+
+  it 'should accept dsc_state predefined value paused' do
+    dsc_xvmhyperv[:dsc_state] = 'paused'
+    expect(dsc_xvmhyperv[:dsc_state]).to eq('paused')
+  end
+
+  it 'should accept dsc_state predefined value Off' do
+    dsc_xvmhyperv[:dsc_state] = 'Off'
+    expect(dsc_xvmhyperv[:dsc_state]).to eq('Off')
+  end
+
+  it 'should accept dsc_state predefined value off' do
+    dsc_xvmhyperv[:dsc_state] = 'off'
+    expect(dsc_xvmhyperv[:dsc_state]).to eq('off')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xvmhyperv[:dsc_state] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_state' do
+    expect{dsc_xvmhyperv[:dsc_state] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_state' do
+    expect{dsc_xvmhyperv[:dsc_state] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_state' do
+    expect{dsc_xvmhyperv[:dsc_state] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_state' do
+    expect{dsc_xvmhyperv[:dsc_state] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_xvmhyperv[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xvmhyperv[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xvmhyperv[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xvmhyperv[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_generation predefined value Vhd' do
+    dsc_xvmhyperv[:dsc_generation] = 'Vhd'
+    expect(dsc_xvmhyperv[:dsc_generation]).to eq('Vhd')
+  end
+
+  it 'should accept dsc_generation predefined value vhd' do
+    dsc_xvmhyperv[:dsc_generation] = 'vhd'
+    expect(dsc_xvmhyperv[:dsc_generation]).to eq('vhd')
+  end
+
+  it 'should accept dsc_generation predefined value Vhdx' do
+    dsc_xvmhyperv[:dsc_generation] = 'Vhdx'
+    expect(dsc_xvmhyperv[:dsc_generation]).to eq('Vhdx')
+  end
+
+  it 'should accept dsc_generation predefined value vhdx' do
+    dsc_xvmhyperv[:dsc_generation] = 'vhdx'
+    expect(dsc_xvmhyperv[:dsc_generation]).to eq('vhdx')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xvmhyperv[:dsc_generation] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_generation' do
+    expect{dsc_xvmhyperv[:dsc_generation] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_generation' do
+    expect{dsc_xvmhyperv[:dsc_generation] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_generation' do
+    expect{dsc_xvmhyperv[:dsc_generation] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_generation' do
+    expect{dsc_xvmhyperv[:dsc_generation] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_startupmemory' do
+    expect{dsc_xvmhyperv[:dsc_startupmemory] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_startupmemory' do
+    expect{dsc_xvmhyperv[:dsc_startupmemory] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_startupmemory' do
+    expect{dsc_xvmhyperv[:dsc_startupmemory] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_startupmemory' do
+    dsc_xvmhyperv[:dsc_startupmemory] = 64
+    expect(dsc_xvmhyperv[:dsc_startupmemory]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_startupmemory' do
+    dsc_xvmhyperv[:dsc_startupmemory] = '16'
+    expect(dsc_xvmhyperv[:dsc_startupmemory]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_startupmemory' do
+    dsc_xvmhyperv[:dsc_startupmemory] = '32'
+    expect(dsc_xvmhyperv[:dsc_startupmemory]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_startupmemory' do
+    dsc_xvmhyperv[:dsc_startupmemory] = '64'
+    expect(dsc_xvmhyperv[:dsc_startupmemory]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_minimummemory' do
+    expect{dsc_xvmhyperv[:dsc_minimummemory] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_minimummemory' do
+    expect{dsc_xvmhyperv[:dsc_minimummemory] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_minimummemory' do
+    expect{dsc_xvmhyperv[:dsc_minimummemory] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_minimummemory' do
+    dsc_xvmhyperv[:dsc_minimummemory] = 64
+    expect(dsc_xvmhyperv[:dsc_minimummemory]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_minimummemory' do
+    dsc_xvmhyperv[:dsc_minimummemory] = '16'
+    expect(dsc_xvmhyperv[:dsc_minimummemory]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_minimummemory' do
+    dsc_xvmhyperv[:dsc_minimummemory] = '32'
+    expect(dsc_xvmhyperv[:dsc_minimummemory]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_minimummemory' do
+    dsc_xvmhyperv[:dsc_minimummemory] = '64'
+    expect(dsc_xvmhyperv[:dsc_minimummemory]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_maximummemory' do
+    expect{dsc_xvmhyperv[:dsc_maximummemory] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_maximummemory' do
+    expect{dsc_xvmhyperv[:dsc_maximummemory] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_maximummemory' do
+    expect{dsc_xvmhyperv[:dsc_maximummemory] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_maximummemory' do
+    dsc_xvmhyperv[:dsc_maximummemory] = 64
+    expect(dsc_xvmhyperv[:dsc_maximummemory]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_maximummemory' do
+    dsc_xvmhyperv[:dsc_maximummemory] = '16'
+    expect(dsc_xvmhyperv[:dsc_maximummemory]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_maximummemory' do
+    dsc_xvmhyperv[:dsc_maximummemory] = '32'
+    expect(dsc_xvmhyperv[:dsc_maximummemory]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_maximummemory' do
+    dsc_xvmhyperv[:dsc_maximummemory] = '64'
+    expect(dsc_xvmhyperv[:dsc_maximummemory]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_macaddress' do
+    expect{dsc_xvmhyperv[:dsc_macaddress] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_macaddress' do
+    expect{dsc_xvmhyperv[:dsc_macaddress] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_macaddress' do
+    expect{dsc_xvmhyperv[:dsc_macaddress] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_macaddress' do
+    expect{dsc_xvmhyperv[:dsc_macaddress] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_processorcount' do
+    expect{dsc_xvmhyperv[:dsc_processorcount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_processorcount' do
+    expect{dsc_xvmhyperv[:dsc_processorcount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_processorcount' do
+    expect{dsc_xvmhyperv[:dsc_processorcount] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_processorcount' do
+    dsc_xvmhyperv[:dsc_processorcount] = 32
+    expect(dsc_xvmhyperv[:dsc_processorcount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_processorcount' do
+    dsc_xvmhyperv[:dsc_processorcount] = '16'
+    expect(dsc_xvmhyperv[:dsc_processorcount]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_processorcount' do
+    dsc_xvmhyperv[:dsc_processorcount] = '32'
+    expect(dsc_xvmhyperv[:dsc_processorcount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_processorcount' do
+    dsc_xvmhyperv[:dsc_processorcount] = '64'
+    expect(dsc_xvmhyperv[:dsc_processorcount]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_waitforip' do
+    expect{dsc_xvmhyperv[:dsc_waitforip] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_waitforip' do
+    dsc_xvmhyperv[:dsc_waitforip] = true
+    expect(dsc_xvmhyperv[:dsc_waitforip]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_waitforip" do
+    dsc_xvmhyperv[:dsc_waitforip] = 'true'
+    expect(dsc_xvmhyperv[:dsc_waitforip]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_waitforip" do
+    dsc_xvmhyperv[:dsc_waitforip] = 'false'
+    expect(dsc_xvmhyperv[:dsc_waitforip]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_waitforip" do
+    dsc_xvmhyperv[:dsc_waitforip] = 'True'
+    expect(dsc_xvmhyperv[:dsc_waitforip]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_waitforip" do
+    dsc_xvmhyperv[:dsc_waitforip] = 'False'
+    expect(dsc_xvmhyperv[:dsc_waitforip]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_waitforip" do
+    dsc_xvmhyperv[:dsc_waitforip] = :true
+    expect(dsc_xvmhyperv[:dsc_waitforip]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_waitforip" do
+    dsc_xvmhyperv[:dsc_waitforip] = :false
+    expect(dsc_xvmhyperv[:dsc_waitforip]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_waitforip' do
+    expect{dsc_xvmhyperv[:dsc_waitforip] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_waitforip' do
+    expect{dsc_xvmhyperv[:dsc_waitforip] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_restartifneeded' do
+    expect{dsc_xvmhyperv[:dsc_restartifneeded] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_restartifneeded' do
+    dsc_xvmhyperv[:dsc_restartifneeded] = true
+    expect(dsc_xvmhyperv[:dsc_restartifneeded]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_restartifneeded" do
+    dsc_xvmhyperv[:dsc_restartifneeded] = 'true'
+    expect(dsc_xvmhyperv[:dsc_restartifneeded]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_restartifneeded" do
+    dsc_xvmhyperv[:dsc_restartifneeded] = 'false'
+    expect(dsc_xvmhyperv[:dsc_restartifneeded]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_restartifneeded" do
+    dsc_xvmhyperv[:dsc_restartifneeded] = 'True'
+    expect(dsc_xvmhyperv[:dsc_restartifneeded]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_restartifneeded" do
+    dsc_xvmhyperv[:dsc_restartifneeded] = 'False'
+    expect(dsc_xvmhyperv[:dsc_restartifneeded]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_restartifneeded" do
+    dsc_xvmhyperv[:dsc_restartifneeded] = :true
+    expect(dsc_xvmhyperv[:dsc_restartifneeded]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_restartifneeded" do
+    dsc_xvmhyperv[:dsc_restartifneeded] = :false
+    expect(dsc_xvmhyperv[:dsc_restartifneeded]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_restartifneeded' do
+    expect{dsc_xvmhyperv[:dsc_restartifneeded] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_restartifneeded' do
+    expect{dsc_xvmhyperv[:dsc_restartifneeded] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xvmhyperv[:dsc_ensure] = 'Present'
+    expect(dsc_xvmhyperv[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xvmhyperv[:dsc_ensure] = 'present'
+    expect(dsc_xvmhyperv[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xvmhyperv[:dsc_ensure] = 'present'
+    expect(dsc_xvmhyperv[:ensure]).to eq(dsc_xvmhyperv[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xvmhyperv[:dsc_ensure] = 'Absent'
+    expect(dsc_xvmhyperv[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xvmhyperv[:dsc_ensure] = 'absent'
+    expect(dsc_xvmhyperv[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xvmhyperv[:dsc_ensure] = 'absent'
+    expect(dsc_xvmhyperv[:ensure]).to eq(dsc_xvmhyperv[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xvmhyperv[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xvmhyperv[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xvmhyperv[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xvmhyperv[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xvmhyperv[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_id' do
+    expect{dsc_xvmhyperv[:dsc_id] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_id' do
+    expect{dsc_xvmhyperv[:dsc_id] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_id' do
+    expect{dsc_xvmhyperv[:dsc_id] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_id' do
+    expect{dsc_xvmhyperv[:dsc_id] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_status' do
+    expect{dsc_xvmhyperv[:dsc_status] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_status' do
+    expect{dsc_xvmhyperv[:dsc_status] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_status' do
+    expect{dsc_xvmhyperv[:dsc_status] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_status' do
+    expect{dsc_xvmhyperv[:dsc_status] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_cpuusage' do
+    expect{dsc_xvmhyperv[:dsc_cpuusage] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_cpuusage' do
+    expect{dsc_xvmhyperv[:dsc_cpuusage] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_cpuusage' do
+    expect{dsc_xvmhyperv[:dsc_cpuusage] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_cpuusage' do
+    dsc_xvmhyperv[:dsc_cpuusage] = 32
+    expect(dsc_xvmhyperv[:dsc_cpuusage]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_cpuusage' do
+    dsc_xvmhyperv[:dsc_cpuusage] = '16'
+    expect(dsc_xvmhyperv[:dsc_cpuusage]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_cpuusage' do
+    dsc_xvmhyperv[:dsc_cpuusage] = '32'
+    expect(dsc_xvmhyperv[:dsc_cpuusage]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_cpuusage' do
+    dsc_xvmhyperv[:dsc_cpuusage] = '64'
+    expect(dsc_xvmhyperv[:dsc_cpuusage]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_memoryassigned' do
+    expect{dsc_xvmhyperv[:dsc_memoryassigned] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_memoryassigned' do
+    expect{dsc_xvmhyperv[:dsc_memoryassigned] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_memoryassigned' do
+    expect{dsc_xvmhyperv[:dsc_memoryassigned] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_memoryassigned' do
+    dsc_xvmhyperv[:dsc_memoryassigned] = 64
+    expect(dsc_xvmhyperv[:dsc_memoryassigned]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_memoryassigned' do
+    dsc_xvmhyperv[:dsc_memoryassigned] = '16'
+    expect(dsc_xvmhyperv[:dsc_memoryassigned]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_memoryassigned' do
+    dsc_xvmhyperv[:dsc_memoryassigned] = '32'
+    expect(dsc_xvmhyperv[:dsc_memoryassigned]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_memoryassigned' do
+    dsc_xvmhyperv[:dsc_memoryassigned] = '64'
+    expect(dsc_xvmhyperv[:dsc_memoryassigned]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_uptime' do
+    expect{dsc_xvmhyperv[:dsc_uptime] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_uptime' do
+    expect{dsc_xvmhyperv[:dsc_uptime] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_uptime' do
+    expect{dsc_xvmhyperv[:dsc_uptime] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_uptime' do
+    expect{dsc_xvmhyperv[:dsc_uptime] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_creationtime' do
+    expect{dsc_xvmhyperv[:dsc_creationtime] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_creationtime' do
+    expect{dsc_xvmhyperv[:dsc_creationtime] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_creationtime' do
+    expect{dsc_xvmhyperv[:dsc_creationtime] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_creationtime' do
+    expect{dsc_xvmhyperv[:dsc_creationtime] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_hasdynamicmemory' do
+    expect{dsc_xvmhyperv[:dsc_hasdynamicmemory] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_hasdynamicmemory' do
+    dsc_xvmhyperv[:dsc_hasdynamicmemory] = true
+    expect(dsc_xvmhyperv[:dsc_hasdynamicmemory]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_hasdynamicmemory" do
+    dsc_xvmhyperv[:dsc_hasdynamicmemory] = 'true'
+    expect(dsc_xvmhyperv[:dsc_hasdynamicmemory]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_hasdynamicmemory" do
+    dsc_xvmhyperv[:dsc_hasdynamicmemory] = 'false'
+    expect(dsc_xvmhyperv[:dsc_hasdynamicmemory]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_hasdynamicmemory" do
+    dsc_xvmhyperv[:dsc_hasdynamicmemory] = 'True'
+    expect(dsc_xvmhyperv[:dsc_hasdynamicmemory]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_hasdynamicmemory" do
+    dsc_xvmhyperv[:dsc_hasdynamicmemory] = 'False'
+    expect(dsc_xvmhyperv[:dsc_hasdynamicmemory]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_hasdynamicmemory" do
+    dsc_xvmhyperv[:dsc_hasdynamicmemory] = :true
+    expect(dsc_xvmhyperv[:dsc_hasdynamicmemory]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_hasdynamicmemory" do
+    dsc_xvmhyperv[:dsc_hasdynamicmemory] = :false
+    expect(dsc_xvmhyperv[:dsc_hasdynamicmemory]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_hasdynamicmemory' do
+    expect{dsc_xvmhyperv[:dsc_hasdynamicmemory] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_hasdynamicmemory' do
+    expect{dsc_xvmhyperv[:dsc_hasdynamicmemory] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_networkadapters' do
+    dsc_xvmhyperv[:dsc_networkadapters] = ["foo", "bar", "spec"]
+    expect(dsc_xvmhyperv[:dsc_networkadapters]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_networkadapters' do
+    expect{dsc_xvmhyperv[:dsc_networkadapters] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_networkadapters' do
+    expect{dsc_xvmhyperv[:dsc_networkadapters] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_networkadapters' do
+    expect{dsc_xvmhyperv[:dsc_networkadapters] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xvmhyperv)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xvmhyperv)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xvmhyperv[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xvmhyperv[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xvmhyperv.original_parameters[:dsc_ensure] = 'present'
+        dsc_xvmhyperv[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xvmhyperv)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xvmhyperv[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xvmhyperv.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xvmhyperv[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xvmhyperv)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xvmhyperv[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xvmhyperv)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xvmhyperv)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xVMHyperV as $MSFT_xVMHyperV1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xVMHyperV/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xvmhyperv[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xvmhyperv)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xvmhyperv[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xvmhyperv[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xvmhyperv)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xvmhyperv[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xvmswitch_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvmswitch_spec.rb
@@ -1,0 +1,392 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xvmswitch) do
+
+  let :dsc_xvmswitch do
+    Puppet::Type.type(:dsc_xvmswitch).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_type => 'External',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xvmswitch.to_s).to eq("Dsc_xvmswitch[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xvmswitch[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xvmswitch[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xvmswitch).new(
+      :name     => 'foo',
+      :dsc_type => 'External',
+      :dsc_netadaptername => 'foo',
+      :dsc_allowmanagementos => true,
+      :dsc_ensure => 'Present',
+      :dsc_id => 'foo',
+      :dsc_netadapterinterfacedescription => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xvmswitch[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xvmswitch[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xvmswitch[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xvmswitch[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_type is specified' do
+    #dsc_xvmswitch[:dsc_type]
+    expect { Puppet::Type.type(:dsc_xvmswitch).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_netadaptername => 'foo',
+      :dsc_allowmanagementos => true,
+      :dsc_ensure => 'Present',
+      :dsc_id => 'foo',
+      :dsc_netadapterinterfacedescription => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_type is a required attribute/)
+  end
+
+  it 'should accept dsc_type predefined value External' do
+    dsc_xvmswitch[:dsc_type] = 'External'
+    expect(dsc_xvmswitch[:dsc_type]).to eq('External')
+  end
+
+  it 'should accept dsc_type predefined value external' do
+    dsc_xvmswitch[:dsc_type] = 'external'
+    expect(dsc_xvmswitch[:dsc_type]).to eq('external')
+  end
+
+  it 'should accept dsc_type predefined value Internal' do
+    dsc_xvmswitch[:dsc_type] = 'Internal'
+    expect(dsc_xvmswitch[:dsc_type]).to eq('Internal')
+  end
+
+  it 'should accept dsc_type predefined value internal' do
+    dsc_xvmswitch[:dsc_type] = 'internal'
+    expect(dsc_xvmswitch[:dsc_type]).to eq('internal')
+  end
+
+  it 'should accept dsc_type predefined value Private' do
+    dsc_xvmswitch[:dsc_type] = 'Private'
+    expect(dsc_xvmswitch[:dsc_type]).to eq('Private')
+  end
+
+  it 'should accept dsc_type predefined value private' do
+    dsc_xvmswitch[:dsc_type] = 'private'
+    expect(dsc_xvmswitch[:dsc_type]).to eq('private')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xvmswitch[:dsc_type] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_type' do
+    expect{dsc_xvmswitch[:dsc_type] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_type' do
+    expect{dsc_xvmswitch[:dsc_type] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_type' do
+    expect{dsc_xvmswitch[:dsc_type] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_type' do
+    expect{dsc_xvmswitch[:dsc_type] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_netadaptername' do
+    expect{dsc_xvmswitch[:dsc_netadaptername] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_netadaptername' do
+    expect{dsc_xvmswitch[:dsc_netadaptername] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_netadaptername' do
+    expect{dsc_xvmswitch[:dsc_netadaptername] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_netadaptername' do
+    expect{dsc_xvmswitch[:dsc_netadaptername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_allowmanagementos' do
+    expect{dsc_xvmswitch[:dsc_allowmanagementos] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_allowmanagementos' do
+    dsc_xvmswitch[:dsc_allowmanagementos] = true
+    expect(dsc_xvmswitch[:dsc_allowmanagementos]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_allowmanagementos" do
+    dsc_xvmswitch[:dsc_allowmanagementos] = 'true'
+    expect(dsc_xvmswitch[:dsc_allowmanagementos]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_allowmanagementos" do
+    dsc_xvmswitch[:dsc_allowmanagementos] = 'false'
+    expect(dsc_xvmswitch[:dsc_allowmanagementos]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_allowmanagementos" do
+    dsc_xvmswitch[:dsc_allowmanagementos] = 'True'
+    expect(dsc_xvmswitch[:dsc_allowmanagementos]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_allowmanagementos" do
+    dsc_xvmswitch[:dsc_allowmanagementos] = 'False'
+    expect(dsc_xvmswitch[:dsc_allowmanagementos]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_allowmanagementos" do
+    dsc_xvmswitch[:dsc_allowmanagementos] = :true
+    expect(dsc_xvmswitch[:dsc_allowmanagementos]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_allowmanagementos" do
+    dsc_xvmswitch[:dsc_allowmanagementos] = :false
+    expect(dsc_xvmswitch[:dsc_allowmanagementos]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_allowmanagementos' do
+    expect{dsc_xvmswitch[:dsc_allowmanagementos] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_allowmanagementos' do
+    expect{dsc_xvmswitch[:dsc_allowmanagementos] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xvmswitch[:dsc_ensure] = 'Present'
+    expect(dsc_xvmswitch[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xvmswitch[:dsc_ensure] = 'present'
+    expect(dsc_xvmswitch[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xvmswitch[:dsc_ensure] = 'present'
+    expect(dsc_xvmswitch[:ensure]).to eq(dsc_xvmswitch[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xvmswitch[:dsc_ensure] = 'Absent'
+    expect(dsc_xvmswitch[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xvmswitch[:dsc_ensure] = 'absent'
+    expect(dsc_xvmswitch[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xvmswitch[:dsc_ensure] = 'absent'
+    expect(dsc_xvmswitch[:ensure]).to eq(dsc_xvmswitch[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xvmswitch[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xvmswitch[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xvmswitch[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xvmswitch[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xvmswitch[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_id' do
+    expect{dsc_xvmswitch[:dsc_id] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_id' do
+    expect{dsc_xvmswitch[:dsc_id] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_id' do
+    expect{dsc_xvmswitch[:dsc_id] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_id' do
+    expect{dsc_xvmswitch[:dsc_id] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_netadapterinterfacedescription' do
+    expect{dsc_xvmswitch[:dsc_netadapterinterfacedescription] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_netadapterinterfacedescription' do
+    expect{dsc_xvmswitch[:dsc_netadapterinterfacedescription] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_netadapterinterfacedescription' do
+    expect{dsc_xvmswitch[:dsc_netadapterinterfacedescription] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_netadapterinterfacedescription' do
+    expect{dsc_xvmswitch[:dsc_netadapterinterfacedescription] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xvmswitch)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xvmswitch)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xvmswitch[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xvmswitch[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xvmswitch.original_parameters[:dsc_ensure] = 'present'
+        dsc_xvmswitch[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xvmswitch)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xvmswitch[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xvmswitch.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xvmswitch[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xvmswitch)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xvmswitch[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xvmswitch)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xvmswitch)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xVMSwitch as $MSFT_xVMSwitch1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xVMSwitch/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xvmswitch[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xvmswitch)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xvmswitch[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xvmswitch[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xvmswitch)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xvmswitch[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwaitforaddomain_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitforaddomain_spec.rb
@@ -1,0 +1,188 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwaitforaddomain) do
+
+  let :dsc_xwaitforaddomain do
+    Puppet::Type.type(:dsc_xwaitforaddomain).new(
+      :name     => 'foo',
+      :dsc_domainname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwaitforaddomain.to_s).to eq("Dsc_xwaitforaddomain[foo]")
+  end
+
+  it 'should require that dsc_domainname is specified' do
+    #dsc_xwaitforaddomain[:dsc_domainname]
+    expect { Puppet::Type.type(:dsc_xwaitforaddomain).new(
+      :name     => 'foo',
+      :dsc_domainusercredential => 'foo',
+      :dsc_retryintervalsec => 64,
+      :dsc_retrycount => 32,
+    )}.to raise_error(Puppet::Error, /dsc_domainname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_domainname' do
+    expect{dsc_xwaitforaddomain[:dsc_domainname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainname' do
+    expect{dsc_xwaitforaddomain[:dsc_domainname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainname' do
+    expect{dsc_xwaitforaddomain[:dsc_domainname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainname' do
+    expect{dsc_xwaitforaddomain[:dsc_domainname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_domainusercredential' do
+    expect{dsc_xwaitforaddomain[:dsc_domainusercredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domainusercredential' do
+    expect{dsc_xwaitforaddomain[:dsc_domainusercredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domainusercredential' do
+    expect{dsc_xwaitforaddomain[:dsc_domainusercredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domainusercredential' do
+    expect{dsc_xwaitforaddomain[:dsc_domainusercredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_retryintervalsec' do
+    expect{dsc_xwaitforaddomain[:dsc_retryintervalsec] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_retryintervalsec' do
+    expect{dsc_xwaitforaddomain[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_retryintervalsec' do
+    expect{dsc_xwaitforaddomain[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_retryintervalsec' do
+    dsc_xwaitforaddomain[:dsc_retryintervalsec] = 64
+    expect(dsc_xwaitforaddomain[:dsc_retryintervalsec]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforaddomain[:dsc_retryintervalsec] = '16'
+    expect(dsc_xwaitforaddomain[:dsc_retryintervalsec]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforaddomain[:dsc_retryintervalsec] = '32'
+    expect(dsc_xwaitforaddomain[:dsc_retryintervalsec]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforaddomain[:dsc_retryintervalsec] = '64'
+    expect(dsc_xwaitforaddomain[:dsc_retryintervalsec]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_retrycount' do
+    expect{dsc_xwaitforaddomain[:dsc_retrycount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_retrycount' do
+    expect{dsc_xwaitforaddomain[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_retrycount' do
+    expect{dsc_xwaitforaddomain[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_retrycount' do
+    dsc_xwaitforaddomain[:dsc_retrycount] = 32
+    expect(dsc_xwaitforaddomain[:dsc_retrycount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforaddomain[:dsc_retrycount] = '16'
+    expect(dsc_xwaitforaddomain[:dsc_retrycount]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforaddomain[:dsc_retrycount] = '32'
+    expect(dsc_xwaitforaddomain[:dsc_retrycount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforaddomain[:dsc_retrycount] = '64'
+    expect(dsc_xwaitforaddomain[:dsc_retrycount]).to eq(64)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwaitforaddomain)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwaitforaddomain)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwaitforaddomain[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwaitforaddomain[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwaitforaddomain)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwaitforaddomain)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWaitForADDomain as $MSFT_xWaitForADDomain1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWaitForADDomain/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwaitforcluster_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitforcluster_spec.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwaitforcluster) do
+
+  let :dsc_xwaitforcluster do
+    Puppet::Type.type(:dsc_xwaitforcluster).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwaitforcluster.to_s).to eq("Dsc_xwaitforcluster[foo]")
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xwaitforcluster[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xwaitforcluster).new(
+      :name     => 'foo',
+      :dsc_retryintervalsec => 64,
+      :dsc_retrycount => 32,
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xwaitforcluster[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xwaitforcluster[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xwaitforcluster[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xwaitforcluster[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_retryintervalsec' do
+    expect{dsc_xwaitforcluster[:dsc_retryintervalsec] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_retryintervalsec' do
+    expect{dsc_xwaitforcluster[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_retryintervalsec' do
+    expect{dsc_xwaitforcluster[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_retryintervalsec' do
+    dsc_xwaitforcluster[:dsc_retryintervalsec] = 64
+    expect(dsc_xwaitforcluster[:dsc_retryintervalsec]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforcluster[:dsc_retryintervalsec] = '16'
+    expect(dsc_xwaitforcluster[:dsc_retryintervalsec]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforcluster[:dsc_retryintervalsec] = '32'
+    expect(dsc_xwaitforcluster[:dsc_retryintervalsec]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforcluster[:dsc_retryintervalsec] = '64'
+    expect(dsc_xwaitforcluster[:dsc_retryintervalsec]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_retrycount' do
+    expect{dsc_xwaitforcluster[:dsc_retrycount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_retrycount' do
+    expect{dsc_xwaitforcluster[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_retrycount' do
+    expect{dsc_xwaitforcluster[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_retrycount' do
+    dsc_xwaitforcluster[:dsc_retrycount] = 32
+    expect(dsc_xwaitforcluster[:dsc_retrycount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforcluster[:dsc_retrycount] = '16'
+    expect(dsc_xwaitforcluster[:dsc_retrycount]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforcluster[:dsc_retrycount] = '32'
+    expect(dsc_xwaitforcluster[:dsc_retrycount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforcluster[:dsc_retrycount] = '64'
+    expect(dsc_xwaitforcluster[:dsc_retrycount]).to eq(64)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwaitforcluster)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwaitforcluster)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwaitforcluster[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwaitforcluster[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwaitforcluster)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwaitforcluster)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWaitForCluster as $MSFT_xWaitForCluster1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWaitForCluster/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwaitforsqlhagroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitforsqlhagroup_spec.rb
@@ -1,0 +1,239 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwaitforsqlhagroup) do
+
+  let :dsc_xwaitforsqlhagroup do
+    Puppet::Type.type(:dsc_xwaitforsqlhagroup).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwaitforsqlhagroup.to_s).to eq("Dsc_xwaitforsqlhagroup[foo]")
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xwaitforsqlhagroup[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xwaitforsqlhagroup).new(
+      :name     => 'foo',
+      :dsc_clustername => 'foo',
+      :dsc_retryintervalsec => 64,
+      :dsc_retrycount => 32,
+      :dsc_instancename => 'foo',
+      :dsc_domaincredential => 'foo',
+      :dsc_sqladministratorcredential => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_clustername' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_clustername] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_clustername' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_clustername] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_clustername' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_clustername] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_clustername' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_clustername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_retryintervalsec' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_retryintervalsec' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_retryintervalsec' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_retryintervalsec' do
+    dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = 64
+    expect(dsc_xwaitforsqlhagroup[:dsc_retryintervalsec]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = '16'
+    expect(dsc_xwaitforsqlhagroup[:dsc_retryintervalsec]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = '32'
+    expect(dsc_xwaitforsqlhagroup[:dsc_retryintervalsec]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retryintervalsec' do
+    dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = '64'
+    expect(dsc_xwaitforsqlhagroup[:dsc_retryintervalsec]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_retrycount' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_retrycount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_retrycount' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_retrycount' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_retrycount' do
+    dsc_xwaitforsqlhagroup[:dsc_retrycount] = 32
+    expect(dsc_xwaitforsqlhagroup[:dsc_retrycount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforsqlhagroup[:dsc_retrycount] = '16'
+    expect(dsc_xwaitforsqlhagroup[:dsc_retrycount]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforsqlhagroup[:dsc_retrycount] = '32'
+    expect(dsc_xwaitforsqlhagroup[:dsc_retrycount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_retrycount' do
+    dsc_xwaitforsqlhagroup[:dsc_retrycount] = '64'
+    expect(dsc_xwaitforsqlhagroup[:dsc_retrycount]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_instancename' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_instancename] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_instancename' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_instancename] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_instancename' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_instancename] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_instancename' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_instancename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_domaincredential' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_domaincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_domaincredential' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_domaincredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_domaincredential' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_domaincredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_domaincredential' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_domaincredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_sqladministratorcredential' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_sqladministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_sqladministratorcredential' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_sqladministratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_sqladministratorcredential' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_sqladministratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_sqladministratorcredential' do
+    expect{dsc_xwaitforsqlhagroup[:dsc_sqladministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwaitforsqlhagroup)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwaitforsqlhagroup)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwaitforsqlhagroup[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwaitforsqlhagroup[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwaitforsqlhagroup)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwaitforsqlhagroup)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWaitForSqlHAGroup as $MSFT_xWaitForSqlHAGroup1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWaitForSqlHAGroup/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwebapplication_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebapplication_spec.rb
@@ -1,0 +1,291 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwebapplication) do
+
+  let :dsc_xwebapplication do
+    Puppet::Type.type(:dsc_xwebapplication).new(
+      :name     => 'foo',
+      :dsc_website => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwebapplication.to_s).to eq("Dsc_xwebapplication[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xwebapplication[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_website is specified' do
+    #dsc_xwebapplication[:dsc_website]
+    expect { Puppet::Type.type(:dsc_xwebapplication).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_webapppool => 'foo',
+      :dsc_physicalpath => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_website is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_website' do
+    expect{dsc_xwebapplication[:dsc_website] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_website' do
+    expect{dsc_xwebapplication[:dsc_website] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_website' do
+    expect{dsc_xwebapplication[:dsc_website] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_website' do
+    expect{dsc_xwebapplication[:dsc_website] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xwebapplication[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xwebapplication).new(
+      :name     => 'foo',
+      :dsc_website => 'foo',
+      :dsc_webapppool => 'foo',
+      :dsc_physicalpath => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xwebapplication[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xwebapplication[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xwebapplication[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xwebapplication[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_webapppool' do
+    expect{dsc_xwebapplication[:dsc_webapppool] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_webapppool' do
+    expect{dsc_xwebapplication[:dsc_webapppool] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_webapppool' do
+    expect{dsc_xwebapplication[:dsc_webapppool] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_webapppool' do
+    expect{dsc_xwebapplication[:dsc_webapppool] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_physicalpath' do
+    expect{dsc_xwebapplication[:dsc_physicalpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_physicalpath' do
+    expect{dsc_xwebapplication[:dsc_physicalpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_physicalpath' do
+    expect{dsc_xwebapplication[:dsc_physicalpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_physicalpath' do
+    expect{dsc_xwebapplication[:dsc_physicalpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xwebapplication[:dsc_ensure] = 'Present'
+    expect(dsc_xwebapplication[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xwebapplication[:dsc_ensure] = 'present'
+    expect(dsc_xwebapplication[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebapplication[:dsc_ensure] = 'present'
+    expect(dsc_xwebapplication[:ensure]).to eq(dsc_xwebapplication[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xwebapplication[:dsc_ensure] = 'Absent'
+    expect(dsc_xwebapplication[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xwebapplication[:dsc_ensure] = 'absent'
+    expect(dsc_xwebapplication[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebapplication[:dsc_ensure] = 'absent'
+    expect(dsc_xwebapplication[:ensure]).to eq(dsc_xwebapplication[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwebapplication[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xwebapplication[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xwebapplication[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xwebapplication[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xwebapplication[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwebapplication)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwebapplication)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwebapplication[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwebapplication[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebapplication.original_parameters[:dsc_ensure] = 'present'
+        dsc_xwebapplication[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xwebapplication)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebapplication[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebapplication.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebapplication[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebapplication)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebapplication[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwebapplication)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwebapplication)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWebApplication as $MSFT_xWebApplication1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWebApplication/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebapplication[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xwebapplication)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebapplication[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebapplication[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xwebapplication)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebapplication[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwebapppool_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebapppool_spec.rb
@@ -1,0 +1,269 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwebapppool) do
+
+  let :dsc_xwebapppool do
+    Puppet::Type.type(:dsc_xwebapppool).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwebapppool.to_s).to eq("Dsc_xwebapppool[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xwebapppool[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xwebapppool[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xwebapppool).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_state => 'Started',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xwebapppool[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xwebapppool[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xwebapppool[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xwebapppool[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xwebapppool[:dsc_ensure] = 'Present'
+    expect(dsc_xwebapppool[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xwebapppool[:dsc_ensure] = 'present'
+    expect(dsc_xwebapppool[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebapppool[:dsc_ensure] = 'present'
+    expect(dsc_xwebapppool[:ensure]).to eq(dsc_xwebapppool[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xwebapppool[:dsc_ensure] = 'Absent'
+    expect(dsc_xwebapppool[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xwebapppool[:dsc_ensure] = 'absent'
+    expect(dsc_xwebapppool[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebapppool[:dsc_ensure] = 'absent'
+    expect(dsc_xwebapppool[:ensure]).to eq(dsc_xwebapppool[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwebapppool[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xwebapppool[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xwebapppool[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xwebapppool[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xwebapppool[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_state predefined value Started' do
+    dsc_xwebapppool[:dsc_state] = 'Started'
+    expect(dsc_xwebapppool[:dsc_state]).to eq('Started')
+  end
+
+  it 'should accept dsc_state predefined value started' do
+    dsc_xwebapppool[:dsc_state] = 'started'
+    expect(dsc_xwebapppool[:dsc_state]).to eq('started')
+  end
+
+  it 'should accept dsc_state predefined value Stopped' do
+    dsc_xwebapppool[:dsc_state] = 'Stopped'
+    expect(dsc_xwebapppool[:dsc_state]).to eq('Stopped')
+  end
+
+  it 'should accept dsc_state predefined value stopped' do
+    dsc_xwebapppool[:dsc_state] = 'stopped'
+    expect(dsc_xwebapppool[:dsc_state]).to eq('stopped')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwebapppool[:dsc_state] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_state' do
+    expect{dsc_xwebapppool[:dsc_state] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_state' do
+    expect{dsc_xwebapppool[:dsc_state] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_state' do
+    expect{dsc_xwebapppool[:dsc_state] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_state' do
+    expect{dsc_xwebapppool[:dsc_state] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwebapppool)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwebapppool)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwebapppool[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwebapppool[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebapppool.original_parameters[:dsc_ensure] = 'present'
+        dsc_xwebapppool[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xwebapppool)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebapppool[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebapppool.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebapppool[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebapppool)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebapppool[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwebapppool)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwebapppool)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWebAppPool as $MSFT_xWebAppPool1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWebAppPool/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebapppool[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xwebapppool)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebapppool[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebapppool[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xwebapppool)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebapppool[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwebconfigkeyvalue_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebconfigkeyvalue_spec.rb
@@ -1,0 +1,354 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwebconfigkeyvalue) do
+
+  let :dsc_xwebconfigkeyvalue do
+    Puppet::Type.type(:dsc_xwebconfigkeyvalue).new(
+      :name     => 'foo',
+      :dsc_websitepath => 'foo',
+      :dsc_configsection => 'AppSettings',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwebconfigkeyvalue.to_s).to eq("Dsc_xwebconfigkeyvalue[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xwebconfigkeyvalue[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_websitepath is specified' do
+    #dsc_xwebconfigkeyvalue[:dsc_websitepath]
+    expect { Puppet::Type.type(:dsc_xwebconfigkeyvalue).new(
+      :name     => 'foo',
+      :dsc_configsection => 'AppSettings',
+      :dsc_ensure => 'Present',
+      :dsc_key => 'foo',
+      :dsc_value => 'foo',
+      :dsc_isattribute => true,
+    )}.to raise_error(Puppet::Error, /dsc_websitepath is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_websitepath' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_websitepath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_websitepath' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_websitepath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_websitepath' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_websitepath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_websitepath' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_websitepath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_configsection is specified' do
+    #dsc_xwebconfigkeyvalue[:dsc_configsection]
+    expect { Puppet::Type.type(:dsc_xwebconfigkeyvalue).new(
+      :name     => 'foo',
+      :dsc_websitepath => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_key => 'foo',
+      :dsc_value => 'foo',
+      :dsc_isattribute => true,
+    )}.to raise_error(Puppet::Error, /dsc_configsection is a required attribute/)
+  end
+
+  it 'should accept dsc_configsection predefined value AppSettings' do
+    dsc_xwebconfigkeyvalue[:dsc_configsection] = 'AppSettings'
+    expect(dsc_xwebconfigkeyvalue[:dsc_configsection]).to eq('AppSettings')
+  end
+
+  it 'should accept dsc_configsection predefined value appsettings' do
+    dsc_xwebconfigkeyvalue[:dsc_configsection] = 'appsettings'
+    expect(dsc_xwebconfigkeyvalue[:dsc_configsection]).to eq('appsettings')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_configsection] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_configsection' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_configsection] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_configsection' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_configsection] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_configsection' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_configsection] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_configsection' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_configsection] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xwebconfigkeyvalue[:dsc_ensure] = 'Present'
+    expect(dsc_xwebconfigkeyvalue[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xwebconfigkeyvalue[:dsc_ensure] = 'present'
+    expect(dsc_xwebconfigkeyvalue[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebconfigkeyvalue[:dsc_ensure] = 'present'
+    expect(dsc_xwebconfigkeyvalue[:ensure]).to eq(dsc_xwebconfigkeyvalue[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xwebconfigkeyvalue[:dsc_ensure] = 'Absent'
+    expect(dsc_xwebconfigkeyvalue[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xwebconfigkeyvalue[:dsc_ensure] = 'absent'
+    expect(dsc_xwebconfigkeyvalue[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebconfigkeyvalue[:dsc_ensure] = 'absent'
+    expect(dsc_xwebconfigkeyvalue[:ensure]).to eq(dsc_xwebconfigkeyvalue[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_key' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_key] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_key' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_key] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_key' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_key] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_key' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_key] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_value' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_value] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_value' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_value] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_value' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_value] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_value' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_value] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_isattribute' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_isattribute] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_isattribute' do
+    dsc_xwebconfigkeyvalue[:dsc_isattribute] = true
+    expect(dsc_xwebconfigkeyvalue[:dsc_isattribute]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_isattribute" do
+    dsc_xwebconfigkeyvalue[:dsc_isattribute] = 'true'
+    expect(dsc_xwebconfigkeyvalue[:dsc_isattribute]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_isattribute" do
+    dsc_xwebconfigkeyvalue[:dsc_isattribute] = 'false'
+    expect(dsc_xwebconfigkeyvalue[:dsc_isattribute]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_isattribute" do
+    dsc_xwebconfigkeyvalue[:dsc_isattribute] = 'True'
+    expect(dsc_xwebconfigkeyvalue[:dsc_isattribute]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_isattribute" do
+    dsc_xwebconfigkeyvalue[:dsc_isattribute] = 'False'
+    expect(dsc_xwebconfigkeyvalue[:dsc_isattribute]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_isattribute" do
+    dsc_xwebconfigkeyvalue[:dsc_isattribute] = :true
+    expect(dsc_xwebconfigkeyvalue[:dsc_isattribute]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_isattribute" do
+    dsc_xwebconfigkeyvalue[:dsc_isattribute] = :false
+    expect(dsc_xwebconfigkeyvalue[:dsc_isattribute]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_isattribute' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_isattribute] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_isattribute' do
+    expect{dsc_xwebconfigkeyvalue[:dsc_isattribute] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwebconfigkeyvalue)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwebconfigkeyvalue)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwebconfigkeyvalue[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwebconfigkeyvalue[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebconfigkeyvalue.original_parameters[:dsc_ensure] = 'present'
+        dsc_xwebconfigkeyvalue[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xwebconfigkeyvalue)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebconfigkeyvalue[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebconfigkeyvalue.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebconfigkeyvalue[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebconfigkeyvalue)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebconfigkeyvalue[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwebconfigkeyvalue)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwebconfigkeyvalue)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWebConfigKeyValue as $MSFT_xWebConfigKeyValue1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWebConfigKeyValue/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebconfigkeyvalue[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xwebconfigkeyvalue)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebconfigkeyvalue[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebconfigkeyvalue[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xwebconfigkeyvalue)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebconfigkeyvalue[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwebsite_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebsite_spec.rb
@@ -1,0 +1,356 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwebsite) do
+
+  let :dsc_xwebsite do
+    Puppet::Type.type(:dsc_xwebsite).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwebsite.to_s).to eq("Dsc_xwebsite[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xwebsite[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xwebsite[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xwebsite).new(
+      :name     => 'foo',
+      :dsc_physicalpath => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_state => 'Started',
+      :dsc_bindinginfo => ["foo", "bar", "spec"],
+      :dsc_applicationpool => 'foo',
+      :dsc_id => 'foo',
+      :dsc_defaultpage => ["foo", "bar", "spec"],
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xwebsite[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xwebsite[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xwebsite[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xwebsite[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_physicalpath' do
+    expect{dsc_xwebsite[:dsc_physicalpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_physicalpath' do
+    expect{dsc_xwebsite[:dsc_physicalpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_physicalpath' do
+    expect{dsc_xwebsite[:dsc_physicalpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_physicalpath' do
+    expect{dsc_xwebsite[:dsc_physicalpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xwebsite[:dsc_ensure] = 'Present'
+    expect(dsc_xwebsite[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xwebsite[:dsc_ensure] = 'present'
+    expect(dsc_xwebsite[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebsite[:dsc_ensure] = 'present'
+    expect(dsc_xwebsite[:ensure]).to eq(dsc_xwebsite[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xwebsite[:dsc_ensure] = 'Absent'
+    expect(dsc_xwebsite[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xwebsite[:dsc_ensure] = 'absent'
+    expect(dsc_xwebsite[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebsite[:dsc_ensure] = 'absent'
+    expect(dsc_xwebsite[:ensure]).to eq(dsc_xwebsite[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwebsite[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xwebsite[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xwebsite[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xwebsite[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xwebsite[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_state predefined value Started' do
+    dsc_xwebsite[:dsc_state] = 'Started'
+    expect(dsc_xwebsite[:dsc_state]).to eq('Started')
+  end
+
+  it 'should accept dsc_state predefined value started' do
+    dsc_xwebsite[:dsc_state] = 'started'
+    expect(dsc_xwebsite[:dsc_state]).to eq('started')
+  end
+
+  it 'should accept dsc_state predefined value Stopped' do
+    dsc_xwebsite[:dsc_state] = 'Stopped'
+    expect(dsc_xwebsite[:dsc_state]).to eq('Stopped')
+  end
+
+  it 'should accept dsc_state predefined value stopped' do
+    dsc_xwebsite[:dsc_state] = 'stopped'
+    expect(dsc_xwebsite[:dsc_state]).to eq('stopped')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwebsite[:dsc_state] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_state' do
+    expect{dsc_xwebsite[:dsc_state] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_state' do
+    expect{dsc_xwebsite[:dsc_state] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_state' do
+    expect{dsc_xwebsite[:dsc_state] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_state' do
+    expect{dsc_xwebsite[:dsc_state] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_bindinginfo' do
+    dsc_xwebsite[:dsc_bindinginfo] = ["foo", "bar", "spec"]
+    expect(dsc_xwebsite[:dsc_bindinginfo]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_bindinginfo' do
+    expect{dsc_xwebsite[:dsc_bindinginfo] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_bindinginfo' do
+    expect{dsc_xwebsite[:dsc_bindinginfo] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_bindinginfo' do
+    expect{dsc_xwebsite[:dsc_bindinginfo] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_applicationpool' do
+    expect{dsc_xwebsite[:dsc_applicationpool] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_applicationpool' do
+    expect{dsc_xwebsite[:dsc_applicationpool] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_applicationpool' do
+    expect{dsc_xwebsite[:dsc_applicationpool] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_applicationpool' do
+    expect{dsc_xwebsite[:dsc_applicationpool] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_id' do
+    expect{dsc_xwebsite[:dsc_id] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_id' do
+    expect{dsc_xwebsite[:dsc_id] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_id' do
+    expect{dsc_xwebsite[:dsc_id] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_id' do
+    expect{dsc_xwebsite[:dsc_id] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_defaultpage' do
+    dsc_xwebsite[:dsc_defaultpage] = ["foo", "bar", "spec"]
+    expect(dsc_xwebsite[:dsc_defaultpage]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_defaultpage' do
+    expect{dsc_xwebsite[:dsc_defaultpage] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_defaultpage' do
+    expect{dsc_xwebsite[:dsc_defaultpage] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_defaultpage' do
+    expect{dsc_xwebsite[:dsc_defaultpage] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwebsite)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwebsite)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwebsite[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwebsite[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebsite.original_parameters[:dsc_ensure] = 'present'
+        dsc_xwebsite[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xwebsite)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebsite[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebsite.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebsite[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebsite)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebsite[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwebsite)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwebsite)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWebsite as $MSFT_xWebsite1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWebsite/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebsite[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xwebsite)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebsite[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebsite[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xwebsite)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebsite[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwebvirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebvirtualdirectory_spec.rb
@@ -1,0 +1,303 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwebvirtualdirectory) do
+
+  let :dsc_xwebvirtualdirectory do
+    Puppet::Type.type(:dsc_xwebvirtualdirectory).new(
+      :name     => 'foo',
+      :dsc_website => 'foo',
+      :dsc_webapplication => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwebvirtualdirectory.to_s).to eq("Dsc_xwebvirtualdirectory[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xwebvirtualdirectory[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_website is specified' do
+    #dsc_xwebvirtualdirectory[:dsc_website]
+    expect { Puppet::Type.type(:dsc_xwebvirtualdirectory).new(
+      :name     => 'foo',
+      :dsc_webapplication => 'foo',
+      :dsc_name => 'foo',
+      :dsc_physicalpath => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_website is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_website' do
+    expect{dsc_xwebvirtualdirectory[:dsc_website] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_website' do
+    expect{dsc_xwebvirtualdirectory[:dsc_website] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_website' do
+    expect{dsc_xwebvirtualdirectory[:dsc_website] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_website' do
+    expect{dsc_xwebvirtualdirectory[:dsc_website] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_webapplication is specified' do
+    #dsc_xwebvirtualdirectory[:dsc_webapplication]
+    expect { Puppet::Type.type(:dsc_xwebvirtualdirectory).new(
+      :name     => 'foo',
+      :dsc_website => 'foo',
+      :dsc_name => 'foo',
+      :dsc_physicalpath => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_webapplication is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_webapplication' do
+    expect{dsc_xwebvirtualdirectory[:dsc_webapplication] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_webapplication' do
+    expect{dsc_xwebvirtualdirectory[:dsc_webapplication] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_webapplication' do
+    expect{dsc_xwebvirtualdirectory[:dsc_webapplication] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_webapplication' do
+    expect{dsc_xwebvirtualdirectory[:dsc_webapplication] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xwebvirtualdirectory[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xwebvirtualdirectory).new(
+      :name     => 'foo',
+      :dsc_website => 'foo',
+      :dsc_webapplication => 'foo',
+      :dsc_physicalpath => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xwebvirtualdirectory[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xwebvirtualdirectory[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xwebvirtualdirectory[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xwebvirtualdirectory[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_physicalpath' do
+    expect{dsc_xwebvirtualdirectory[:dsc_physicalpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_physicalpath' do
+    expect{dsc_xwebvirtualdirectory[:dsc_physicalpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_physicalpath' do
+    expect{dsc_xwebvirtualdirectory[:dsc_physicalpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_physicalpath' do
+    expect{dsc_xwebvirtualdirectory[:dsc_physicalpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xwebvirtualdirectory[:dsc_ensure] = 'Present'
+    expect(dsc_xwebvirtualdirectory[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xwebvirtualdirectory[:dsc_ensure] = 'present'
+    expect(dsc_xwebvirtualdirectory[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebvirtualdirectory[:dsc_ensure] = 'present'
+    expect(dsc_xwebvirtualdirectory[:ensure]).to eq(dsc_xwebvirtualdirectory[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xwebvirtualdirectory[:dsc_ensure] = 'Absent'
+    expect(dsc_xwebvirtualdirectory[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xwebvirtualdirectory[:dsc_ensure] = 'absent'
+    expect(dsc_xwebvirtualdirectory[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwebvirtualdirectory[:dsc_ensure] = 'absent'
+    expect(dsc_xwebvirtualdirectory[:ensure]).to eq(dsc_xwebvirtualdirectory[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwebvirtualdirectory[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xwebvirtualdirectory[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xwebvirtualdirectory[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xwebvirtualdirectory[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xwebvirtualdirectory[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwebvirtualdirectory)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwebvirtualdirectory)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwebvirtualdirectory[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwebvirtualdirectory[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebvirtualdirectory.original_parameters[:dsc_ensure] = 'present'
+        dsc_xwebvirtualdirectory[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xwebvirtualdirectory)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebvirtualdirectory[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebvirtualdirectory.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebvirtualdirectory[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebvirtualdirectory)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebvirtualdirectory[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwebvirtualdirectory)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwebvirtualdirectory)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWebVirtualDirectory as $MSFT_xWebVirtualDirectory1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWebVirtualDirectory/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwebvirtualdirectory[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xwebvirtualdirectory)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwebvirtualdirectory[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwebvirtualdirectory[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xwebvirtualdirectory)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwebvirtualdirectory[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwindowsoptionalfeature_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwindowsoptionalfeature_spec.rb
@@ -1,0 +1,462 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwindowsoptionalfeature) do
+
+  let :dsc_xwindowsoptionalfeature do
+    Puppet::Type.type(:dsc_xwindowsoptionalfeature).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwindowsoptionalfeature.to_s).to eq("Dsc_xwindowsoptionalfeature[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xwindowsoptionalfeature[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_xwindowsoptionalfeature[:dsc_name]
+    expect { Puppet::Type.type(:dsc_xwindowsoptionalfeature).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_source => ["foo", "bar", "spec"],
+      :dsc_nowindowsupdatecheck => true,
+      :dsc_removefilesondisable => true,
+      :dsc_loglevel => 'ErrorsOnly',
+      :dsc_logpath => 'foo',
+      :dsc_customproperties => ["foo", "bar", "spec"],
+      :dsc_description => 'foo',
+      :dsc_displayname => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xwindowsoptionalfeature[:dsc_ensure] = 'Present'
+    expect(dsc_xwindowsoptionalfeature[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xwindowsoptionalfeature[:dsc_ensure] = 'present'
+    expect(dsc_xwindowsoptionalfeature[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwindowsoptionalfeature[:dsc_ensure] = 'present'
+    expect(dsc_xwindowsoptionalfeature[:ensure]).to eq(dsc_xwindowsoptionalfeature[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xwindowsoptionalfeature[:dsc_ensure] = 'Absent'
+    expect(dsc_xwindowsoptionalfeature[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xwindowsoptionalfeature[:dsc_ensure] = 'absent'
+    expect(dsc_xwindowsoptionalfeature[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwindowsoptionalfeature[:dsc_ensure] = 'absent'
+    expect(dsc_xwindowsoptionalfeature[:ensure]).to eq(dsc_xwindowsoptionalfeature[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_source' do
+    dsc_xwindowsoptionalfeature[:dsc_source] = ["foo", "bar", "spec"]
+    expect(dsc_xwindowsoptionalfeature[:dsc_source]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_source' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_source] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_source' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_source] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_source' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_source] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_nowindowsupdatecheck' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_nowindowsupdatecheck' do
+    dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = true
+    expect(dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_nowindowsupdatecheck" do
+    dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = 'true'
+    expect(dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_nowindowsupdatecheck" do
+    dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = 'false'
+    expect(dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_nowindowsupdatecheck" do
+    dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = 'True'
+    expect(dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_nowindowsupdatecheck" do
+    dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = 'False'
+    expect(dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_nowindowsupdatecheck" do
+    dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = :true
+    expect(dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_nowindowsupdatecheck" do
+    dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = :false
+    expect(dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_nowindowsupdatecheck' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_nowindowsupdatecheck' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_nowindowsupdatecheck] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_removefilesondisable' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_removefilesondisable' do
+    dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = true
+    expect(dsc_xwindowsoptionalfeature[:dsc_removefilesondisable]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_removefilesondisable" do
+    dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = 'true'
+    expect(dsc_xwindowsoptionalfeature[:dsc_removefilesondisable]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_removefilesondisable" do
+    dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = 'false'
+    expect(dsc_xwindowsoptionalfeature[:dsc_removefilesondisable]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_removefilesondisable" do
+    dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = 'True'
+    expect(dsc_xwindowsoptionalfeature[:dsc_removefilesondisable]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_removefilesondisable" do
+    dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = 'False'
+    expect(dsc_xwindowsoptionalfeature[:dsc_removefilesondisable]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_removefilesondisable" do
+    dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = :true
+    expect(dsc_xwindowsoptionalfeature[:dsc_removefilesondisable]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_removefilesondisable" do
+    dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = :false
+    expect(dsc_xwindowsoptionalfeature[:dsc_removefilesondisable]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_removefilesondisable' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_removefilesondisable' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_removefilesondisable] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_loglevel predefined value ErrorsOnly' do
+    dsc_xwindowsoptionalfeature[:dsc_loglevel] = 'ErrorsOnly'
+    expect(dsc_xwindowsoptionalfeature[:dsc_loglevel]).to eq('ErrorsOnly')
+  end
+
+  it 'should accept dsc_loglevel predefined value errorsonly' do
+    dsc_xwindowsoptionalfeature[:dsc_loglevel] = 'errorsonly'
+    expect(dsc_xwindowsoptionalfeature[:dsc_loglevel]).to eq('errorsonly')
+  end
+
+  it 'should accept dsc_loglevel predefined value ErrorsAndWarning' do
+    dsc_xwindowsoptionalfeature[:dsc_loglevel] = 'ErrorsAndWarning'
+    expect(dsc_xwindowsoptionalfeature[:dsc_loglevel]).to eq('ErrorsAndWarning')
+  end
+
+  it 'should accept dsc_loglevel predefined value errorsandwarning' do
+    dsc_xwindowsoptionalfeature[:dsc_loglevel] = 'errorsandwarning'
+    expect(dsc_xwindowsoptionalfeature[:dsc_loglevel]).to eq('errorsandwarning')
+  end
+
+  it 'should accept dsc_loglevel predefined value ErrorsAndWarningAndInformation' do
+    dsc_xwindowsoptionalfeature[:dsc_loglevel] = 'ErrorsAndWarningAndInformation'
+    expect(dsc_xwindowsoptionalfeature[:dsc_loglevel]).to eq('ErrorsAndWarningAndInformation')
+  end
+
+  it 'should accept dsc_loglevel predefined value errorsandwarningandinformation' do
+    dsc_xwindowsoptionalfeature[:dsc_loglevel] = 'errorsandwarningandinformation'
+    expect(dsc_xwindowsoptionalfeature[:dsc_loglevel]).to eq('errorsandwarningandinformation')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_loglevel] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_loglevel' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_loglevel] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_loglevel' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_loglevel] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_loglevel' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_loglevel] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_loglevel' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_loglevel] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_logpath' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_logpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_logpath' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_logpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_logpath' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_logpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_logpath' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_logpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept array for dsc_customproperties' do
+    dsc_xwindowsoptionalfeature[:dsc_customproperties] = ["foo", "bar", "spec"]
+    expect(dsc_xwindowsoptionalfeature[:dsc_customproperties]).to eq(["foo", "bar", "spec"])
+  end
+
+  it 'should not accept boolean for dsc_customproperties' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_customproperties] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_customproperties' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_customproperties] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_customproperties' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_customproperties] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_displayname' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_displayname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_displayname' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_displayname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_displayname' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_displayname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_displayname' do
+    expect{dsc_xwindowsoptionalfeature[:dsc_displayname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwindowsoptionalfeature)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwindowsoptionalfeature)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwindowsoptionalfeature[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwindowsoptionalfeature[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwindowsoptionalfeature.original_parameters[:dsc_ensure] = 'present'
+        dsc_xwindowsoptionalfeature[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xwindowsoptionalfeature)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwindowsoptionalfeature[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwindowsoptionalfeature.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwindowsoptionalfeature[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwindowsoptionalfeature)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwindowsoptionalfeature[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwindowsoptionalfeature)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwindowsoptionalfeature)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWindowsOptionalFeature as $MSFT_xWindowsOptionalFeature1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWindowsOptionalFeature/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwindowsoptionalfeature[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xwindowsoptionalfeature)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwindowsoptionalfeature[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwindowsoptionalfeature[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xwindowsoptionalfeature)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwindowsoptionalfeature[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwindowsprocess_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwindowsprocess_spec.rb
@@ -1,0 +1,582 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwindowsprocess) do
+
+  let :dsc_xwindowsprocess do
+    Puppet::Type.type(:dsc_xwindowsprocess).new(
+      :name     => 'foo',
+      :dsc_path => 'foo',
+      :dsc_arguments => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwindowsprocess.to_s).to eq("Dsc_xwindowsprocess[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xwindowsprocess[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_path is specified' do
+    #dsc_xwindowsprocess[:dsc_path]
+    expect { Puppet::Type.type(:dsc_xwindowsprocess).new(
+      :name     => 'foo',
+      :dsc_arguments => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_standardoutputpath => 'foo',
+      :dsc_standarderrorpath => 'foo',
+      :dsc_standardinputpath => 'foo',
+      :dsc_workingdirectory => 'foo',
+      :dsc_pagedmemorysize => 64,
+      :dsc_nonpagedmemorysize => 64,
+      :dsc_virtualmemorysize => 64,
+      :dsc_handlecount => -32,
+      :dsc_processid => -32,
+    )}.to raise_error(Puppet::Error, /dsc_path is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_path' do
+    expect{dsc_xwindowsprocess[:dsc_path] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_path' do
+    expect{dsc_xwindowsprocess[:dsc_path] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_path' do
+    expect{dsc_xwindowsprocess[:dsc_path] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_path' do
+    expect{dsc_xwindowsprocess[:dsc_path] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_arguments is specified' do
+    #dsc_xwindowsprocess[:dsc_arguments]
+    expect { Puppet::Type.type(:dsc_xwindowsprocess).new(
+      :name     => 'foo',
+      :dsc_path => 'foo',
+      :dsc_credential => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_standardoutputpath => 'foo',
+      :dsc_standarderrorpath => 'foo',
+      :dsc_standardinputpath => 'foo',
+      :dsc_workingdirectory => 'foo',
+      :dsc_pagedmemorysize => 64,
+      :dsc_nonpagedmemorysize => 64,
+      :dsc_virtualmemorysize => 64,
+      :dsc_handlecount => -32,
+      :dsc_processid => -32,
+    )}.to raise_error(Puppet::Error, /dsc_arguments is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_arguments' do
+    expect{dsc_xwindowsprocess[:dsc_arguments] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_arguments' do
+    expect{dsc_xwindowsprocess[:dsc_arguments] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_arguments' do
+    expect{dsc_xwindowsprocess[:dsc_arguments] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_arguments' do
+    expect{dsc_xwindowsprocess[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_credential' do
+    expect{dsc_xwindowsprocess[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_credential' do
+    expect{dsc_xwindowsprocess[:dsc_credential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_credential' do
+    expect{dsc_xwindowsprocess[:dsc_credential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_credential' do
+    expect{dsc_xwindowsprocess[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xwindowsprocess[:dsc_ensure] = 'Present'
+    expect(dsc_xwindowsprocess[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xwindowsprocess[:dsc_ensure] = 'present'
+    expect(dsc_xwindowsprocess[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwindowsprocess[:dsc_ensure] = 'present'
+    expect(dsc_xwindowsprocess[:ensure]).to eq(dsc_xwindowsprocess[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xwindowsprocess[:dsc_ensure] = 'Absent'
+    expect(dsc_xwindowsprocess[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xwindowsprocess[:dsc_ensure] = 'absent'
+    expect(dsc_xwindowsprocess[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwindowsprocess[:dsc_ensure] = 'absent'
+    expect(dsc_xwindowsprocess[:ensure]).to eq(dsc_xwindowsprocess[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwindowsprocess[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xwindowsprocess[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xwindowsprocess[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xwindowsprocess[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xwindowsprocess[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_standardoutputpath' do
+    expect{dsc_xwindowsprocess[:dsc_standardoutputpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_standardoutputpath' do
+    expect{dsc_xwindowsprocess[:dsc_standardoutputpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_standardoutputpath' do
+    expect{dsc_xwindowsprocess[:dsc_standardoutputpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_standardoutputpath' do
+    expect{dsc_xwindowsprocess[:dsc_standardoutputpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_standarderrorpath' do
+    expect{dsc_xwindowsprocess[:dsc_standarderrorpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_standarderrorpath' do
+    expect{dsc_xwindowsprocess[:dsc_standarderrorpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_standarderrorpath' do
+    expect{dsc_xwindowsprocess[:dsc_standarderrorpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_standarderrorpath' do
+    expect{dsc_xwindowsprocess[:dsc_standarderrorpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_standardinputpath' do
+    expect{dsc_xwindowsprocess[:dsc_standardinputpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_standardinputpath' do
+    expect{dsc_xwindowsprocess[:dsc_standardinputpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_standardinputpath' do
+    expect{dsc_xwindowsprocess[:dsc_standardinputpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_standardinputpath' do
+    expect{dsc_xwindowsprocess[:dsc_standardinputpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_workingdirectory' do
+    expect{dsc_xwindowsprocess[:dsc_workingdirectory] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_workingdirectory' do
+    expect{dsc_xwindowsprocess[:dsc_workingdirectory] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_workingdirectory' do
+    expect{dsc_xwindowsprocess[:dsc_workingdirectory] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_workingdirectory' do
+    expect{dsc_xwindowsprocess[:dsc_workingdirectory] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_pagedmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_pagedmemorysize] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_pagedmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_pagedmemorysize] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_pagedmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_pagedmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_pagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_pagedmemorysize] = 64
+    expect(dsc_xwindowsprocess[:dsc_pagedmemorysize]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_pagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_pagedmemorysize] = '16'
+    expect(dsc_xwindowsprocess[:dsc_pagedmemorysize]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_pagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_pagedmemorysize] = '32'
+    expect(dsc_xwindowsprocess[:dsc_pagedmemorysize]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_pagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_pagedmemorysize] = '64'
+    expect(dsc_xwindowsprocess[:dsc_pagedmemorysize]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_nonpagedmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_nonpagedmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_nonpagedmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_nonpagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = 64
+    expect(dsc_xwindowsprocess[:dsc_nonpagedmemorysize]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_nonpagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = '16'
+    expect(dsc_xwindowsprocess[:dsc_nonpagedmemorysize]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_nonpagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = '32'
+    expect(dsc_xwindowsprocess[:dsc_nonpagedmemorysize]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_nonpagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = '64'
+    expect(dsc_xwindowsprocess[:dsc_nonpagedmemorysize]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_virtualmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_virtualmemorysize] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_virtualmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_virtualmemorysize] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_virtualmemorysize' do
+    expect{dsc_xwindowsprocess[:dsc_virtualmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_virtualmemorysize' do
+    dsc_xwindowsprocess[:dsc_virtualmemorysize] = 64
+    expect(dsc_xwindowsprocess[:dsc_virtualmemorysize]).to eq(64)
+  end
+
+
+  it 'should accept string-like int for dsc_virtualmemorysize' do
+    dsc_xwindowsprocess[:dsc_virtualmemorysize] = '16'
+    expect(dsc_xwindowsprocess[:dsc_virtualmemorysize]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_virtualmemorysize' do
+    dsc_xwindowsprocess[:dsc_virtualmemorysize] = '32'
+    expect(dsc_xwindowsprocess[:dsc_virtualmemorysize]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_virtualmemorysize' do
+    dsc_xwindowsprocess[:dsc_virtualmemorysize] = '64'
+    expect(dsc_xwindowsprocess[:dsc_virtualmemorysize]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_handlecount' do
+    expect{dsc_xwindowsprocess[:dsc_handlecount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_handlecount' do
+    expect{dsc_xwindowsprocess[:dsc_handlecount] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept int for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = -32
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(-32)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = '16'
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = '-16'
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(-16)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = '32'
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = '-32'
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(-32)
+  end
+
+
+  it 'should accept uint for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = -32
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(-32)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = '16'
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = '32'
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_handlecount' do
+    dsc_xwindowsprocess[:dsc_handlecount] = '64'
+    expect(dsc_xwindowsprocess[:dsc_handlecount]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_processid' do
+    expect{dsc_xwindowsprocess[:dsc_processid] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_processid' do
+    expect{dsc_xwindowsprocess[:dsc_processid] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept int for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = -32
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(-32)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = '16'
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = '-16'
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(-16)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = '32'
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = '-32'
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(-32)
+  end
+
+
+  it 'should accept uint for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = -32
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(-32)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = '16'
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = '32'
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_processid' do
+    dsc_xwindowsprocess[:dsc_processid] = '64'
+    expect(dsc_xwindowsprocess[:dsc_processid]).to eq(64)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwindowsprocess)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwindowsprocess)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwindowsprocess[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwindowsprocess[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwindowsprocess.original_parameters[:dsc_ensure] = 'present'
+        dsc_xwindowsprocess[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xwindowsprocess)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwindowsprocess[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwindowsprocess.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwindowsprocess[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwindowsprocess)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwindowsprocess[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwindowsprocess)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwindowsprocess)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xProcessResource as $MSFT_xProcessResource1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xProcessResource/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwindowsprocess[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xwindowsprocess)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwindowsprocess[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwindowsprocess[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xwindowsprocess)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwindowsprocess[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwineventlog_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwineventlog_spec.rb
@@ -1,0 +1,277 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwineventlog) do
+
+  let :dsc_xwineventlog do
+    Puppet::Type.type(:dsc_xwineventlog).new(
+      :name     => 'foo',
+      :dsc_logname => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwineventlog.to_s).to eq("Dsc_xwineventlog[foo]")
+  end
+
+  it 'should require that dsc_logname is specified' do
+    #dsc_xwineventlog[:dsc_logname]
+    expect { Puppet::Type.type(:dsc_xwineventlog).new(
+      :name     => 'foo',
+      :dsc_maximumsizeinbytes => -64,
+      :dsc_isenabled => true,
+      :dsc_logmode => 'AutoBackup',
+      :dsc_securitydescriptor => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_logname is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_logname' do
+    expect{dsc_xwineventlog[:dsc_logname] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_logname' do
+    expect{dsc_xwineventlog[:dsc_logname] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_logname' do
+    expect{dsc_xwineventlog[:dsc_logname] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_logname' do
+    expect{dsc_xwineventlog[:dsc_logname] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_maximumsizeinbytes' do
+    expect{dsc_xwineventlog[:dsc_maximumsizeinbytes] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_maximumsizeinbytes' do
+    expect{dsc_xwineventlog[:dsc_maximumsizeinbytes] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept int for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = -64
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(-64)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = '16'
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = '-16'
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(-16)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = '32'
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = '-32'
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(-32)
+  end
+
+
+  it 'should accept uint for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = -64
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(-64)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = '16'
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(16)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = '32'
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(32)
+  end
+
+
+  it 'should accept string-like int for dsc_maximumsizeinbytes' do
+    dsc_xwineventlog[:dsc_maximumsizeinbytes] = '64'
+    expect(dsc_xwineventlog[:dsc_maximumsizeinbytes]).to eq(64)
+  end
+
+  it 'should not accept array for dsc_isenabled' do
+    expect{dsc_xwineventlog[:dsc_isenabled] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_isenabled' do
+    dsc_xwineventlog[:dsc_isenabled] = true
+    expect(dsc_xwineventlog[:dsc_isenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_isenabled" do
+    dsc_xwineventlog[:dsc_isenabled] = 'true'
+    expect(dsc_xwineventlog[:dsc_isenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_isenabled" do
+    dsc_xwineventlog[:dsc_isenabled] = 'false'
+    expect(dsc_xwineventlog[:dsc_isenabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_isenabled" do
+    dsc_xwineventlog[:dsc_isenabled] = 'True'
+    expect(dsc_xwineventlog[:dsc_isenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_isenabled" do
+    dsc_xwineventlog[:dsc_isenabled] = 'False'
+    expect(dsc_xwineventlog[:dsc_isenabled]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_isenabled" do
+    dsc_xwineventlog[:dsc_isenabled] = :true
+    expect(dsc_xwineventlog[:dsc_isenabled]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_isenabled" do
+    dsc_xwineventlog[:dsc_isenabled] = :false
+    expect(dsc_xwineventlog[:dsc_isenabled]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_isenabled' do
+    expect{dsc_xwineventlog[:dsc_isenabled] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_isenabled' do
+    expect{dsc_xwineventlog[:dsc_isenabled] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_logmode predefined value AutoBackup' do
+    dsc_xwineventlog[:dsc_logmode] = 'AutoBackup'
+    expect(dsc_xwineventlog[:dsc_logmode]).to eq('AutoBackup')
+  end
+
+  it 'should accept dsc_logmode predefined value autobackup' do
+    dsc_xwineventlog[:dsc_logmode] = 'autobackup'
+    expect(dsc_xwineventlog[:dsc_logmode]).to eq('autobackup')
+  end
+
+  it 'should accept dsc_logmode predefined value Circular' do
+    dsc_xwineventlog[:dsc_logmode] = 'Circular'
+    expect(dsc_xwineventlog[:dsc_logmode]).to eq('Circular')
+  end
+
+  it 'should accept dsc_logmode predefined value circular' do
+    dsc_xwineventlog[:dsc_logmode] = 'circular'
+    expect(dsc_xwineventlog[:dsc_logmode]).to eq('circular')
+  end
+
+  it 'should accept dsc_logmode predefined value Retain' do
+    dsc_xwineventlog[:dsc_logmode] = 'Retain'
+    expect(dsc_xwineventlog[:dsc_logmode]).to eq('Retain')
+  end
+
+  it 'should accept dsc_logmode predefined value retain' do
+    dsc_xwineventlog[:dsc_logmode] = 'retain'
+    expect(dsc_xwineventlog[:dsc_logmode]).to eq('retain')
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwineventlog[:dsc_logmode] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_logmode' do
+    expect{dsc_xwineventlog[:dsc_logmode] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_logmode' do
+    expect{dsc_xwineventlog[:dsc_logmode] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_logmode' do
+    expect{dsc_xwineventlog[:dsc_logmode] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_logmode' do
+    expect{dsc_xwineventlog[:dsc_logmode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_securitydescriptor' do
+    expect{dsc_xwineventlog[:dsc_securitydescriptor] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_securitydescriptor' do
+    expect{dsc_xwineventlog[:dsc_securitydescriptor] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_securitydescriptor' do
+    expect{dsc_xwineventlog[:dsc_securitydescriptor] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_securitydescriptor' do
+    expect{dsc_xwineventlog[:dsc_securitydescriptor] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwineventlog)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwineventlog)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwineventlog[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwineventlog[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwineventlog)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwineventlog)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWinEventLog as $MSFT_xWinEventLog1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWinEventLog/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_xwordpresssite_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwordpresssite_spec.rb
@@ -1,0 +1,279 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_xwordpresssite) do
+
+  let :dsc_xwordpresssite do
+    Puppet::Type.type(:dsc_xwordpresssite).new(
+      :name     => 'foo',
+      :dsc_uri => 'foo',
+    )
+  end
+
+  it "should stringify normally" do
+    expect(dsc_xwordpresssite.to_s).to eq("Dsc_xwordpresssite[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_xwordpresssite[:ensure]).to eq :present
+  end
+
+  it 'should require that dsc_uri is specified' do
+    #dsc_xwordpresssite[:dsc_uri]
+    expect { Puppet::Type.type(:dsc_xwordpresssite).new(
+      :name     => 'foo',
+      :dsc_title => 'foo',
+      :dsc_administratorcredential => 'foo',
+      :dsc_administratoremail => 'foo',
+      :dsc_ensure => 'Present',
+    )}.to raise_error(Puppet::Error, /dsc_uri is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_uri' do
+    expect{dsc_xwordpresssite[:dsc_uri] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_uri' do
+    expect{dsc_xwordpresssite[:dsc_uri] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_uri' do
+    expect{dsc_xwordpresssite[:dsc_uri] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_uri' do
+    expect{dsc_xwordpresssite[:dsc_uri] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_title' do
+    expect{dsc_xwordpresssite[:dsc_title] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_title' do
+    expect{dsc_xwordpresssite[:dsc_title] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_title' do
+    expect{dsc_xwordpresssite[:dsc_title] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_title' do
+    expect{dsc_xwordpresssite[:dsc_title] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_administratorcredential' do
+    expect{dsc_xwordpresssite[:dsc_administratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_administratorcredential' do
+    expect{dsc_xwordpresssite[:dsc_administratorcredential] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_administratorcredential' do
+    expect{dsc_xwordpresssite[:dsc_administratorcredential] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_administratorcredential' do
+    expect{dsc_xwordpresssite[:dsc_administratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_administratoremail' do
+    expect{dsc_xwordpresssite[:dsc_administratoremail] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_administratoremail' do
+    expect{dsc_xwordpresssite[:dsc_administratoremail] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_administratoremail' do
+    expect{dsc_xwordpresssite[:dsc_administratoremail] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_administratoremail' do
+    expect{dsc_xwordpresssite[:dsc_administratoremail] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_xwordpresssite[:dsc_ensure] = 'Present'
+    expect(dsc_xwordpresssite[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_xwordpresssite[:dsc_ensure] = 'present'
+    expect(dsc_xwordpresssite[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwordpresssite[:dsc_ensure] = 'present'
+    expect(dsc_xwordpresssite[:ensure]).to eq(dsc_xwordpresssite[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_xwordpresssite[:dsc_ensure] = 'Absent'
+    expect(dsc_xwordpresssite[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_xwordpresssite[:dsc_ensure] = 'absent'
+    expect(dsc_xwordpresssite[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_xwordpresssite[:dsc_ensure] = 'absent'
+    expect(dsc_xwordpresssite[:ensure]).to eq(dsc_xwordpresssite[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_xwordpresssite[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_xwordpresssite[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_xwordpresssite[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_xwordpresssite[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_xwordpresssite[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_xwordpresssite)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_xwordpresssite)
+    end
+
+    describe "when dscmeta_import_resource is true (default) and dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Import-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script with Import-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dscmeta_import_resource is false" do
+
+      it "should compute powershell dsc test script without Import-DscResource" do
+        dsc_xwordpresssite[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('test')).not_to match(/Import-DscResource/)
+      end
+
+      it "should compute powershell dsc set script without Import-DscResource" do
+        dsc_xwordpresssite[:dscmeta_import_resource] = false
+        expect(@provider.ps_script_content('set')).not_to match(/Import-DscResource/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwordpresssite.original_parameters[:dsc_ensure] = 'present'
+        dsc_xwordpresssite[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_xwordpresssite)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwordpresssite[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwordpresssite.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwordpresssite[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwordpresssite)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwordpresssite[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+
+  # mof PROVIDERS TESTS
+
+  describe "mof provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:mof).new(dsc_xwordpresssite)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:mof).new(dsc_xwordpresssite)
+    end
+
+    it "should successfully build mof file" do
+#     expect(@provider.mof_test_content).to match(/instance of MSFT_xWordPressSite as $MSFT_xWordPressSite1ref$/)
+      expect(@provider.mof_test_content).to match(/instance of MSFT_xWordPressSite/)
+    end
+
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_xwordpresssite[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:mof).new(dsc_xwordpresssite)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_xwordpresssite[:ensure]).to eq(:present)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_xwordpresssite[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:mof).new(dsc_xwordpresssite)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_xwordpresssite[:ensure]).to eq(:absent)
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
Previously to use this type, it would require having the ability to
actually build the types and generate them from the DSC MOF repos and
use the MOF parser, hoping everything was set up correctly so the end
result was built types. However that keeps it from being usable out of
the box. The code generator is meant to save time for
creation/maintenance of the types, but should not be relied on to be
used every time someone would like to work on the module. It may be
best in the generation to include a note at the top that the generated
type should not be changed, but the underlying MOF that the type is
generated from.

Without this change, it would not be possible to easily use the module
from github.
