### PR TITLE
(MODULES-2223) Update Integration Test Run Scripts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,15 +38,13 @@ group :test do
 end
 
 beaker_version = ENV['BEAKER_VERSION']
-unless ENV['GEM_SOURCE'].nil?
-  group :system_tests do
-    if beaker_version
-      gem 'beaker', *location_for(beaker_version)
-    else
-      gem 'beaker', '~> 2.16'
-    end
-    gem 'master_manipulator', '~> 1.1'
+group :system_tests do
+  if beaker_version
+    gem 'beaker', *location_for(beaker_version)
+  else
+    gem 'beaker', '~> 2.18'
   end
+  gem 'master_manipulator', '~> 1.1'
 end
 
 if File.exists? "#{__FILE__}.local"

--- a/tests/test_run_scripts/all_integration_tests_w2008r2.sh
+++ b/tests/test_run_scripts/all_integration_tests_w2008r2.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../../
 fi
 
-export pe_dist_dir=http://neptune.puppetlabs.lan/4.0/ci-ready/
+export pe_dist_dir=http://neptune.puppetlabs.lan/2015.2/ci-ready/
 export BEAKER_PUPPET_AGENT_VERSION=1.2.1
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
 

--- a/tests/test_run_scripts/all_integration_tests_w2012r2.sh
+++ b/tests/test_run_scripts/all_integration_tests_w2012r2.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../../
 fi
 
-export pe_dist_dir=http://neptune.puppetlabs.lan/4.0/ci-ready/
+export pe_dist_dir=http://neptune.puppetlabs.lan/2015.2/ci-ready/
 export BEAKER_PUPPET_AGENT_VERSION=1.2.1
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
 


### PR DESCRIPTION
The test run scripts for integration tests point to the old name for SG and
need to be updated to point to the renamed package repository. Also, the
Gemfile has been updated to use the latest version of Beaker as well as the
public version of "master_manipulator".