### PR TITLE
(MODULES-1957) use original MOF gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'librarian-puppet', '>=1.0.2'
 group :build do
   gem 'librarian-repo', :git => 'https://github.com/msutter/librarian-repo.git'
   gem 'cim'
-  gem 'mof', :git => 'https://github.com/msutter/mof.git'
+  gem 'mof'
   gem 'charlock_holmes'
 end
 

--- a/build/dsc/mof.rb
+++ b/build/dsc/mof.rb
@@ -42,7 +42,7 @@ module Dsc
       create_index_mof(@dsc_base_mof, base_mof_file_pathes)
 
       moffiles, options = MOF::Parser.argv_handler "moflint", []
-      options[:style] ||= :cim;
+      options[:style] ||= :wmi
       options[:includes] ||= []
       options[:quiet] ||= false
 


### PR DESCRIPTION
Blocked by #5.

Switch over to using original MOF parser from ruby gems.

Use WMI style instead of CIM.