### PR TITLE
(maint) Remove librarian-puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ coverage/
 
 bin
 import
-.librarian
 .tmp
 .rbenv-gemsets
 .ruby-version

--- a/.pmtignore
+++ b/.pmtignore
@@ -1,6 +1,5 @@
 import/
 /spec/fixtures/
-.librarian
 .tmp
 *.lock
 .rbenv-gemsets

--- a/.sync.yml
+++ b/.sync.yml
@@ -17,8 +17,6 @@ Gemfile:
       - gem: mocha
         version: '~>0.10.5'
       - gem: puppet-blacksmith
-      - gem: librarian-puppet
-        version: '>=1.0.2'
     ':system_tests':
       - gem: beaker
       - gem: master_manipulator
@@ -41,7 +39,6 @@ spec/spec_helper.rb:
   paths:
   - 'bin'
   - 'import'
-  - '.librarian'
   - '.tmp'
   - '.rbenv-gemsets'
   - '.ruby-version'

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ group :development do
   gem 'puppet_facts',                 :require => false
   gem 'mocha', '~>0.10.5',            :require => false
   gem 'puppet-blacksmith',            :require => false
-  gem 'librarian-puppet', '>=1.0.2',  :require => false
 end
 
 group :system_tests do

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,1 +1,0 @@
-forge "https://forgeapi.puppetlabs.com"

--- a/Rakefile
+++ b/Rakefile
@@ -19,15 +19,4 @@ PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}
 PuppetLint.configuration.send("disable_class_inherits_from_params_class")
 PuppetLint.configuration.send("disable_80chars")
 
-# use librarian-puppet to manage fixtures instead of .fixtures.yml
-# offers more possibilities like explicit version management, forge downloads,...
-task :librarian_spec_prep do
-  sh "librarian-puppet install --path=spec/fixtures/modules/"
-  pwd = `pwd`.strip
-  unless File.directory?("#{pwd}/spec/fixtures/modules/dsc")
-    sh "ln -s #{pwd} #{pwd}/spec/fixtures/modules/dsc"
-  end
-end
-task :spec_prep => :librarian_spec_prep
-
 task :default => [:spec, :lint]


### PR DESCRIPTION
 - Librarian-puppet is completely unused in this module, so remove any
   references, including related rake tasks.  The existing rake tasks
   were in conflict with the usage of .fixtures.yml in
   puppetlabs_spec_helper (PSH), which is the default tool uesd by
   Puppet for modules.

   The conflicting task also included a call to `ln -s`, rendering the
   current approach incompatible with Windows. This commit restores the
   ability to correctly install fixtures with PSH on Windows.