### PR TITLE
(DO NOT MERGE)(MODULES-2267) Fix ensure absent

### DIFF
--- a/build/dsc/templates/dsc_type_spec.rb.erb
+++ b/build/dsc/templates/dsc_type_spec.rb.erb
@@ -242,6 +242,22 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
       end
 
     end
+
+    describe "when dsc_ensure is 'absent' in a real execution run that both tests and sets" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_<%= resource.friendlyname.downcase %>.original_parameters[:dsc_ensure] = 'absent'
+        dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_<%= resource.friendlyname.downcase %>)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
 <%  end # if resource.ensurable? -%>
 
   end

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -11,9 +11,10 @@ Applies DSC Resources by generating a configuration file and applying it.
 EOT
 
   def exists?
-    Puppet.debug "\n" + ps_script_content('test')
     set_test_dsc_parameters
-    output = powershell(powershell_args, ps_script_content('test'))
+    script_content = ps_script_content('test')
+    Puppet.debug "\n" + script_content
+    output = powershell(powershell_args, script_content)
     if ['true','false'].include?(output.to_s.strip.downcase)
       check = (output.to_s.strip.downcase == 'true')
       Puppet.debug "Dsc Resource Exists?: #{check}"
@@ -26,15 +27,19 @@ EOT
   end
 
   def create
-    Puppet.debug "\n" + ps_script_content('set')
-    output = powershell(powershell_args, ps_script_content('set'))
+    set_original_dsc_parameters
+    script_content = ps_script_content('set')
+    Puppet.debug "\n" + script_content
+    output = powershell(powershell_args, script_content)
     Puppet.debug "Dsc Resource Return: #{output}"
   end
 
   def destroy
-    Puppet.debug "\n" + ps_script_content('set')
-    output = powershell(powershell_args, ps_script_content('set'))
-    Puppet.debug output
+    set_original_dsc_parameters
+    script_content = ps_script_content('set')
+    Puppet.debug "\n" + script_content
+    output = powershell(powershell_args, script_content)
+    Puppet.debug "Dsc Resource Return: #{output}"
   end
 
   def format_dsc_value(dsc_value)

--- a/spec/unit/puppet/type/dsc_archive_spec.rb
+++ b/spec/unit/puppet/type/dsc_archive_spec.rb
@@ -369,6 +369,22 @@ describe Puppet::Type.type(:dsc_archive) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_archive.original_parameters[:dsc_ensure] = 'absent'
+        dsc_archive[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_archive)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_environment_spec.rb
+++ b/spec/unit/puppet/type/dsc_environment_spec.rb
@@ -237,6 +237,22 @@ describe Puppet::Type.type(:dsc_environment) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_environment.original_parameters[:dsc_ensure] = 'absent'
+        dsc_environment[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_environment)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_file_spec.rb
+++ b/spec/unit/puppet/type/dsc_file_spec.rb
@@ -609,6 +609,22 @@ describe Puppet::Type.type(:dsc_file) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_file.original_parameters[:dsc_ensure] = 'absent'
+        dsc_file[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_file)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_group_spec.rb
+++ b/spec/unit/puppet/type/dsc_group_spec.rb
@@ -260,6 +260,22 @@ describe Puppet::Type.type(:dsc_group) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_group.original_parameters[:dsc_ensure] = 'absent'
+        dsc_group[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_group)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_package_spec.rb
+++ b/spec/unit/puppet/type/dsc_package_spec.rb
@@ -448,6 +448,22 @@ describe Puppet::Type.type(:dsc_package) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_package.original_parameters[:dsc_ensure] = 'absent'
+        dsc_package[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_package)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_registry_spec.rb
+++ b/spec/unit/puppet/type/dsc_registry_spec.rb
@@ -398,6 +398,22 @@ describe Puppet::Type.type(:dsc_registry) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_registry.original_parameters[:dsc_ensure] = 'absent'
+        dsc_registry[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_registry)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_user_spec.rb
+++ b/spec/unit/puppet/type/dsc_user_spec.rb
@@ -415,6 +415,22 @@ describe Puppet::Type.type(:dsc_user) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_user.original_parameters[:dsc_ensure] = 'absent'
+        dsc_user[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_user)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_webdeploy_spec.rb
+++ b/spec/unit/puppet/type/dsc_webdeploy_spec.rb
@@ -199,6 +199,22 @@ describe Puppet::Type.type(:dsc_webdeploy) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_webdeploy.original_parameters[:dsc_ensure] = 'absent'
+        dsc_webdeploy[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_webdeploy)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_windowsfeature_spec.rb
+++ b/spec/unit/puppet/type/dsc_windowsfeature_spec.rb
@@ -288,6 +288,22 @@ describe Puppet::Type.type(:dsc_windowsfeature) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_windowsfeature.original_parameters[:dsc_ensure] = 'absent'
+        dsc_windowsfeature[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_windowsfeature)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_windowsprocess_spec.rb
+++ b/spec/unit/puppet/type/dsc_windowsprocess_spec.rb
@@ -526,6 +526,22 @@ describe Puppet::Type.type(:dsc_windowsprocess) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_windowsprocess.original_parameters[:dsc_ensure] = 'absent'
+        dsc_windowsprocess[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_windowsprocess)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xaddomaintrust_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaddomaintrust_spec.rb
@@ -301,6 +301,22 @@ describe Puppet::Type.type(:dsc_xaddomaintrust) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xaddomaintrust.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xaddomaintrust[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xaddomaintrust)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xaduser_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaduser_spec.rb
@@ -235,6 +235,22 @@ describe Puppet::Type.type(:dsc_xaduser) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xaduser.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xaduser[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xaduser)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazureaffinitygroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazureaffinitygroup_spec.rb
@@ -223,6 +223,22 @@ describe Puppet::Type.type(:dsc_xazureaffinitygroup) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazureaffinitygroup.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazureaffinitygroup[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazureaffinitygroup)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazurequickvm_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurequickvm_spec.rb
@@ -370,6 +370,22 @@ describe Puppet::Type.type(:dsc_xazurequickvm) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazurequickvm.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazurequickvm[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazurequickvm)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazureservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazureservice_spec.rb
@@ -223,6 +223,22 @@ describe Puppet::Type.type(:dsc_xazureservice) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazureservice.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazureservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazureservice)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazuresqldatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazuresqldatabase_spec.rb
@@ -310,6 +310,22 @@ describe Puppet::Type.type(:dsc_xazuresqldatabase) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazuresqldatabase.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazuresqldatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresqldatabase)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazuresqldatabaseserverfirewallrule_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazuresqldatabaseserverfirewallrule_spec.rb
@@ -271,6 +271,22 @@ describe Puppet::Type.type(:dsc_xazuresqldatabaseserverfirewallrule) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazuresqldatabaseserverfirewallrule.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazuresqldatabaseserverfirewallrule[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresqldatabaseserverfirewallrule)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazurestorageaccount_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurestorageaccount_spec.rb
@@ -240,6 +240,22 @@ describe Puppet::Type.type(:dsc_xazurestorageaccount) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazurestorageaccount.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazurestorageaccount[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazurestorageaccount)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazuresubscription_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazuresubscription_spec.rb
@@ -189,6 +189,22 @@ describe Puppet::Type.type(:dsc_xazuresubscription) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazuresubscription.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazuresubscription[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazuresubscription)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazurevm_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurevm_spec.rb
@@ -404,6 +404,22 @@ describe Puppet::Type.type(:dsc_xazurevm) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazurevm.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazurevm[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazurevm)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xazurevmdscconfiguration_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurevmdscconfiguration_spec.rb
@@ -257,6 +257,22 @@ describe Puppet::Type.type(:dsc_xazurevmdscconfiguration) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xazurevmdscconfiguration.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xazurevmdscconfiguration[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xazurevmdscconfiguration)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xdatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdatabase_spec.rb
@@ -325,6 +325,22 @@ describe Puppet::Type.type(:dsc_xdatabase) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xdatabase.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdatabase)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xdhcpserveroption_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdhcpserveroption_spec.rb
@@ -238,6 +238,22 @@ describe Puppet::Type.type(:dsc_xdhcpserveroption) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xdhcpserveroption.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdhcpserveroption[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserveroption)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xdhcpserverreservation_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdhcpserverreservation_spec.rb
@@ -267,6 +267,22 @@ describe Puppet::Type.type(:dsc_xdhcpserverreservation) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xdhcpserverreservation.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdhcpserverreservation[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserverreservation)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xdhcpserverscope_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdhcpserverscope_spec.rb
@@ -345,6 +345,22 @@ describe Puppet::Type.type(:dsc_xdhcpserverscope) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xdhcpserverscope.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdhcpserverscope[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdhcpserverscope)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xdnsserversecondaryzone_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdnsserversecondaryzone_spec.rb
@@ -207,6 +207,22 @@ describe Puppet::Type.type(:dsc_xdnsserversecondaryzone) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xdnsserversecondaryzone.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdnsserversecondaryzone[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdnsserversecondaryzone)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xdscwebservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdscwebservice_spec.rb
@@ -382,6 +382,22 @@ describe Puppet::Type.type(:dsc_xdscwebservice) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xdscwebservice.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xdscwebservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xdscwebservice)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xfirewall_spec.rb
+++ b/spec/unit/puppet/type/dsc_xfirewall_spec.rb
@@ -505,6 +505,22 @@ describe Puppet::Type.type(:dsc_xfirewall) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xfirewall.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xfirewall[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xfirewall)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xgroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xgroup_spec.rb
@@ -260,6 +260,22 @@ describe Puppet::Type.type(:dsc_xgroup) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xgroup.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xgroup[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xgroup)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xiismodule_spec.rb
+++ b/spec/unit/puppet/type/dsc_xiismodule_spec.rb
@@ -320,6 +320,22 @@ describe Puppet::Type.type(:dsc_xiismodule) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xiismodule.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xiismodule[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xiismodule)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xjeaendpoint_spec.rb
+++ b/spec/unit/puppet/type/dsc_xjeaendpoint_spec.rb
@@ -273,6 +273,22 @@ describe Puppet::Type.type(:dsc_xjeaendpoint) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xjeaendpoint.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xjeaendpoint[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xjeaendpoint)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xjeatoolkit_spec.rb
+++ b/spec/unit/puppet/type/dsc_xjeatoolkit_spec.rb
@@ -225,6 +225,22 @@ describe Puppet::Type.type(:dsc_xjeatoolkit) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xjeatoolkit.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xjeatoolkit[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xjeatoolkit)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xmysqldatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqldatabase_spec.rb
@@ -189,6 +189,22 @@ describe Puppet::Type.type(:dsc_xmysqldatabase) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xmysqldatabase.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xmysqldatabase[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqldatabase)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xmysqlgrant_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqlgrant_spec.rb
@@ -319,6 +319,22 @@ describe Puppet::Type.type(:dsc_xmysqlgrant) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xmysqlgrant.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xmysqlgrant[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqlgrant)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xmysqlserver_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqlserver_spec.rb
@@ -189,6 +189,22 @@ describe Puppet::Type.type(:dsc_xmysqlserver) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xmysqlserver.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xmysqlserver[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqlserver)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xmysqluser_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqluser_spec.rb
@@ -206,6 +206,22 @@ describe Puppet::Type.type(:dsc_xmysqluser) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xmysqluser.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xmysqluser[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xmysqluser)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xpackage_spec.rb
+++ b/spec/unit/puppet/type/dsc_xpackage_spec.rb
@@ -520,6 +520,22 @@ describe Puppet::Type.type(:dsc_xpackage) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xpackage.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xpackage[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xpackage)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xpsendpoint_spec.rb
+++ b/spec/unit/puppet/type/dsc_xpsendpoint_spec.rb
@@ -274,6 +274,22 @@ describe Puppet::Type.type(:dsc_xpsendpoint) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xpsendpoint.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xpsendpoint[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xpsendpoint)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xremotedesktopadmin_spec.rb
+++ b/spec/unit/puppet/type/dsc_xremotedesktopadmin_spec.rb
@@ -196,6 +196,22 @@ describe Puppet::Type.type(:dsc_xremotedesktopadmin) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xremotedesktopadmin.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xremotedesktopadmin[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xremotedesktopadmin)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xremotefile_spec.rb
+++ b/spec/unit/puppet/type/dsc_xremotefile_spec.rb
@@ -241,6 +241,22 @@ describe Puppet::Type.type(:dsc_xremotefile) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xremotefile.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xremotefile[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xremotefile)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xservice_spec.rb
@@ -418,6 +418,22 @@ describe Puppet::Type.type(:dsc_xservice) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xservice.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xservice[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xservice)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xsmbshare_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsmbshare_spec.rb
@@ -471,6 +471,22 @@ describe Puppet::Type.type(:dsc_xsmbshare) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xsmbshare.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xsmbshare[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xsmbshare)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xvhd_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvhd_spec.rb
@@ -418,6 +418,22 @@ describe Puppet::Type.type(:dsc_xvhd) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xvhd.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xvhd[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xvhd)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xvmhyperv_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvmhyperv_spec.rb
@@ -778,6 +778,22 @@ describe Puppet::Type.type(:dsc_xvmhyperv) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xvmhyperv.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xvmhyperv[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xvmhyperv)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xvmswitch_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvmswitch_spec.rb
@@ -336,6 +336,22 @@ describe Puppet::Type.type(:dsc_xvmswitch) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xvmswitch.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xvmswitch[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xvmswitch)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xwebapplication_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebapplication_spec.rb
@@ -235,6 +235,22 @@ describe Puppet::Type.type(:dsc_xwebapplication) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xwebapplication.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebapplication[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebapplication)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xwebapppool_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebapppool_spec.rb
@@ -213,6 +213,22 @@ describe Puppet::Type.type(:dsc_xwebapppool) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xwebapppool.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebapppool[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebapppool)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xwebconfigkeyvalue_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebconfigkeyvalue_spec.rb
@@ -298,6 +298,22 @@ describe Puppet::Type.type(:dsc_xwebconfigkeyvalue) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xwebconfigkeyvalue.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebconfigkeyvalue[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebconfigkeyvalue)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xwebsite_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebsite_spec.rb
@@ -300,6 +300,22 @@ describe Puppet::Type.type(:dsc_xwebsite) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xwebsite.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebsite[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebsite)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xwebvirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwebvirtualdirectory_spec.rb
@@ -247,6 +247,22 @@ describe Puppet::Type.type(:dsc_xwebvirtualdirectory) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xwebvirtualdirectory.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwebvirtualdirectory[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwebvirtualdirectory)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xwindowsoptionalfeature_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwindowsoptionalfeature_spec.rb
@@ -406,6 +406,22 @@ describe Puppet::Type.type(:dsc_xwindowsoptionalfeature) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xwindowsoptionalfeature.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwindowsoptionalfeature[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwindowsoptionalfeature)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xwindowsprocess_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwindowsprocess_spec.rb
@@ -526,6 +526,22 @@ describe Puppet::Type.type(:dsc_xwindowsprocess) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xwindowsprocess.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwindowsprocess[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwindowsprocess)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS

--- a/spec/unit/puppet/type/dsc_xwordpresssite_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwordpresssite_spec.rb
@@ -223,6 +223,22 @@ describe Puppet::Type.type(:dsc_xwordpresssite) do
 
     end
 
+    describe "when dsc_ensure is 'absent' for realz" do
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        dsc_xwordpresssite.original_parameters[:dsc_ensure] = 'absent'
+        dsc_xwordpresssite[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_xwordpresssite)
+
+        @provider.set_test_dsc_parameters
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+
+        @provider.set_original_dsc_parameters
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
   end
 
   # mof PROVIDERS TESTS


### PR DESCRIPTION
The method set_test_dsc_parameters resets any dsc_ensure line to
'present' if the user set dsc_ensure to 'absent'. When the destroy
method is called, set_test_dsc_parameters has already been called and
changed the dsc_ensure value to the opposite of what we want.

The exists? method as is, is a silent bug because it executes
set_test_dsc_parameters after the DEBUG output is shown to the user,
hiding the fact that it is changing the dsc_ensure value during the test
run, making it appear that it is changed during teh destroy run. Moving
it up one line shows the value change in the DEBUG output. Since the
values are changed with set_test_dsc_parameters and not set back, the
destroy method passes the 'present' value to the DSC Script instead of
the 'absent' value the user specified.

By invoking set_original_dsc_parameters before we compile the script in
the destroy method we set the values back to their original settings. We
still need to invoke set_original_dsc_parameters in the exists? method
because we need to flip our logic for DSC. DSC returns false if the
target node is not in the desired state, so we have to inverse our logic
to get it to give us a true (true meaning in this case that the thing we
want to destroy actually exists).