### PR TITLE
(FM-2932) Fix Failing Acceptance Test

### DIFF
--- a/tests/acceptance/pre-suite/02_configure_lcm.rb
+++ b/tests/acceptance/pre-suite/02_configure_lcm.rb
@@ -10,7 +10,7 @@ dsc_conf_path_name = 'LCMSettings'
 dsc_conf_mof = <<-CONF
 instance of MSFT_DSCMetaConfiguration as $MSFT_DSCMetaConfiguration1ref
 {
-  RefreshMode = "Disabled";
+  RefreshMode = "Push";
 };
 
 instance of OMI_ConfigurationDocument

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
@@ -35,12 +35,10 @@ end
 agents.each do |agent|
   step 'Apply Manifest'
   on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-    expect_failure('Expected to fail due to FM-2783') do
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify Results'
-  #Expected failure due to FM-2783.
+  # Expected failure due to MODULES-1960 not being implemented yet.
   test_dsc_resource(agent, 'File', true, :DestinationPath => test_file_path, :Contents => test_file_contents)
 end


### PR DESCRIPTION
The single acceptance test is failing because FM-2783 was resolved, but
MODULES-1960 has yet to be implemented.