### PR TITLE
(FM-2783) Fix Module Failure on WMF5 base resources

### DIFF
--- a/lib/puppet_x/msutter/templates/set_dsc_configuration.erb
+++ b/lib/puppet_x/msutter/templates/set_dsc_configuration.erb
@@ -6,10 +6,8 @@ Remove-Item $LCMConfigFolder\*.mof | out-null
 
 configuration PuppetConfiguration
 {
-<% unless ['msft_filedirectoryconfiguration'].include?(resource[:dscmeta_resource_name].downcase) -%>
 <%   if resource.parameters[:dscmeta_module_name] && resource[:dscmeta_import_resource] -%>
-    Import-DscResource <%= "-Name #{resource[:dscmeta_resource_name]}" if resource.parameters[:dscmeta_resource_name] %> <%= "-ModuleName #{resource[:dscmeta_module_name]}" if resource.parameters[:dscmeta_module_name] %>
-<%   end -%>
+    Import-DscResource -ModuleName <%= resource[:dscmeta_module_name] %>
 <% end -%>
 
     node "localhost"

--- a/lib/puppet_x/msutter/templates/test_dsc_configuration.erb
+++ b/lib/puppet_x/msutter/templates/test_dsc_configuration.erb
@@ -6,10 +6,8 @@ Remove-Item $LCMConfigFolder\*.mof | out-null
 
 configuration PuppetConfiguration
 {
-<% unless ['msft_filedirectoryconfiguration'].include?(resource[:dscmeta_resource_name].downcase) -%>
 <%   if resource.parameters[:dscmeta_module_name] && resource[:dscmeta_import_resource] -%>
-    Import-DscResource <%= "-Name #{resource[:dscmeta_resource_name]}" if resource.parameters[:dscmeta_resource_name] %> <%= "-ModuleName #{resource[:dscmeta_module_name]}" if resource.parameters[:dscmeta_module_name] %>
-<%   end -%>
+    Import-DscResource -ModuleName <%= resource[:dscmeta_module_name] %>
 <% end -%>
 
     node "localhost"


### PR DESCRIPTION
If a user tries to run the module on a Windows system running WMF 5
errors will occur when applying manifests with DSC resources specified:

~~~
Error: /Stage[main]/Main/Dsc_file[tmp_folder]: Could not
evaluate: WARNING: The configuration 'PuppetConfiguration' is loading
one or more
built-in resources without explicitly importing associated modules. Add
Import-DscResource -ModuleName 'PSDesiredStateConfiguration' to your
configuration to avoid this message.
False
~~~

Without this fix the warning will continue to occur producing nothing
to move forward with in setting the configuratin.