### PR TITLE
(maint) Enable rake without Bundler 'build' group

### DIFF
--- a/build/dsc.rb
+++ b/build/dsc.rb
@@ -4,11 +4,15 @@ require 'fileutils'
 require 'pathname'
 require 'erb'
 require 'open-uri'
-require 'mof'
-require 'cim'
 require 'find'
 require 'logger'
-require 'charlock_holmes/string'
+
+# Bundler group 'build'
+if Bundler.rubygems.find_name('mof').any?
+  require 'mof'
+  require 'cim'
+  require 'charlock_holmes/string'
+end
 
 # Debug
 require 'pry' if Bundler.rubygems.find_name('pry').any?


### PR DESCRIPTION
 - The 'build' gems cannot presently be installed on Windows due to
   some conflicts with 'charlock_holmes' that includes native code that
   doesn't compile on Windows, and 'librarian-repo' which relies on
   'rubyzip' that includes native code that doesn't compile on Windows.

   This makes a typical Windows bundle install:

   `bundle install --path .bundle/gems --without system_tests build`

   However, the current rake tasks always try to load these gems, and
   therefore rake tasks cannot run on Windows.

   At a future date, some of the build process will be reworked to
   run on Windows, but for now, simply guard the loading of build
   related gems based on their existence.

   Build tasks will not work properly on Windows, but at least other
   tasks like 'spec_prep', included with puppetlabs_spec_helper, are
   now functional.