### PR TITLE
(DO NOT MERGE)(MODULES-2243) Remove LCM RefreshMode Change

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,6 @@
+fixtures:
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"
+    powershell: "puppetlabs/powershell"
+  symlinks:
+    "dsc": "#{source_dir}"

--- a/lib/puppet_x/msutter/templates/invoke_dsc_resource.erb
+++ b/lib/puppet_x/msutter/templates/invoke_dsc_resource.erb
@@ -4,33 +4,10 @@ if (!(Test-Path($PuppetModulesFolder))) {
   & cmd.exe /c mklink /d "$PuppetModulesFolder" "<%= vendored_modules_path %>" | Out-Null
 }
 
-function Set-RefreshMode
-{
-  param($mode)
-
-  $configOutputPath = [IO.Path]::GetTempPath()
-
-  [DscLocalConfigurationManager()]
-  Configuration LCMSettings {
-      Node localhost
-      {
-          Settings
-          {
-              RefreshMode = $mode
-          }
-      }
-  }
-
-  LCMSettings -OutputPath $configOutputPath | Out-Null
-
-  Set-DscLocalConfigurationManager -Path $configOutputPath
-}
-
 $currentState = Get-DscLocalConfigurationManager
 
 if ($currentState.RefreshMode -ne 'Disabled') {
-  $currentRefreshMode = $currentState.RefreshMode
-  Set-RefreshMode 'Disabled'
+  throw "DSC LCM RefreshMode must be set to Disabled for Puppet to execute DSC Resources!"
 }
 
 $invokeParams = @{

--- a/manifests/lcm_config.pp
+++ b/manifests/lcm_config.pp
@@ -1,0 +1,12 @@
+define dsc::lcm_config (
+  $refresh_mode = 'Disabled'
+) {
+
+  validate_re($refresh_mode, '^(Disabled|Pull|Push)$', 'refresh_mode must be one of \'Disabled\', \'Push\', \'Pull\'')
+
+  exec { "dsc_provider_set_lcm_refreshmode_${refresh_mode}":
+    provider => 'powershell',
+    onlyif   => "if ((Get-DscLocalConfigurationManager).RefreshMode -eq '${refresh_mode}') {exit 1} else {exit 0}",
+    command  => template('dsc/set-lcm-mode.ps1.erb'),
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -37,6 +37,13 @@
     }
   ],
   "dependencies": [
-
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "puppetlabs-powershell",
+      "version_requirement": ">= 1.0.1"
+    }
   ]
 }

--- a/spec/defines/lcm_config_spec.rb
+++ b/spec/defines/lcm_config_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe 'dsc::lcm_config', :type => :define do
+
+  context 'refresh_mode should default to Disabled' do
+    let (:title) { 'lcm_default' }
+
+    it {
+      should contain_dsc__lcm_config("#{title}").with(
+        {
+          'refresh_mode' => 'Disabled'
+        }
+      )
+    }
+  end
+
+  ["Disabled","Push","Pull"].each do |mode|
+    context "when refresh_mode => #{mode}" do
+      let (:title) { "lcm_#{mode}" }
+      let(:params) { {:refresh_mode => "#{mode}"} }
+
+      it {should compile}
+
+      it {
+        should contain_dsc__lcm_config("#{title}").with(
+          {
+            'refresh_mode' => "#{mode}"
+          }
+        )
+      }
+    end
+  end
+
+  ["disabled","push","pull","foo","bar"].each do |mode|
+    context "when refresh_mode => #{mode}" do
+      let (:title) { "lcm_#{mode}" }
+      let(:params) { {:refresh_mode => "#{mode}"} }
+
+      it {should_not compile}
+
+      let (:error_message) { /refresh_mode must be one of/}
+      it {
+        expect { catalogue }.to raise_error(Puppet::Error, error_message)
+      }
+    end
+  end
+end

--- a/templates/set-lcm-mode.ps1.erb
+++ b/templates/set-lcm-mode.ps1.erb
@@ -1,0 +1,50 @@
+$lcmRefreshMode = '<%= @refresh_mode %>'
+$generationDate = (get-date -format "M/d/yyyy HH:mm:ss")
+$encoding       = [Text.Encoding]::UTF8
+$namespace      = 'root/Microsoft/Windows/DesiredStateConfiguration'
+$className      = 'MSFT_DSCLocalConfigurationManager'
+$generationHost = [Environment]::MachineName
+
+$mofData = @"
+/*
+@TargetNode=''localhost''
+@GeneratedBy=PUPPET
+@GenerationDate=$generationDate
+@GenerationHost=$generationHost
+*/
+
+instance of MSFT_DSCMetaConfiguration as `$MSFT_DSCMetaConfiguration1ref
+{
+RefreshMode = "$lcmRefreshMode";
+};
+
+instance of OMI_ConfigurationDocument
+{
+Version="2.0.0";
+MinimumCompatibleVersion = "1.0.0";
+CompatibleVersionAdditionalProperties= { "MSFT_DSCMetaConfiguration:StatusRetentionTimeInDays" };
+Author="PUPPET";
+GenerationDate="$generationDate";
+GenerationHost="$generationHost";
+Name="LCMSettings";
+};
+"@
+
+$totalSize = [BitConverter]::GetBytes($mofData.Length + 4)
+$bytes     = $totalSize + $encoding.GetBytes($mofData)
+
+$cimClass       = Get-CimClass -Namespace $namespace -ClassName $className
+$sessionOptions = New-CimSessionOption -Protocol Wsman
+$wsmanSession   = New-CimSession -ComputerName localhost -SessionOption $sessionOptions
+
+$invokeParams = @{
+  Verbose    = $true
+  CimClass   = $cimClass
+  CimSession = $wsmanSession
+  MethodName = "SendMetaConfigurationApply"
+  Arguments  = @{
+    ConfigurationData = $bytes;
+  }
+}
+
+Invoke-CimMethod @invokeParams


### PR DESCRIPTION
Removes setting the LCM RefreshMode in the Invoke DSC Resource script and
have it bail out if it is set to anything else than Disabled.

Creates a Puppet type that will set the LCM RefreshMode to one of the
supported values