### PR TITLE
(MODULES-2257) Manage DSC resource without ensure

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -51,13 +51,15 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
 <%  end %>
   newparam(:name, :namevar => true ) do
   end
-<%  if resource.ensurable? -%>
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+<%  if resource.ensurable? -%>
+    newvalue(:absent)  { provider.destroy }
+<%  end -%>
     defaultto :present
   end
-<%  end -%>
 
 <%  resource.properties.each do |property| -%>
   # Name:         <%= property.name %>

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -17,7 +17,7 @@ EOT
     if ['true','false'].include?(output.to_s.strip.downcase)
       check = (output.to_s.strip.downcase == 'true')
       Puppet.debug "Dsc Resource Exists?: #{check}"
-      Puppet.debug "dsc_ensure: #{resource[:dsc_ensure]}"
+      Puppet.debug "dsc_ensure: #{resource[:dsc_ensure]}" if resource.parameters.has_key?(:dsc_ensure)
       Puppet.debug "ensure: #{resource[:ensure]}"
       check
     else

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -48,7 +48,9 @@ Puppet::Type.newtype(:dsc_archive) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -47,7 +47,9 @@ Puppet::Type.newtype(:dsc_environment) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -47,7 +47,9 @@ Puppet::Type.newtype(:dsc_file) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -47,7 +47,9 @@ Puppet::Type.newtype(:dsc_group) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -45,6 +45,12 @@ Puppet::Type.newtype(:dsc_log) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Message
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -48,7 +48,9 @@ Puppet::Type.newtype(:dsc_package) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -48,7 +48,9 @@ Puppet::Type.newtype(:dsc_registry) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -48,6 +48,12 @@ Puppet::Type.newtype(:dsc_script) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         GetScript
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -46,6 +46,12 @@ Puppet::Type.newtype(:dsc_service) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -47,7 +47,9 @@ Puppet::Type.newtype(:dsc_user) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_webdeploy.rb
+++ b/lib/puppet/type/dsc_webdeploy.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_webdeploy) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -47,7 +47,9 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -48,7 +48,9 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xaddomain) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xaduser) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xarchive) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Destination
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xazureservice) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xazurestorageaccount) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xazuresubscription) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xazurevm) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xcluster) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xcomputer) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xdatabase) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Credentials
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xdhcpserverscope) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Address
   # Type:         string[]
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xfirewall) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xgroup) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xiismodule) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xiiswordpresssite.rb
+++ b/lib/puppet/type/dsc_xiiswordpresssite.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xiiswordpresssite) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         DestinationPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -51,6 +51,12 @@ Puppet::Type.newtype(:dsc_xipaddress) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         IPAddress
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xpackage) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -51,6 +51,12 @@ Puppet::Type.newtype(:dsc_xrdsessioncollection) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         CollectionName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         CollectionName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -52,6 +52,12 @@ Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         SessionHost
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xremotefile) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xservice) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -51,6 +51,12 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xvhd) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         VhdPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xwebapplication) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xwebsite) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -53,7 +53,9 @@ Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -52,7 +52,9 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -50,6 +50,12 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
   newparam(:name, :namevar => true ) do
   end
 
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    defaultto :present
+  end
+
   # Name:         LogName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -51,7 +51,9 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
   end
 
   ensurable do
-    defaultvalues
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
     defaultto :present
   end
 


### PR DESCRIPTION
 - Previously the heuristic for generated types was to look for a
   'Ensure' property on the DSC MOF schema.  However, this is not
   appropriate for many types that are missing an 'Ensure' such as
   dsc_service.  In Puppet parlance, an 'Ensure' implies that the
   resource can be set to :absent to remove it, but that concept doesn't
   mesh with what DSC supports in the box.

   Therefore modify the code generation process so that all resources
   generated from DSC types are Puppet ensurable.  However, for those
   that are not DSC ensurable, only support :exists? and :present, but
   not :absent.