### PR TITLE
(MODULES-2365) Allow Tests to be Run Locally

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -63,9 +63,14 @@ To run acceptance tests use the "acceptance_tests.sh" test run script.
 ./acceptance.sh
 ```
 
-**Example: Run with Puppet Agent 1.2.1 on Windows 2008 R2**
+**Example: Run with Puppet Agent 1.2.1 on Windows 2008 R2 using Forge**
 ```
-./acceptance.sh windows-2008r2-64a 1.2.1
+./acceptance.sh windows-2008r2-64a 1.2.1 forge
+```
+
+**Example: Run with Puppet Agent 1.2.2 on Windows 2012 R2 with local module code (No Forge)**
+```
+./acceptance.sh windows-2012r2-64a 1.2.2 local
 ```
 
 ### Running Integration Tests
@@ -77,9 +82,14 @@ To run integration tests use the "integration_tests.sh" test run script.
 ./integration.sh
 ```
 
-**Example: Run with alternate PE package repo on Windows 2008 R2**
+**Example: Run with alternate PE package repo on Windows 2008 R2 using Forge**
 ```
-./integration.sh windows-2008r2-64mda http://alt.address.local/3.8.2/preview
+./integration.sh windows-2008r2-64mda http://alt.address.local/3.8.2/preview forge
+```
+
+**Example: Run with alternate PE package repo on Windows 2012 R2 with local module code (No Forge)**
+```
+./acceptance.sh windows-2012r2-64a http://alt.address.local/3.8.2/preview local
 ```
 
 ## Documentation

--- a/tests/acceptance/pre-suite/02_dsc_module_install.rb
+++ b/tests/acceptance/pre-suite/02_dsc_module_install.rb
@@ -2,6 +2,19 @@ test_name 'FM-2626 - C68503 - Install Module via PMT on Agent with Prerequisites
 
 confine(:to, :platform => 'windows')
 
-step 'Install Module via PMT'
-stub_forge_on(agents)
-on(agents, puppet('module install puppetlabs-dsc --module_working_dir C:/Windows/Temp'))
+# Init
+proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+staging = { :module_name => 'puppetlabs-dsc' }
+
+
+agents.each do |agent|
+  local = { :module_name => 'dsc', :proj_root => proj_root, :target_module_path => agent['distmoduledir'] }
+
+  step 'Install DSC Module Dependencies'
+  on(agent, puppet('module install puppetlabs-stdlib'))
+  on(agent, puppet('module install puppetlabs-powershell'))
+
+  step 'Install DSC Module'
+  # in CI install from staging forge, otherwise from local
+  install_dev_puppet_module_on(agent, options[:forge_host] ? staging : local)
+end

--- a/tests/configs/windows-2008r2-64a
+++ b/tests/configs/windows-2008r2-64a
@@ -13,4 +13,3 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
-  forge_host: api-module-staging.puppetlabs.com

--- a/tests/configs/windows-2008r2-64mda
+++ b/tests/configs/windows-2008r2-64mda
@@ -21,4 +21,3 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
-  forge_host: api-module-staging.puppetlabs.com

--- a/tests/configs/windows-2012r2-64a
+++ b/tests/configs/windows-2012r2-64a
@@ -13,4 +13,3 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
-  forge_host: api-module-staging.puppetlabs.com

--- a/tests/configs/windows-2012r2-64mda
+++ b/tests/configs/windows-2012r2-64mda
@@ -21,4 +21,3 @@ CONFIG:
   folder: Delivery/Quality Assurance/Enterprise/Dynamic
   resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
   pooling_api: http://vmpooler.delivery.puppetlabs.net/
-  forge_host: api-module-staging.puppetlabs.com

--- a/tests/integration/pre-suite/01_dsc_module_install.rb
+++ b/tests/integration/pre-suite/01_dsc_module_install.rb
@@ -3,3 +3,16 @@ test_name 'FM-2626 - C68506 - Plug-in Sync Module from Master with Prerequisites
 step 'Install Module via PMT'
 stub_forge_on(master)
 on(master, puppet('module install puppetlabs-dsc'))
+
+# Init
+proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+staging = { :module_name => 'puppetlabs-dsc' }
+local = { :module_name => 'dsc', :proj_root => proj_root, :target_module_path => master['distmoduledir'] }
+
+step 'Install DSC Module Dependencies'
+on(master, puppet('module install puppetlabs-stdlib'))
+on(master, puppet('module install puppetlabs-powershell'))
+
+step 'Install DSC Module'
+# in CI install from staging forge, otherwise from local
+install_dev_puppet_module_on(master, options[:forge_host] ? staging : local)

--- a/tests/test_run_scripts/acceptance_tests.sh
+++ b/tests/test_run_scripts/acceptance_tests.sh
@@ -12,8 +12,9 @@ declare -a ARGS
 if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64a'
   ARGS[1]='1.2.2'
-elif [ $# -ne 2 ]; then
-  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VERSION>'
+  ARGS[2]='forge'
+elif [ $# -ne 3 ]; then
+  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE>'
   exit 1
 else
   ARGS=("$@")
@@ -22,6 +23,18 @@ fi
 # Figure out where we are in the directory hierarchy
 if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../../
+fi
+
+# Determine if the forge is needed for the test.
+if [ ${ARGS[2]} == 'forge' ]; then
+  echo 'Testing Module Using Forge Package'
+  export BEAKER_FORGE_HOST=api-module-staging.puppetlabs.com
+elif [ ${ARGS[2]} == 'local' ]; then
+  echo 'Testing Module Using Local Code'
+else
+  echo 'You must specify "forge" or "local" for test type!'
+  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE>'
+  exit 1
 fi
 
 export BEAKER_PUPPET_AGENT_VERSION=${ARGS[1]}

--- a/tests/test_run_scripts/integration_tests.sh
+++ b/tests/test_run_scripts/integration_tests.sh
@@ -11,8 +11,9 @@ declare -a ARGS
 if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64mda'
   ARGS[1]='http://neptune.puppetlabs.lan/2015.2/preview'
-elif [ $# -ne 2 ]; then
-  echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR>'
+  ARGS[2]='true'
+elif [ $# -ne 3 ]; then
+  echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR> <LOCAL_OR_FORGE>'
   exit 1
 else
   ARGS=("$@")
@@ -21,6 +22,18 @@ fi
 # Figure out where we are in the directory hierarchy
 if [ $SCRIPT_BASE_PATH = "test_run_scripts" ]; then
   cd ../../
+fi
+
+# Determine if the forge is needed for the test.
+if [ ${ARGS[2]} == 'forge' ]; then
+  echo 'Testing Module Using Forge Package'
+  export BEAKER_FORGE_HOST=api-module-staging.puppetlabs.com
+elif [ ${ARGS[2]} == 'local' ]; then
+  echo 'Testing Module Using Local Code'
+else
+  echo 'You must specify "forge" or "local" for test type!'
+  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE>'
+  exit 1
 fi
 
 export pe_dist_dir=${ARGS[1]}


### PR DESCRIPTION
The acceptance and integration tests can only be ran against artifacts
on the module forge. This is problematic for developers that want to test
their changes before commiting code. The changes made update the test run
scripts, configs and documentation to allow for local testing.