### PR TITLE
(maint) puppetlabs_spec_helper ~>0.10.3 / rake to default group

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -13,6 +13,7 @@ Gemfile:
         version: '~>2.14.1'
       - gem: puppet-lint
       - gem: puppetlabs_spec_helper
+        version: '~>0.10.3'
       - gem: puppet_facts
       - gem: mocha
         version: '~>0.10.5'

--- a/.sync.yml
+++ b/.sync.yml
@@ -8,7 +8,6 @@ Gemfile:
   supports_windows: true
   required:
     ':development':
-      - gem: rake
       - gem: rspec
         version: '~>2.14.1'
       - gem: puppet-lint

--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,9 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
+gem 'rake', :require => false
+
 group :development do
-  gem 'rake',                                :require => false
   gem 'rspec', '~>2.14.1',                   :require => false
   gem 'puppet-lint',                         :require => false
   gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -26,13 +26,13 @@ def location_for(place_or_version, fake_version = nil)
 end
 
 group :development do
-  gem 'rake',                         :require => false
-  gem 'rspec', '~>2.14.1',            :require => false
-  gem 'puppet-lint',                  :require => false
-  gem 'puppetlabs_spec_helper',       :require => false
-  gem 'puppet_facts',                 :require => false
-  gem 'mocha', '~>0.10.5',            :require => false
-  gem 'puppet-blacksmith',            :require => false
+  gem 'rake',                                :require => false
+  gem 'rspec', '~>2.14.1',                   :require => false
+  gem 'puppet-lint',                         :require => false
+  gem 'puppetlabs_spec_helper', '~>0.10.3',  :require => false
+  gem 'puppet_facts',                        :require => false
+  gem 'mocha', '~>0.10.5',                   :require => false
+  gem 'puppet-blacksmith',                   :require => false
 end
 
 group :system_tests do


### PR DESCRIPTION
Using PSH with versions lower than 0.9.0 results in issues
attempting to symlink on Windows. We'll take the latest
version as the dependency since it has the best fixes
available for cross platform testing.

Rake is required by other groups, so move it from just the
development group to the default group to allow it to always
be pulled in.