### PR TITLE
(MODULES-1960) Don't version in-OS resources

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -44,11 +44,11 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
   newparam(:dscmeta_module_name) do
     defaultto "<%= resource.ps_module.name %>"
   end
-
+<%  if resource.ps_module.name != 'PSDesiredStateConfiguration' %>
   newparam(:dscmeta_module_version) do
     defaultto "<%= resource.ps_module.version %>"
   end
-
+<%  end %>
   newparam(:name, :namevar => true ) do
   end
 <%  if resource.ensurable? -%>

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -44,10 +44,6 @@ Puppet::Type.newtype(:dsc_archive) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -43,10 +43,6 @@ Puppet::Type.newtype(:dsc_environment) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -43,10 +43,6 @@ Puppet::Type.newtype(:dsc_file) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -43,10 +43,6 @@ Puppet::Type.newtype(:dsc_group) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -42,10 +42,6 @@ Puppet::Type.newtype(:dsc_log) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -44,10 +44,6 @@ Puppet::Type.newtype(:dsc_package) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -44,10 +44,6 @@ Puppet::Type.newtype(:dsc_registry) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -45,10 +45,6 @@ Puppet::Type.newtype(:dsc_script) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -43,10 +43,6 @@ Puppet::Type.newtype(:dsc_service) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -43,10 +43,6 @@ Puppet::Type.newtype(:dsc_user) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -43,10 +43,6 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -44,10 +44,6 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
     defaultto "PSDesiredStateConfiguration"
   end
 
-  newparam(:dscmeta_module_version) do
-    defaultto "1.0"
-  end
-
   newparam(:name, :namevar => true ) do
   end
 

--- a/lib/puppet_x/msutter/templates/invoke_dsc_resource.erb
+++ b/lib/puppet_x/msutter/templates/invoke_dsc_resource.erb
@@ -42,12 +42,13 @@ $invokeParams = @{
 <% dsc_parameters.each do |p| -%>
     <%= p.name.to_s.gsub(/^dsc_/,'') %> = <%= format_dsc_value(p.value) %>
 <% end -%>
-  }
-<% if resource[:dscmeta_module_name].casecmp('PSDesiredStateConfiguration') == 0 -%>
+  }<% if resource.parameters[:dscmeta_module_version] %>
   ModuleName = @{
-    <%= "ModuleName=\"#{resource[:dscmeta_module_name]}\"" %>
-    <%= "RequiredVersion=\"#{resource[:dscmeta_module_version]}\"" if resource.parameters[:dscmeta_module_version] %>
+    ModuleName      = <%= "\"#{resource[:dscmeta_module_name]}\"" %>
+    RequiredVersion = <%= "\"#{resource[:dscmeta_module_version]}\"" %>
   }
+<% else %>
+  ModuleName = <%= "\"#{resource[:dscmeta_module_name]}\"" %>
 <% end -%>
 }
 

--- a/lib/puppet_x/msutter/templates/mof.erb
+++ b/lib/puppet_x/msutter/templates/mof.erb
@@ -9,7 +9,9 @@ instance of <%= resource[:dscmeta_resource_name] %> as $<%= resource[:dscmeta_re
 {
 	resourceid = "[<%= resource[:dscmeta_resource_friendly_name] %>]<%= resource.title %>";
 	modulename = <%= format_mof_value(resource[:dscmeta_module_name]) %>;
+<% if resource.parameters.has_key?(:dscmeta_module_version) -%>
 	moduleversion = <%= format_mof_value(resource[:dscmeta_module_version]) %>;
+<% end -%>
 <% dsc_parameters.each do |p| -%>
  	<%= p.name.to_s.gsub(/^dsc_/,'') %> = <%= format_mof_value(p.value) %>;
 <% end -%>


### PR DESCRIPTION
 - Fix a bug in the logic around when to specify a module version when
   generating PowerShell code.
 - Also, after some discussion, decided to use the presence / absence
   of dscmeta_module_version to determine whether to use module name or
   module name + version. In the code generation for specific types - in
   this case PSDesiredStateConfiguration - omit dscmeta_module_version.

   After some discussion it was decided since these resources are not
   vendored, and can vary based on the operating system version that the
   Puppet module is installed on, that we should be less strict around
   requesting a particular version.  It's possible that minor .z
   versions will have the same interface, but may include OS specific
   bugfixes, etc.  Hardcoding a single version number is too inflexible
   given these DSC types are not vendored.