### PR TITLE
(MODULES-2236) Enable Work-a-round for Path Length Issue

### DIFF
--- a/tests/acceptance/pre-suite/01_dsc_module_install.rb
+++ b/tests/acceptance/pre-suite/01_dsc_module_install.rb
@@ -4,4 +4,4 @@ confine(:to, :platform => 'windows')
 
 step 'Install Module via PMT'
 stub_forge_on(agents)
-on(agents, puppet('module install puppetlabs-dsc'))
+on(agents, puppet('module install puppetlabs-dsc --module_working_dir C:/Windows/Temp'))

--- a/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
@@ -1,6 +1,8 @@
 require 'dsc_utils'
 test_name 'FM-2624 - C87654 - Apply DSC Resource Manifest with Multiple Failing DSC Resources'
 
+skip_test('Expected to fail due to MODULES-2194')
+
 # In-line Manifest
 test_dir_bad = "Q:/not/here"
 
@@ -25,9 +27,7 @@ confine_block(:to, :platform => 'windows') do
   agents.each do |agent|
     step 'Apply Manifest'
     on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      expect_failure('expected to fail due to  MODULES-2194') do
-        assert_match(error_msg, result.stderr, 'Expected error was not detected!')
-      end
+      assert_match(error_msg, result.stderr, 'Expected error was not detected!')
     end
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -1,6 +1,8 @@
 require 'dsc_utils'
 test_name 'FM-2624 - C68533 - Apply DSC Resource Manifest with Mix of Passing and Failing DSC Resources'
 
+skip_test('Expected to fail due to MODULES-2194')
+
 # Init
 test_dir_name = 'test'
 
@@ -37,9 +39,7 @@ confine_block(:to, :platform => 'windows') do
   agents.each do |agent|
     step 'Apply Manifest'
     on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      expect_failure('expected to fail due to  MODULES-2194') do
-        assert_match(error_msg, result.stderr, 'Expected error was not detected!')
-      end
+      assert_match(error_msg, result.stderr, 'Expected error was not detected!')
     end
   end
 end


### PR DESCRIPTION
The acceptance tests install the DSC module using PMT on Windows agent nodes
which no longer works because of PUP-4854. The pre-suite has been updated
to utilize a shorter root path for module unpacking.

Also, two other tests were changed to skip since the breaking behavior for
errored DSC resources has changed. The tests never passed to begin with so
nothing has really changed.