### PR TITLE
(MODULES-2201) Rename DSC Test Helper Method

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
@@ -39,7 +39,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify Results'
-    # Expected failure due to MODULES-1960 not being implemented yet.
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+    expect_failure('Expected failure due to MODULES-1960 not being implemented yet') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path, :Contents => test_file_contents)
+    end
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
@@ -39,7 +39,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify Results'
-    # Expected failure due to MODULES-1960 not being implemented yet.
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+    expect_failure('Expected failure due to MODULES-1960 not being implemented yet') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path, :Contents => test_file_contents)
+    end
   end
 end

--- a/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
+++ b/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
@@ -31,7 +31,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify Results'
-    # Expected failure due to MODULES-1960 not being implemented yet.
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path.gsub("\\", '/'), :Contents => test_file_contents)
+    expect_failure('Expected failure due to MODULES-1960 not being implemented yet') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path.gsub("\\", '/'), :Contents => test_file_contents)
+    end
   end
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
@@ -35,7 +35,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify that No Changes were Made'
-    # Expected failure due to MODULES-1960 not being implemented yet.
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+    expect_failure('Expected failure due to MODULES-1960 not being implemented yet') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path, :Contents => test_file_contents)
+    end
   end
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
@@ -31,7 +31,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify Results'
-    # Expected failure due to MODULES-1960 not being implemented yet.
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+    expect_failure('Expected failure due to MODULES-1960 not being implemented yet') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path, :Contents => test_file_contents)
+    end
   end
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
@@ -23,6 +23,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify that No Changes were Made'
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+    expect_failure('Expect failure because nothing should have changed') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path, :Contents => test_file_contents)
+    end
   end
 end

--- a/tests/integration/tests/basic_functionality/puppet_agent_debug_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_debug_dsc_manifest.rb
@@ -41,7 +41,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify that No Changes were Made'
-    # Expected failure due to MODULES-1960 not being implemented yet.
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+    expect_failure('Expected failure due to MODULES-1960 not being implemented yet') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path, :Contents => test_file_contents)
+    end
   end
 end

--- a/tests/integration/tests/basic_functionality/puppet_agent_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_dsc_manifest.rb
@@ -37,7 +37,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify Results'
-    # Expected failure due to MODULES-1960 not being implemented yet.
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+    expect_failure('Expected failure due to MODULES-1960 not being implemented yet') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path, :Contents => test_file_contents)
+    end
   end
 end

--- a/tests/integration/tests/basic_functionality/puppet_agent_noop_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_noop_dsc_manifest.rb
@@ -29,6 +29,8 @@ confine_block(:to, :platform => 'windows') do
     end
 
     step 'Verify that No Changes were Made'
-    test_dsc_resource(agent, 'File', :expect_failure? => true, :DestinationPath => test_file_path, :Contents => test_file_contents)
+    expect_failure('Expect failure because nothing should have changed') do
+      test_dsc_resource(agent, 'File', :DestinationPath => test_file_path, :Contents => test_file_contents)
+    end
   end
 end


### PR DESCRIPTION
The "test_dsc_resource" method will be renamed to "assert_dsc_resource" to make it clear that it throws assertion exceptions.