### PR TITLE
(MODULES-2266) Fix All the Tests

### DIFF
--- a/tests/acceptance/pre-suite/01_puppet_agent_install.rb
+++ b/tests/acceptance/pre-suite/01_puppet_agent_install.rb
@@ -3,7 +3,7 @@ test_name 'Install Puppet Agent'
 confine(:to, :platform => 'windows')
 
 #Init
-puppet_agent_version = ENV['BEAKER_PUPPET_AGENT_VERSION'] || '1.2.1'
+puppet_agent_version = ENV['BEAKER_PUPPET_AGENT_VERSION'] || '1.2.2'
 
 step 'Install Puppet Agent'
 install_puppet_agent_on(agents, :version => puppet_agent_version)

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
@@ -1,6 +1,8 @@
 require 'dsc_utils'
 test_name 'FM-2624 - C68527 - Apply DSC Resource Manifest with "before" on Puppet Resource Type'
 
+confine(:to, :platform => 'windows')
+
 # Init
 test_dir_name = 'test'
 
@@ -24,25 +26,21 @@ MANIFEST
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
-  end
+  step 'Remove Test Artifacts'
+  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
-
-    step 'Verify Results'
-    assert_dsc_resource(
-      agent, 'File',
-      :DestinationPath => test_file_path,
-      :Contents => test_file_contents
-    )
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  step 'Verify Results'
+  assert_dsc_resource(
+    agent, 'File',
+    :DestinationPath => test_file_path,
+    :Contents => test_file_contents
+  )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
@@ -1,6 +1,8 @@
 require 'dsc_utils'
 test_name 'FM-2624 - C68526 - Apply DSC Resource Manifest with "requires" on Puppet Resource Type'
 
+confine(:to, :platform => 'windows')
+
 # Init
 test_dir_name = 'test'
 
@@ -24,26 +26,22 @@ MANIFEST
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
-  end
+  step 'Remove Test Artifacts'
+  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
-
-    step 'Verify Results'
-    assert_dsc_resource(
-      agent,
-      'File',
-      :DestinationPath => test_file_path,
-      :Contents => test_file_contents
-    )
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  step 'Verify Results'
+  assert_dsc_resource(
+    agent,
+    'File',
+    :DestinationPath => test_file_path,
+    :Contents => test_file_contents
+  )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
@@ -1,6 +1,8 @@
 require 'dsc_utils'
 test_name 'FM-2624 - C87654 - Apply DSC Resource Manifest with Multiple Failing DSC Resources'
 
+confine(:to, :platform => 'windows')
+
 # In-line Manifest
 test_dir_bad = "Q:/not/here"
 
@@ -21,13 +23,11 @@ MANIFEST
 error_msg = /Error:/
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
-      expect_failure('Expected to fail because of MODULES-2194') do
-        assert_no_match(error_msg, result.stderr, 'Expected error was not detected!')
-      end
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
+    expect_failure('Expected to fail because of MODULES-2194') do
+      assert_no_match(error_msg, result.stderr, 'Expected error was not detected!')
     end
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_binary_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_binary_value.rb
@@ -2,8 +2,9 @@ require 'erb'
 require 'dsc_utils'
 test_name 'MODULES-2230 - C68710 - Attempt to Apply DSC Registry Resource with Invalid "ValueData" Specified Binary Type'
 
+confine(:to, :platform => 'windows')
+
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
@@ -20,16 +21,12 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resourc
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
 # Verify
-error_msg = /Convert property 'valuedata' value from type 'STRING' to/
+error_msg = /'ValueData' has an invalid value/
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Attempt to Apply Manifest'
-    expect_failure('Expected to fail because of MODULES-2194') do
-      on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-        assert_no_match(error_msg, result.stderr, 'Unexpected error was detected!')
-      end
-    end
+agents.each do |agent|
+  step 'Attempt to Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_dword_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_dword_value.rb
@@ -2,8 +2,9 @@ require 'erb'
 require 'dsc_utils'
 test_name 'MODULES-2230 - C68711 - Attempt to Apply DSC Registry Resource with Invalid "ValueData" Specified Dword Type'
 
+confine(:to, :platform => 'windows')
+
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
@@ -20,16 +21,12 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resourc
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
 # Verify
-error_msg = /Convert property 'valuedata' value from type 'STRING' to/
+error_msg = /string was not in a correct format/
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Attempt to Apply Manifest'
-    expect_failure('Expected to fail because of MODULES-2194') do
-      on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-        assert_no_match(error_msg, result.stderr, 'Unexpected error was detected!')
-      end
-    end
+agents.each do |agent|
+  step 'Attempt to Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_key.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/negative/reg_invalid_key.rb
@@ -2,8 +2,9 @@ require 'erb'
 require 'dsc_utils'
 test_name 'MODULES-2230 - C68708 - Attempt to Apply DSC Registry Resource with Invalid "Key" Specified'
 
+confine(:to, :platform => 'windows')
+
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
@@ -22,13 +23,9 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 error_msg = /registry hive was specified in registry key 'HKEY_COW_MEAT\\TestKey'/
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Attempt to Apply Manifest'
-    expect_failure('Expected to fail because of MODULES-2194') do
-      on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-        assert_no_match(error_msg, result.stderr, 'Unexpected error was detected!')
-      end
-    end
+agents.each do |agent|
+  step 'Attempt to Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_force_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_force_value.rb
@@ -2,8 +2,9 @@ require 'erb'
 require 'dsc_utils'
 test_name 'MODULES-2230 - C88970 - Apply DSC Registry Resource with "Force" Enabled'
 
+confine(:to, :platform => 'windows')
+
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
@@ -21,51 +22,42 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    set_dsc_resource(
-      agents,
-      dsc_type,
-      :Ensure    => 'Absent',
-      :Key       => dsc_props[:dsc_key],
-      :ValueName => dsc_props[:dsc_valuename]
-    )
-  end
+  step 'Remove Test Artifacts'
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    :Ensure    => 'Absent',
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename]
+  )
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest to Create Value'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      expect_failure('Expected to fail because of MODULES-2256') do
-        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-      end
-    end
-
-    # New manifest to force value.
-    dsc_props[:dsc_force] = 'true'
-    dsc_force_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
-
-    step 'Apply Manifest Again with Force Enabled'
-    on(agent, puppet('apply'), :stdin => dsc_force_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      expect_failure('Expected to fail because of MODULES-2256') do
-        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-      end
-    end
-
-    step 'Verify Results'
-    expect_failure('Expected to fail because of MODULES-2256') do
-      assert_dsc_resource(
-        agent,
-        dsc_type,
-        :Ensure    => dsc_props[:dsc_ensure],
-        :Key       => dsc_props[:dsc_key],
-        :ValueName => dsc_props[:dsc_valuename],
-        :ValueData => dsc_props[:dsc_valuedata],
-        :ValueType => dsc_props[:dsc_valuetype],
-        :Force     => dsc_props[:dsc_force]
-      )
-    end
+agents.each do |agent|
+  step 'Apply Manifest to Create Value'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  # New manifest to force value.
+  dsc_props[:dsc_force] = 'true'
+  dsc_props[:dsc_valuedata] = 'Meow Police!'
+  dsc_force_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+  step 'Apply Manifest Again with Force Enabled'
+  on(agent, puppet('apply'), :stdin => dsc_force_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+  end
+
+  step 'Verify Results'
+  assert_dsc_resource(
+    agent,
+    dsc_type,
+    :Ensure    => dsc_props[:dsc_ensure],
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename],
+    :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")",
+    :ValueType => dsc_props[:dsc_valuetype],
+    :Force     => "$#{dsc_props[:dsc_force]}"
+  )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_binary_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_binary_valuedata.rb
@@ -2,8 +2,9 @@ require 'erb'
 require 'dsc_utils'
 test_name 'MODULES-2230 - C68702 - Apply DSC Registry Resource with Valid "ValueData" Specified for Binary Type'
 
+confine(:to, :platform => 'windows')
+
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
@@ -21,39 +22,31 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    set_dsc_resource(
-      agents,
-      dsc_type,
-      :Ensure    => 'Absent',
-      :Key       => dsc_props[:dsc_key],
-      :ValueName => dsc_props[:dsc_valuename]
-    )
-  end
+  step 'Remove Test Artifacts'
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    :Ensure    => 'Absent',
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename]
+  )
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      expect_failure('Expected to fail because of MODULES-2256') do
-        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-      end
-    end
-
-    step 'Verify Results'
-    expect_failure('Expected to fail because of MODULES-2256') do
-      assert_dsc_resource(
-        agent,
-        dsc_type,
-        :Ensure    => dsc_props[:dsc_ensure],
-        :Key       => dsc_props[:dsc_key],
-        :ValueName => dsc_props[:dsc_valuename],
-        :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")",
-        :ValueType => dsc_props[:dsc_valuetype]
-      )
-    end
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  step 'Verify Results'
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      :Ensure    => dsc_props[:dsc_ensure],
+      :Key       => dsc_props[:dsc_key],
+      :ValueName => dsc_props[:dsc_valuename],
+      :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")",
+      :ValueType => dsc_props[:dsc_valuetype]
+    )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_hex_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_hex_valuedata.rb
@@ -2,8 +2,9 @@ require 'erb'
 require 'dsc_utils'
 test_name 'MODULES-2230 - C68704 - Apply DSC Registry Resource with Valid "ValueData" Specified for Dword Hex Type'
 
+confine(:to, :platform => 'windows')
+
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
@@ -22,40 +23,32 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    set_dsc_resource(
-      agents,
-      dsc_type,
-      :Ensure    => 'Absent',
-      :Key       => dsc_props[:dsc_key],
-      :ValueName => dsc_props[:dsc_valuename]
-    )
-  end
+  step 'Remove Test Artifacts'
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    :Ensure    => 'Absent',
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename]
+  )
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      expect_failure('Expected to fail because of MODULES-2256') do
-        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-      end
-    end
-
-    step 'Verify Results'
-    expect_failure('Expected to fail because of MODULES-2256') do
-      assert_dsc_resource(
-        agent,
-        dsc_type,
-        :Ensure    => dsc_props[:dsc_ensure],
-        :Key       => dsc_props[:dsc_key],
-        :ValueName => dsc_props[:dsc_valuename],
-        :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")",
-        :ValueType => dsc_props[:dsc_valuetype],
-        :Hex       => dsc_props[:dsc_hex]
-      )
-    end
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  step 'Verify Results'
+  assert_dsc_resource(
+    agent,
+    dsc_type,
+    :Ensure    => dsc_props[:dsc_ensure],
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename],
+    :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")",
+    :ValueType => dsc_props[:dsc_valuetype],
+    :Hex       => "$#{dsc_props[:dsc_hex]}"
+  )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_valuedata.rb
@@ -2,8 +2,9 @@ require 'erb'
 require 'dsc_utils'
 test_name 'MODULES-2230 - C68703 - Apply DSC Registry Resource with Valid "ValueData" Specified for Dword Type'
 
+confine(:to, :platform => 'windows')
+
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
@@ -21,39 +22,31 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    set_dsc_resource(
-      agents,
-      dsc_type,
-      :Ensure    => 'Absent',
-      :Key       => dsc_props[:dsc_key],
-      :ValueName => dsc_props[:dsc_valuename]
-    )
-  end
+  step 'Remove Test Artifacts'
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    :Ensure    => 'Absent',
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename]
+  )
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      expect_failure('Expected to fail because of MODULES-2256') do
-        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-      end
-    end
-
-    step 'Verify Results'
-    expect_failure('Expected to fail because of MODULES-2256') do
-      assert_dsc_resource(
-        agent,
-        dsc_type,
-        :Ensure    => dsc_props[:dsc_ensure],
-        :Key       => dsc_props[:dsc_key],
-        :ValueName => dsc_props[:dsc_valuename],
-        :ValueData => dsc_props[:dsc_valuedata],
-        :ValueType => dsc_props[:dsc_valuetype]
-      )
-    end
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  step 'Verify Results'
+  assert_dsc_resource(
+    agent,
+    dsc_type,
+    :Ensure    => dsc_props[:dsc_ensure],
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename],
+    :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")",
+    :ValueType => dsc_props[:dsc_valuetype]
+  )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_implicit_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_implicit_valuedata.rb
@@ -2,8 +2,9 @@ require 'erb'
 require 'dsc_utils'
 test_name 'MODULES-2230 - C68701 - Apply DSC Registry Resource with Valid "ValueData" Specified for Implicit String Type'
 
+confine(:to, :platform => 'windows')
+
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
@@ -20,38 +21,30 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    set_dsc_resource(
-      agents,
-      dsc_type,
-      :Ensure    => 'Absent',
-      :Key       => dsc_props[:dsc_key],
-      :ValueName => dsc_props[:dsc_valuename]
-    )
-  end
+  step 'Remove Test Artifacts'
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    :Ensure    => 'Absent',
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename]
+  )
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      expect_failure('Expected to fail because of MODULES-2256') do
-        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-      end
-    end
-
-    step 'Verify Results'
-    expect_failure('Expected to fail because of MODULES-2256') do
-      assert_dsc_resource(
-        agent,
-        dsc_type,
-        :Ensure    => dsc_props[:dsc_ensure],
-        :Key       => dsc_props[:dsc_key],
-        :ValueName => dsc_props[:dsc_valuename],
-        :ValueData => dsc_props[:dsc_valuedata]
-      )
-    end
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  step 'Verify Results'
+  assert_dsc_resource(
+    agent,
+    dsc_type,
+    :Ensure    => dsc_props[:dsc_ensure],
+    :Key       => dsc_props[:dsc_key],
+    :ValueName => dsc_props[:dsc_valuename],
+    :ValueData => "@(\"#{dsc_props[:dsc_valuedata]}\")"
+  )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -1,6 +1,8 @@
 require 'dsc_utils'
 test_name 'FM-2624 - C68533 - Apply DSC Resource Manifest with Mix of Passing and Failing DSC Resources'
 
+confine(:to, :platform => 'windows')
+
 # Init
 test_dir_name = 'test'
 
@@ -26,20 +28,16 @@ error_msg = /Error:/
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
-  end
+  step 'Remove Test Artifacts'
+  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
-      expect_failure('Expected to fail because of MODULES-2194') do
-        assert_no_match(error_msg, result.stderr, 'Expected error was not detected!')
-      end
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
+    expect_failure('Expected to fail because of MODULES-2194') do
+      assert_no_match(error_msg, result.stderr, 'Expected error was not detected!')
     end
   end
 end

--- a/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
+++ b/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
@@ -2,6 +2,8 @@ require 'erb'
 require 'dsc_utils'
 test_name 'FM-2623 - C68680 - Apply DSC Resource Manifest Containing Alternate Path Separators'
 
+confine(:to, :platform => 'windows')
+
 # Init
 test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
@@ -16,26 +18,22 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
-  end
+  step 'Remove Test Artifacts'
+  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
-
-    step 'Verify Results'
-    assert_dsc_resource(
-      agent,
-      'File',
-      :DestinationPath => test_file_path.gsub("\\", '/'),
-      :Contents => test_file_contents
-    )
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  step 'Verify Results'
+  assert_dsc_resource(
+    agent,
+    'File',
+    :DestinationPath => test_file_path.gsub("\\", '/'),
+    :Contents => test_file_contents
+  )
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
@@ -2,6 +2,8 @@ require 'erb'
 require 'dsc_utils'
 test_name 'FM-2623 - C68534 - Apply DSC Resource Manifest via "puppet apply" with Debug Enabled'
 
+confine(:to, :platform => 'windows')
+
 # Init
 test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
@@ -19,27 +21,23 @@ debug_msg = /Debug:.*Dsc_file\[tmp_file\]: The container Class\[Main\] will prop
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
-  end
+  step 'Remove Test Artifacts'
+  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply --debug'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-      assert_match(debug_msg, result.stdout, 'Expected debug message was not detected!')
-    end
-
-    step 'Verify that No Changes were Made'
-    assert_dsc_resource(
-      agent,
-      'File',
-      :DestinationPath => test_file_path,
-      :Contents => test_file_contents
-    )
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply --debug'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    assert_match(debug_msg, result.stdout, 'Expected debug message was not detected!')
   end
+
+  step 'Verify that No Changes were Made'
+  assert_dsc_resource(
+    agent,
+    'File',
+    :DestinationPath => test_file_path,
+    :Contents => test_file_contents
+  )
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
@@ -2,6 +2,8 @@ require 'erb'
 require 'dsc_utils'
 test_name 'FM-2625 - C68511 - Apply DSC Resource Manifest via "puppet apply"'
 
+confine(:to, :platform => 'windows')
+
 # Init
 test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
@@ -16,26 +18,22 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Teardown
 teardown do
-  confine_block(:to, :platform => 'windows') do
-    step 'Remove Test Artifacts'
-    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
-  end
+  step 'Remove Test Artifacts'
+  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
 end
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
-
-    step 'Verify Results'
-    assert_dsc_resource(
-      agent,
-      'File',
-      :DestinationPath => test_file_path,
-      :Contents => test_file_contents
-    )
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
+
+  step 'Verify Results'
+  assert_dsc_resource(
+    agent,
+    'File',
+    :DestinationPath => test_file_path,
+    :Contents => test_file_contents
+  )
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
@@ -2,6 +2,8 @@ require 'erb'
 require 'dsc_utils'
 test_name 'FM-2623 - C68509 - Apply DSC Resource Manifest in "noop" Mode Using "puppet apply"'
 
+confine(:to, :platform => 'windows')
+
 # Init
 test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
@@ -15,21 +17,19 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionali
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Tests
-confine_block(:to, :platform => 'windows') do
-  agents.each do |agent|
-    step 'Apply Manifest'
-    on(agent, puppet('apply --noop'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
+agents.each do |agent|
+  step 'Apply Manifest'
+  on(agent, puppet('apply --noop'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+  end
 
-    step 'Verify that No Changes were Made'
-    expect_failure('Expect failure because nothing should have changed') do
-      assert_dsc_resource(
-        agent,
-        'File',
-        :DestinationPath => test_file_path,
-        :Contents => test_file_contents
-      )
-    end
+  step 'Verify that No Changes were Made'
+  expect_failure('Expect failure because nothing should have changed') do
+    assert_dsc_resource(
+      agent,
+      'File',
+      :DestinationPath => test_file_path,
+      :Contents => test_file_contents
+    )
   end
 end

--- a/tests/test_run_scripts/all_acceptance_tests_w2008r2.sh
+++ b/tests/test_run_scripts/all_acceptance_tests_w2008r2.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../../
 fi
 
-export BEAKER_PUPPET_AGENT_VERSION=1.2.1
+export BEAKER_PUPPET_AGENT_VERSION=1.2.2
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
 
 bundle install --without build development test --path .bundle/gems

--- a/tests/test_run_scripts/all_acceptance_tests_w2012r2.sh
+++ b/tests/test_run_scripts/all_acceptance_tests_w2012r2.sh
@@ -7,7 +7,7 @@ if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../../
 fi
 
-export BEAKER_PUPPET_AGENT_VERSION=1.2.1
+export BEAKER_PUPPET_AGENT_VERSION=1.2.2
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
 
 bundle install --without build development test --path .bundle/gems


### PR DESCRIPTION
Some recent merges have caused the tests to go red because the affected
tests were set to expect failure. With the fixes in place the tests now need
to actually test something. Also, I updated the tests to use less "confine"
statements and remove unused variables.