### PR TITLE
(maint) Ensure CI can execute against Ruby 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ end
 group :development do
   gem 'puppet-blacksmith'
   gem 'pry'
+
+  gem 'iconv', '~> 1.0.4' if RUBY_VERSION >= '2.0'
 end
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
 - Prior to this change, tests could execute under Ruby 1.9.3,
   but failed under Ruby 2 in our CI environment with:

   Running tests
     rake aborted!
     LoadError: cannot load such file -- iconv
     /tmp/tmp.egwevqY6m1/ruby/2.1.0/gems/mof-1.2.2/lib/mof/scanner.rb:22:in `require'

 - This change includes the iconv gem on Ruby 2+ platforms so that
   tests may be executed.  It's possible that the mof gem will
   later feature updates to make it a Ruby 1.9.3+ gem that will no
   longer require iconv, but this workaround fixes the issue for now