### PR TITLE
(MODULES-2228) Create Tests for "Registry" DSC Resource

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_binary_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_binary_value.rb
@@ -1,0 +1,35 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68710 - Attempt to Apply DSC Registry Resource with Invalid "ValueData" Specified Binary Type'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'BadBinaryValue',
+  :dsc_valuedata => 'This is not binary!',
+  :dsc_valuetype => 'Binary'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Verify
+error_msg = /Convert property 'valuedata' value from type 'STRING' to/
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Attempt to Apply Manifest'
+    expect_failure('Expected to fail because of MODULES-2194') do
+      on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+        assert_no_match(error_msg, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_dword_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_dword_value.rb
@@ -1,0 +1,35 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68711 - Attempt to Apply DSC Registry Resource with Invalid "ValueData" Specified Dword Type'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'BadDwordValue',
+  :dsc_valuedata => 'This is not a dword!',
+  :dsc_valuetype => 'Dword'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Verify
+error_msg = /Convert property 'valuedata' value from type 'STRING' to/
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Attempt to Apply Manifest'
+    expect_failure('Expected to fail because of MODULES-2194') do
+      on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+        assert_no_match(error_msg, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_key.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_key.rb
@@ -1,0 +1,34 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68708 - Attempt to Apply DSC Registry Resource with Invalid "Key" Specified'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_COW_MEAT\TestKey',
+  :dsc_valuename => 'TestValueName',
+  :dsc_valuetype => 'String'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Verify
+error_msg = /registry hive was specified in registry key 'HKEY_COW_MEAT\\TestKey'/
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Attempt to Apply Manifest'
+    expect_failure('Expected to fail because of MODULES-2194') do
+      on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+        assert_no_match(error_msg, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_force_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_force_value.rb
@@ -1,0 +1,71 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C88970 - Apply DSC Registry Resource with "Force" Enabled'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'TestForceValue',
+  :dsc_valuedata => 'Gif Party!',
+  :dsc_valuetype => 'String'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      :Ensure    => 'Absent',
+      :Key       => dsc_props[:dsc_key],
+      :ValueName => dsc_props[:dsc_valuename]
+    )
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Create Value'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('Expected to fail because of MODULES-2256') do
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    # New manifest to force value.
+    dsc_props[:dsc_force] = 'true'
+    dsc_force_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+    step 'Apply Manifest Again with Force Enabled'
+    on(agent, puppet('apply'), :stdin => dsc_force_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('Expected to fail because of MODULES-2256') do
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    step 'Verify Results'
+    expect_failure('Expected to fail because of MODULES-2256') do
+      assert_dsc_resource(
+        agent,
+        dsc_type,
+        :Ensure    => dsc_props[:dsc_ensure],
+        :Key       => dsc_props[:dsc_key],
+        :ValueName => dsc_props[:dsc_valuename],
+        :ValueData => dsc_props[:dsc_valuedata],
+        :ValueType => dsc_props[:dsc_valuetype],
+        :Force     => dsc_props[:dsc_force]
+      )
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_remove_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_remove_value.rb
@@ -1,0 +1,56 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68706 - Apply DSC Registry Resource that Removes Registry Value'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'TestRemoveValue',
+  :dsc_valuedata => 'Cats',
+  :dsc_valuetype => 'String'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Create Value'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('Expected to fail because of MODULES-2256') do
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    # New manifest to remove value.
+    dsc_props[:dsc_ensure] = 'Absent'
+    dsc_remove_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+    step 'Apply Manifest to Remove Value'
+    on(agent, puppet('apply'), :stdin => dsc_remove_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('Expected to fail because of MODULES-2256') do
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    step 'Verify Results'
+    expect_failure('Expected to fail because of MODULES-2256') do
+      assert_dsc_resource(
+        agent,
+        dsc_type,
+        :Ensure    => dsc_props[:dsc_ensure],
+        :Key       => dsc_props[:dsc_key],
+        :ValueName => dsc_props[:dsc_valuename],
+        :ValueData => dsc_props[:dsc_valuedata],
+        :ValueType => dsc_props[:dsc_valuetype]
+      )
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_binary_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_binary_valuedata.rb
@@ -1,0 +1,59 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68702 - Apply DSC Registry Resource with Valid "ValueData" Specified for Binary Type'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'TestBinaryValue',
+  :dsc_valuedata => 'BEEF',
+  :dsc_valuetype => 'Binary'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      :Ensure    => 'Absent',
+      :Key       => dsc_props[:dsc_key],
+      :ValueName => dsc_props[:dsc_valuename]
+    )
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('Expected to fail because of MODULES-2256') do
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    step 'Verify Results'
+    expect_failure('Expected to fail because of MODULES-2256') do
+      assert_dsc_resource(
+        agent,
+        dsc_type,
+        :Ensure    => dsc_props[:dsc_ensure],
+        :Key       => dsc_props[:dsc_key],
+        :ValueName => dsc_props[:dsc_valuename],
+        :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")",
+        :ValueType => dsc_props[:dsc_valuetype]
+      )
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_hex_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_hex_valuedata.rb
@@ -1,0 +1,61 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68704 - Apply DSC Registry Resource with Valid "ValueData" Specified for Dword Hex Type'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'TestDwordHexValue',
+  :dsc_valuedata => 'BEEF',
+  :dsc_valuetype => 'Dword',
+  :dsc_hex       => 'true'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      :Ensure    => 'Absent',
+      :Key       => dsc_props[:dsc_key],
+      :ValueName => dsc_props[:dsc_valuename]
+    )
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('Expected to fail because of MODULES-2256') do
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    step 'Verify Results'
+    expect_failure('Expected to fail because of MODULES-2256') do
+      assert_dsc_resource(
+        agent,
+        dsc_type,
+        :Ensure    => dsc_props[:dsc_ensure],
+        :Key       => dsc_props[:dsc_key],
+        :ValueName => dsc_props[:dsc_valuename],
+        :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")",
+        :ValueType => dsc_props[:dsc_valuetype],
+        :Hex       => dsc_props[:dsc_hex]
+      )
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_valuedata.rb
@@ -1,0 +1,59 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68703 - Apply DSC Registry Resource with Valid "ValueData" Specified for Dword Type'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'TestDwordValue',
+  :dsc_valuedata => '-2147483648',
+  :dsc_valuetype => 'Dword'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      :Ensure    => 'Absent',
+      :Key       => dsc_props[:dsc_key],
+      :ValueName => dsc_props[:dsc_valuename]
+    )
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('Expected to fail because of MODULES-2256') do
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    step 'Verify Results'
+    expect_failure('Expected to fail because of MODULES-2256') do
+      assert_dsc_resource(
+        agent,
+        dsc_type,
+        :Ensure    => dsc_props[:dsc_ensure],
+        :Key       => dsc_props[:dsc_key],
+        :ValueName => dsc_props[:dsc_valuename],
+        :ValueData => dsc_props[:dsc_valuedata],
+        :ValueType => dsc_props[:dsc_valuetype]
+      )
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_implicit_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_implicit_valuedata.rb
@@ -1,0 +1,57 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68701 - Apply DSC Registry Resource with Valid "ValueData" Specified for Implicit String Type'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'TestStringValue',
+  :dsc_valuedata => 'This is a test string!'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      :Ensure    => 'Absent',
+      :Key       => dsc_props[:dsc_key],
+      :ValueName => dsc_props[:dsc_valuename]
+    )
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      expect_failure('Expected to fail because of MODULES-2256') do
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    step 'Verify Results'
+    expect_failure('Expected to fail because of MODULES-2256') do
+      assert_dsc_resource(
+        agent,
+        dsc_type,
+        :Ensure    => dsc_props[:dsc_ensure],
+        :Key       => dsc_props[:dsc_key],
+        :ValueName => dsc_props[:dsc_valuename],
+        :ValueData => dsc_props[:dsc_valuedata]
+      )
+    end
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_key_valuename.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_key_valuename.rb
@@ -1,0 +1,51 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2230 - C68700 - Apply DSC Registry Resource with Valid "Key" and "ValueName" Specified'
+
+# Init
+test_dir_name = 'test'
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'registry'
+dsc_props = {
+  :dsc_ensure    => 'Present',
+  :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
+  :dsc_valuename => 'TestValueName'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      :Ensure    => 'Absent',
+      :Key       => dsc_props[:dsc_key],
+      :ValueName => dsc_props[:dsc_valuename]
+    )
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      :Ensure    => dsc_props[:dsc_ensure],
+      :Key       => dsc_props[:dsc_key],
+      :ValueName => dsc_props[:dsc_valuename]
+    )
+  end
+end

--- a/tests/lib/dsc_utils.rb
+++ b/tests/lib/dsc_utils.rb
@@ -1,3 +1,81 @@
+# Build a PowerShell DSC command string.
+#
+# ==== Attributes
+#
+# * +dsc_method+ - The method (set, test) to use for the DSC command.
+# * +dsc_resource_type+ - The DSC resource type name to verify.
+# * +dsc_properties+ - DSC properties to verify on resource.
+#
+# ==== Returns
+#
+# +nil+
+#
+# ==== Raises
+#
+# +nil+
+#
+# ==== Examples
+#
+# _build_dsc_command('Set', 'File', :DestinationPath=>'C:\test.txt', :Contents=>'catcat')
+def _build_dsc_command(dsc_method, dsc_resource_type, dsc_properties)
+  #Init
+  ps_launch = 'powershell.exe -ExecutionPolicy Bypass -InputFormat Text -OutputFormat Text -NoLogo -NoProfile -NonInteractive'
+
+  #Flatten hash into formatted string.
+  dsc_prop_merge = '@{'
+  dsc_properties.each do |k, v|
+    dsc_prop_merge << "\\\"#{k}\\\"="
+
+    if v =~ /^\$/
+      dsc_prop_merge << "\\#{v};"
+    elsif v =~ /^@/
+      dsc_prop_merge << "#{v.gsub(/\"/, '\\\"')};"
+    elsif v =~ /^-?\d+/
+      dsc_prop_merge << "#{v};"
+    else
+      dsc_prop_merge << "\\\"#{v}\\\";"
+    end
+  end
+
+  dsc_prop_merge.chop!
+  dsc_prop_merge << '}'
+
+  #Compose strings for PS command.
+  dsc_command = "Invoke-DscResource -Name #{dsc_resource_type} -Method #{dsc_method} -Verbose -Property #{dsc_prop_merge}"
+
+  return "#{ps_launch} -Command \"if ( #{dsc_command} ) { exit 0 } else { exit 1 }\""
+end
+
+# Set a DSC resource on a host machine.
+#
+# ==== Attributes
+#
+# * +host+ - The target Windows host for verification.
+# * +dsc_resource_type+ - The DSC resource type name to verify.
+# * +dsc_properties+ - DSC properties to verify on resource.
+#
+# ==== Returns
+#
+# +Beaker::Result+
+#
+# ==== Raises
+#
+# +Minitest::Assertion+ - DSC failed to be set.
+#
+# ==== Examples
+#
+# set_dsc_resource(agents, 'File', :DestinationPath=>'C:\test.txt', :Contents=>'catcat')
+def set_dsc_resource(host, dsc_resource_type, dsc_properties)
+  # Init
+  ps_command = _build_dsc_command('Set', dsc_resource_type, dsc_properties)
+
+  # Execute Set Command
+  on(host, ps_command, :acceptable_exit_codes => [0,1])
+
+  # Verify State
+  assert_dsc_resource(host, dsc_resource_type, dsc_properties)
+end
+
 module Beaker
   module DSL
     module Assertions
@@ -19,22 +97,10 @@ module Beaker
       #
       # ==== Examples
       #
-      # test_dsc_resource(agents, 'File', :DestinationPath=>'C:\test.txt', :Contents=>'catcat')
+      # assert_dsc_resource(agents, 'File', :DestinationPath=>'C:\test.txt', :Contents=>'catcat')
       def assert_dsc_resource(host, dsc_resource_type, dsc_properties)
-        #Init
-        ps_launch = 'powershell.exe -ExecutionPolicy Bypass -InputFormat Text -OutputFormat Text -NoLogo -NoProfile -NonInteractive'
-
-        #Flatten hash into formatted string.
-        dsc_prop_merge = '@{'
-        dsc_properties.each do |k, v|
-          dsc_prop_merge << "\\\"#{k}\\\"=\\\"#{v}\\\";"
-        end
-        dsc_prop_merge.chop!
-        dsc_prop_merge << '}'
-
-        #Compose strings for PS command.
-        dsc_command = "Invoke-DscResource -Name #{dsc_resource_type} -Method Test -Verbose -Property #{dsc_prop_merge}"
-        ps_command = "#{ps_launch} -Command \"if ( #{dsc_command} ) { exit 0 } else { exit 1 }\""
+        # Init
+        ps_command = _build_dsc_command('Test', dsc_resource_type, dsc_properties)
 
         on(host, ps_command, :acceptable_exit_codes => [0,1]) do |result|
           assert(0 == result.exit_code, 'DSC resource not in desired state!')

--- a/tests/manifests/basic_dsc_resources/dsc_single_resource.pp.erb
+++ b/tests/manifests/basic_dsc_resources/dsc_single_resource.pp.erb
@@ -1,0 +1,5 @@
+dsc_<%= dsc_type %> {'<%= dsc_type %>_test':
+  <% dsc_props.each do |k, v| %>
+    <%= k %> => '<%= v %>',
+  <% end %>
+}


### PR DESCRIPTION
Add automated tests for the "Registry" DSC resource type. Also, update the
"dsc_utils.rb" helper library to be more better-er.

Cannot merge this until #28 is merged.