### PR TITLE
(FM-2624) Add Basic DSC Resource Tests

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
@@ -1,0 +1,46 @@
+require 'dsc_utils'
+test_name 'FM-2624 - C68527 - Apply DSC Resource Manifest with "before" on Puppet Resource Type'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# In-line Manifest
+test_dir_path = "C:/#{test_dir_name}"
+test_file_path = "#{test_dir_path}/test.txt"
+test_file_contents = 'catcat'
+
+dsc_manifest = <<-MANIFEST
+file {'#{test_file_path}':
+  ensure  => 'file',
+  content => '#{test_file_contents}'
+}
+dsc_file {'tmp_folder':
+  dsc_ensure          => 'present',
+  dsc_type            => 'Directory',
+  dsc_destinationpath => '#{test_dir_path}',
+  before              => File['#{test_file_path}']
+}
+MANIFEST
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    # Expected failure due to MODULES-1960 not being implemented yet.
+    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
@@ -3,7 +3,6 @@ test_name 'FM-2624 - C68527 - Apply DSC Resource Manifest with "before" on Puppe
 
 # Init
 test_dir_name = 'test'
-local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # In-line Manifest
 test_dir_path = "C:/#{test_dir_name}"

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
@@ -1,0 +1,46 @@
+require 'dsc_utils'
+test_name 'FM-2624 - C68526 - Apply DSC Resource Manifest with "requires" on Puppet Resource Type'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# In-line Manifest
+test_dir_path = "C:/#{test_dir_name}"
+test_file_path = "#{test_dir_path}/test.txt"
+test_file_contents = 'catcat'
+
+dsc_manifest = <<-MANIFEST
+dsc_file {'tmp_file':
+  dsc_ensure          => 'present',
+  dsc_type            => 'File',
+  dsc_destinationpath => '#{test_file_path}',
+  dsc_contents        => '#{test_file_contents}',
+  require             => File['#{test_dir_path}']
+}
+file {'#{test_dir_path}':
+  ensure => 'directory'
+}
+MANIFEST
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    # Expected failure due to MODULES-1960 not being implemented yet.
+    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
@@ -3,7 +3,6 @@ test_name 'FM-2624 - C68526 - Apply DSC Resource Manifest with "requires" on Pup
 
 # Init
 test_dir_name = 'test'
-local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # In-line Manifest
 test_dir_path = "C:/#{test_dir_name}"

--- a/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
@@ -1,0 +1,37 @@
+require 'dsc_utils'
+test_name 'FM-2624 - C87654 - Apply DSC Resource Manifest with Multiple Failing DSC Resources'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# In-line Manifest
+test_dir_bad = "Q:/not/here"
+
+dsc_manifest = <<-MANIFEST
+dsc_file {'bad_test_dir_1':
+  dsc_ensure          => 'present',
+  dsc_type            => 'Directory',
+  dsc_destinationpath => '#{test_dir_bad}_1'
+}
+dsc_file {'bad_test_dir_2':
+  dsc_ensure          => 'present',
+  dsc_type            => 'Directory',
+  dsc_destinationpath => '#{test_dir_bad}_2'
+}
+MANIFEST
+
+# Verify
+error_msg = /Error:/
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('expected to fail due to  MODULES-2194') do
+        assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+      end
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
@@ -1,10 +1,6 @@
 require 'dsc_utils'
 test_name 'FM-2624 - C87654 - Apply DSC Resource Manifest with Multiple Failing DSC Resources'
 
-# Init
-test_dir_name = 'test'
-local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
-
 # In-line Manifest
 test_dir_bad = "Q:/not/here"
 

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -1,0 +1,46 @@
+require 'dsc_utils'
+test_name 'FM-2624 - C68533 - Apply DSC Resource Manifest with Mix of Passing and Failing DSC Resources'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# In-line Manifest
+test_dir_good = "C:/#{test_dir_name}"
+test_dir_bad = "Q:/not/here"
+
+dsc_manifest = <<-MANIFEST
+dsc_file {'good_test_dir':
+  dsc_ensure          => 'present',
+  dsc_type            => 'Directory',
+  dsc_destinationpath => '#{test_dir_good}'
+}
+dsc_file {'bad_test_dir':
+  dsc_ensure          => 'present',
+  dsc_type            => 'Directory',
+  dsc_destinationpath => '#{test_dir_bad}'
+}
+MANIFEST
+
+# Verify
+error_msg = /Error:/
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('expected to fail due to  MODULES-2194') do
+        assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+      end
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -3,7 +3,6 @@ test_name 'FM-2624 - C68533 - Apply DSC Resource Manifest with Mix of Passing an
 
 # Init
 test_dir_name = 'test'
-local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # In-line Manifest
 test_dir_good = "C:/#{test_dir_name}"


### PR DESCRIPTION
Add tests that verify simple resource behavior of DSC resource types
in a Puppet manifest.