### PR TITLE
(maint) don't monkey patch bool munging

### DIFF
--- a/build/dsc.rb
+++ b/build/dsc.rb
@@ -36,12 +36,3 @@ module Dsc
   end
 
 end
-
-class String
-  def to_bool
-    return true if self =~ (/^(true|t|yes|y|1)$/i)
-    return false if self.empty? || self =~ (/^(false|f|no|n|0)$/i)
-
-    raise ArgumentError.new "invalid value: #{self}"
-  end
-end

--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -124,7 +124,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     end
 <%    when property.bool? -%>
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 <%    when (property.int? || property.uint?) -%>
     munge do |value|

--- a/build/dsc/templates/dsc_type_spec.rb.erb
+++ b/build/dsc/templates/dsc_type_spec.rb.erb
@@ -1,6 +1,14 @@
 #!/usr/bin/env ruby
 require 'spec_helper'
 
+<%-
+def munge_boolean(value)
+  return true if value =~ (/^(true|t|yes|y|1)$/i)
+  return false if value.empty? || value =~ (/^(false|f|no|n|0)$/i)
+
+  raise ArgumentError.new "invalid value: #{value}"
+end
+-%>
 describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
 
   let :dsc_<%= resource.friendlyname.downcase %> do
@@ -108,7 +116,7 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
 <%      @spec_test_values['munged_bools'].each do |munged_bool| %>
   it "should accept boolean-like value <%= format_type_value(munged_bool) %> and munge this value to boolean for dsc_<%= property.name.downcase %>" do
     dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>] = <%= format_type_value(munged_bool) %>
-    expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq(<%= munged_bool.to_s.downcase.to_bool %>)
+    expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq(<%= munge_boolean(munged_bool.to_s) %>)
   end
 <%      end #  @spec_test_values['munged_bools']... -%>
 <%    else # if property.bool? -%>

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -62,6 +62,13 @@ EOT
     Puppet.debug "Dsc Resource Return: #{output}"
   end
 
+  def munge_boolean(value)
+    return true if value =~ (/^(true|t|yes|y|1)$/i)
+    return false if value.empty? || value =~ (/^(false|f|no|n|0)$/i)
+
+    raise ArgumentError.new "invalid value: #{value}"
+  end
+
   def format_dsc_value(dsc_value)
     case
     when dsc_value.class.name == 'String'

--- a/lib/puppet/type/base_dsc.rb
+++ b/lib/puppet/type/base_dsc.rb
@@ -1,10 +1,7 @@
 # This is the base type for dsc.
 # Used to inherit the providers for the generated DSC resources
-require 'puppet_x/string'
-
 Puppet::Type.newtype(:base_dsc) do
 
   newparam(:name, :namevar => true ) do
   end
-
 end

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_archive) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -103,7 +103,7 @@ Puppet::Type.newtype(:dsc_archive) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_archive) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_environment) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -101,7 +101,7 @@ Puppet::Type.newtype(:dsc_environment) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_file) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -143,7 +143,7 @@ Puppet::Type.newtype(:dsc_file) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -156,7 +156,7 @@ Puppet::Type.newtype(:dsc_file) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -260,7 +260,7 @@ Puppet::Type.newtype(:dsc_file) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_group) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -30,7 +30,7 @@ Puppet::Type.newtype(:dsc_log) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_package) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -229,7 +229,7 @@ Puppet::Type.newtype(:dsc_package) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_registry) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -133,7 +133,7 @@ Puppet::Type.newtype(:dsc_registry) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -146,7 +146,7 @@ Puppet::Type.newtype(:dsc_registry) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:dsc_script) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_service) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_user) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -125,7 +125,7 @@ Puppet::Type.newtype(:dsc_user) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -138,7 +138,7 @@ Puppet::Type.newtype(:dsc_user) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -151,7 +151,7 @@ Puppet::Type.newtype(:dsc_user) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_user) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_webdeploy.rb
+++ b/lib/puppet/type/dsc_webdeploy.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_webdeploy) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xaddomain) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xaduser) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xarchive) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -125,7 +125,7 @@ Puppet::Type.newtype(:dsc_xarchive) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -122,7 +122,7 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -149,7 +149,7 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazureservice) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazurestorageaccount) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazuresubscription) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazurevm) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_xazurevm) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_xazurevm) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xcluster) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xcomputer) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdatabase) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xdhcpserverscope) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -171,7 +171,7 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xfirewall) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xgroup) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xiismodule) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -167,7 +167,7 @@ Puppet::Type.newtype(:dsc_xiismodule) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xiiswordpresssite.rb
+++ b/lib/puppet/type/dsc_xiiswordpresssite.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xiiswordpresssite) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xipaddress) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -139,7 +139,7 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xpackage) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -233,7 +233,7 @@ Puppet::Type.newtype(:dsc_xpackage) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollection) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -94,7 +94,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -108,7 +108,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -276,7 +276,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -303,7 +303,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xremotefile) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xservice) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -137,7 +137,7 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xvhd) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -198,7 +198,7 @@ Puppet::Type.newtype(:dsc_xvhd) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -227,7 +227,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -241,7 +241,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -356,7 +356,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -110,7 +110,7 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xwebapplication) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -139,7 +139,7 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwebsite) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -108,7 +108,7 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 
@@ -121,7 +121,7 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -93,7 +93,7 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
     end
     newvalues(true, false)
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -31,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
     newvalues(true, false)
 
     munge do |value|
-      value.to_s.downcase.to_bool
+      provider.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet_x/string.rb
+++ b/lib/puppet_x/string.rb
@@ -1,8 +1,0 @@
-class String
-  def to_bool
-    return true if self =~ (/^(true|t|yes|y|1)$/i)
-    return false if self.empty? || self =~ (/^(false|f|no|n|0)$/i)
-
-    raise ArgumentError.new "invalid value: #{self}"
-  end
-end


### PR DESCRIPTION
 - Create a new munge_boolean helper inside the provider based on the
   current monkey patching.
 - Similarly in the MOF parsing and building step, don't monkey-patch
   String, but instead use a method defined in the template when
   generating tests.