### PR TITLE
(MODULES-2205) Fix DSC Array generation

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -118,6 +118,10 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     newvalues(true, false)
 <%  end -%>
 <%    case -%>
+<%    when property.array? -%>
+    munge do |value|
+      Array(value)
+    end
 <%    when property.bool? -%>
     munge do |value|
       value.to_s.downcase.to_bool

--- a/build/dsc/templates/dsc_type_spec.rb.erb
+++ b/build/dsc/templates/dsc_type_spec.rb.erb
@@ -45,6 +45,17 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
 <%    if property.values -%>
 <%      property.values.each do |value| -%>
 
+<%    if property.array? -%>
+  it 'should accept dsc_<%= property.name.downcase %> predefined value <%= value %>' do
+    dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>] = '<%= value %>'
+    expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq(['<%= value %>'])
+  end
+
+  it 'should accept dsc_<%= property.name.downcase %> predefined value <%= value.downcase %>' do
+    dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>] = '<%= value.downcase %>'
+    expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq(['<%= value.downcase %>'])
+  end
+<%    else -%>
   it 'should accept dsc_<%= property.name.downcase %> predefined value <%= value %>' do
     dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>] = '<%= value %>'
     expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq('<%= value %>')
@@ -54,6 +65,7 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
     dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>] = '<%= value.downcase %>'
     expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq('<%= value.downcase %>')
   end
+<%    end -%>
 <%        if property.name.downcase == 'ensure' -%>
 
   it 'should accept dsc_ensure predefined value <%= value.downcase %> and update ensure with this value (ensure end value should be a symbol)' do

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -48,7 +48,7 @@ EOT
     when ['trueclass','falseclass'].include?(dsc_value.class.name.downcase)
       "$#{dsc_value.to_s}"
     when dsc_value.class.name == 'Array'
-      dsc_value.collect{|m| format_dsc_value(m)}.join(', ')
+      "@(" + dsc_value.collect{|m| format_dsc_value(m)}.join(', ') + ")"
     else
       fail "unsupported type #{dsc_value.class} of value '#{dsc_value}'"
     end

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -216,6 +216,9 @@ Puppet::Type.newtype(:dsc_file) do
         end
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         Size
@@ -242,6 +245,9 @@ Puppet::Type.newtype(:dsc_file) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -102,6 +102,9 @@ Puppet::Type.newtype(:dsc_group) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         MembersToInclude
@@ -114,6 +117,9 @@ Puppet::Type.newtype(:dsc_group) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         MembersToExclude
@@ -125,6 +131,9 @@ Puppet::Type.newtype(:dsc_group) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -140,6 +140,9 @@ Puppet::Type.newtype(:dsc_package) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         LogPath

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -88,6 +88,9 @@ Puppet::Type.newtype(:dsc_registry) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         ValueType

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -174,6 +174,9 @@ Puppet::Type.newtype(:dsc_service) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
 

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -74,6 +74,9 @@ Puppet::Type.newtype(:dsc_xarchive) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         CompressionLevel

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -80,6 +80,9 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         DnsDomain

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -60,6 +60,9 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -80,6 +80,9 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -91,6 +91,9 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
 

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -165,6 +165,9 @@ Puppet::Type.newtype(:dsc_xfirewall) do
         end
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         Direction
@@ -194,6 +197,9 @@ Puppet::Type.newtype(:dsc_xfirewall) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         LocalPort
@@ -206,6 +212,9 @@ Puppet::Type.newtype(:dsc_xfirewall) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -106,6 +106,9 @@ Puppet::Type.newtype(:dsc_xgroup) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         MembersToInclude
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xgroup) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         MembersToExclude
@@ -129,6 +135,9 @@ Puppet::Type.newtype(:dsc_xgroup) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -106,6 +106,9 @@ Puppet::Type.newtype(:dsc_xiismodule) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         SiteName

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -80,6 +80,9 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         SecurityDescriptorSddl
@@ -105,6 +108,9 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -93,6 +93,9 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         Applications
@@ -105,6 +108,9 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -144,6 +144,9 @@ Puppet::Type.newtype(:dsc_xpackage) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         LogPath

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -106,6 +106,9 @@ Puppet::Type.newtype(:dsc_xremotefile) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         Credential

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -183,6 +183,9 @@ Puppet::Type.newtype(:dsc_xservice) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -106,6 +106,9 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         ConcurrentUserLimit
@@ -165,6 +168,9 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         NoAccess
@@ -178,6 +184,9 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         ReadAccess
@@ -190,6 +199,9 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         ClusterName

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
 

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -371,6 +371,9 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
 

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -122,6 +122,9 @@ Puppet::Type.newtype(:dsc_xwebsite) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         ApplicationPool
@@ -158,6 +161,9 @@ Puppet::Type.newtype(:dsc_xwebsite) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -94,6 +94,9 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
     end
+    munge do |value|
+      Array(value)
+    end
   end
 
   # Name:         NoWindowsUpdateCheck
@@ -158,6 +161,9 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+    end
+    munge do |value|
+      Array(value)
     end
   end
 

--- a/spec/unit/puppet/type/dsc_file_spec.rb
+++ b/spec/unit/puppet/type/dsc_file_spec.rb
@@ -391,42 +391,42 @@ describe Puppet::Type.type(:dsc_file) do
 
   it 'should accept dsc_attributes predefined value ReadOnly' do
     dsc_file[:dsc_attributes] = 'ReadOnly'
-    expect(dsc_file[:dsc_attributes]).to eq('ReadOnly')
+    expect(dsc_file[:dsc_attributes]).to eq(['ReadOnly'])
   end
 
   it 'should accept dsc_attributes predefined value readonly' do
     dsc_file[:dsc_attributes] = 'readonly'
-    expect(dsc_file[:dsc_attributes]).to eq('readonly')
+    expect(dsc_file[:dsc_attributes]).to eq(['readonly'])
   end
 
   it 'should accept dsc_attributes predefined value Hidden' do
     dsc_file[:dsc_attributes] = 'Hidden'
-    expect(dsc_file[:dsc_attributes]).to eq('Hidden')
+    expect(dsc_file[:dsc_attributes]).to eq(['Hidden'])
   end
 
   it 'should accept dsc_attributes predefined value hidden' do
     dsc_file[:dsc_attributes] = 'hidden'
-    expect(dsc_file[:dsc_attributes]).to eq('hidden')
+    expect(dsc_file[:dsc_attributes]).to eq(['hidden'])
   end
 
   it 'should accept dsc_attributes predefined value System' do
     dsc_file[:dsc_attributes] = 'System'
-    expect(dsc_file[:dsc_attributes]).to eq('System')
+    expect(dsc_file[:dsc_attributes]).to eq(['System'])
   end
 
   it 'should accept dsc_attributes predefined value system' do
     dsc_file[:dsc_attributes] = 'system'
-    expect(dsc_file[:dsc_attributes]).to eq('system')
+    expect(dsc_file[:dsc_attributes]).to eq(['system'])
   end
 
   it 'should accept dsc_attributes predefined value Archive' do
     dsc_file[:dsc_attributes] = 'Archive'
-    expect(dsc_file[:dsc_attributes]).to eq('Archive')
+    expect(dsc_file[:dsc_attributes]).to eq(['Archive'])
   end
 
   it 'should accept dsc_attributes predefined value archive' do
     dsc_file[:dsc_attributes] = 'archive'
-    expect(dsc_file[:dsc_attributes]).to eq('archive')
+    expect(dsc_file[:dsc_attributes]).to eq(['archive'])
   end
 
   it 'should not accept values not equal to predefined values' do

--- a/spec/unit/puppet/type/dsc_xfirewall_spec.rb
+++ b/spec/unit/puppet/type/dsc_xfirewall_spec.rb
@@ -228,42 +228,42 @@ describe Puppet::Type.type(:dsc_xfirewall) do
 
   it 'should accept dsc_profile predefined value Any' do
     dsc_xfirewall[:dsc_profile] = 'Any'
-    expect(dsc_xfirewall[:dsc_profile]).to eq('Any')
+    expect(dsc_xfirewall[:dsc_profile]).to eq(['Any'])
   end
 
   it 'should accept dsc_profile predefined value any' do
     dsc_xfirewall[:dsc_profile] = 'any'
-    expect(dsc_xfirewall[:dsc_profile]).to eq('any')
+    expect(dsc_xfirewall[:dsc_profile]).to eq(['any'])
   end
 
   it 'should accept dsc_profile predefined value Public' do
     dsc_xfirewall[:dsc_profile] = 'Public'
-    expect(dsc_xfirewall[:dsc_profile]).to eq('Public')
+    expect(dsc_xfirewall[:dsc_profile]).to eq(['Public'])
   end
 
   it 'should accept dsc_profile predefined value public' do
     dsc_xfirewall[:dsc_profile] = 'public'
-    expect(dsc_xfirewall[:dsc_profile]).to eq('public')
+    expect(dsc_xfirewall[:dsc_profile]).to eq(['public'])
   end
 
   it 'should accept dsc_profile predefined value Private' do
     dsc_xfirewall[:dsc_profile] = 'Private'
-    expect(dsc_xfirewall[:dsc_profile]).to eq('Private')
+    expect(dsc_xfirewall[:dsc_profile]).to eq(['Private'])
   end
 
   it 'should accept dsc_profile predefined value private' do
     dsc_xfirewall[:dsc_profile] = 'private'
-    expect(dsc_xfirewall[:dsc_profile]).to eq('private')
+    expect(dsc_xfirewall[:dsc_profile]).to eq(['private'])
   end
 
   it 'should accept dsc_profile predefined value Domain' do
     dsc_xfirewall[:dsc_profile] = 'Domain'
-    expect(dsc_xfirewall[:dsc_profile]).to eq('Domain')
+    expect(dsc_xfirewall[:dsc_profile]).to eq(['Domain'])
   end
 
   it 'should accept dsc_profile predefined value domain' do
     dsc_xfirewall[:dsc_profile] = 'domain'
-    expect(dsc_xfirewall[:dsc_profile]).to eq('domain')
+    expect(dsc_xfirewall[:dsc_profile]).to eq(['domain'])
   end
 
   it 'should not accept values not equal to predefined values' do


### PR DESCRIPTION
When generating the types for each DSC Resource we were not explicitly
making any parameter that was an array in the DSC return an array in
Puppet. Puppet sometimes unwraps arrays if they only contain one item,
which does not work when the DSC Resource parameter is expecting a
string.

To fix this we munge the value to always be an array in DSC Resource type
and make sure that when the PowerShell script is compiled it uses proper
PowerShell array syntax.

Additionaly we change the spec tests to expect array notation if the
parameter is an array