### PR TITLE
(MODULES-2121) Use Modified Mof Repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 group :build do
   gem 'librarian-repo', :git => 'https://github.com/msutter/librarian-repo.git'
   gem 'cim'
-  gem 'mof'
+  gem 'mof', :git => 'https://github.com/puppetlabs/mof.git'
   gem 'charlock_holmes'
 end
 


### PR DESCRIPTION
Use PuppetLabs's mof repo with required fixes until the fixes have been
accepted in the mof maintainer's repo and a new version of the gem has
been cut.