### PR TITLE
(MODULES-2384) Update Test Helper Library

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
@@ -39,7 +39,9 @@ agents.each do |agent|
 
   step 'Verify Results'
   assert_dsc_resource(
-    agent, 'File',
+    agent,
+    'File',
+    'PSDesiredStateConfiguration',
     :DestinationPath => test_file_path,
     :Contents => test_file_contents
   )

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
@@ -41,6 +41,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     'File',
+    'PSDesiredStateConfiguration',
     :DestinationPath => test_file_path,
     :Contents => test_file_contents
   )

--- a/tests/acceptance/tests/basic_dsc_resources/file/dir_recurse.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/dir_recurse.rb
@@ -10,6 +10,7 @@ sub_dir_name = "sub_dir_test_"
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_type            => 'Directory',
@@ -27,6 +28,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure          => 'Absent',
     :Type            => dsc_props[:dsc_type],
     :DestinationPath => dsc_props[:dsc_destinationpath],
@@ -36,6 +38,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure          => 'Absent',
     :Type            => dsc_props[:dsc_type],
     :DestinationPath => dsc_props[:dsc_sourcepath],
@@ -51,6 +54,7 @@ agents.each do |agent|
     set_dsc_resource(
       agent,
       dsc_type,
+      dsc_module,
       :Ensure          => 'Present',
       :Type            => dsc_props[:dsc_type],
       :DestinationPath => "#{dsc_props[:dsc_sourcepath]}\\#{sub_dir_name}#{n}"
@@ -70,6 +74,7 @@ agents.each do |agent|
     assert_dsc_resource(
       agent,
       dsc_type,
+      dsc_module,
       :Ensure          => dsc_props[:dsc_ensure],
       :Type            => dsc_props[:dsc_type],
       :DestinationPath => "#{dsc_props[:dsc_destinationpath]}\\#{sub_dir_name}#{n}"

--- a/tests/acceptance/tests/basic_dsc_resources/file/dir_remove_dir.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/dir_remove_dir.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_type            => 'Directory',
@@ -38,6 +39,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure          => dsc_props[:dsc_ensure],
     :Type            => dsc_props[:dsc_type],
     :DestinationPath => dsc_props[:dsc_destinationpath],

--- a/tests/acceptance/tests/basic_dsc_resources/file/dir_valid_path.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/dir_valid_path.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_type            => 'Directory',
@@ -24,6 +25,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure          => 'Absent',
     :Type            => dsc_props[:dsc_type],
     :DestinationPath => dsc_props[:dsc_destinationpath]
@@ -41,6 +43,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure          => dsc_props[:dsc_ensure],
     :Type            => dsc_props[:dsc_type],
     :DestinationPath => dsc_props[:dsc_destinationpath],

--- a/tests/acceptance/tests/basic_dsc_resources/file/dir_valid_unicode_path.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/dir_valid_unicode_path.rb
@@ -11,6 +11,7 @@ test_dir_name = "\u1134\u1169\u1185\u1173\u112D\u1117\u1114\u1135\u114E"
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_type            => 'Directory',

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_remove_file.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_remove_file.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_destinationpath => 'C:\test_remove.file',
@@ -38,6 +39,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure          => dsc_props[:dsc_ensure],
     :DestinationPath => dsc_props[:dsc_destinationpath],
     :Contents        => dsc_props[:dsc_contents]

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_valid_path_contents.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_valid_path_contents.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_destinationpath => 'C:\test.file',
@@ -24,6 +25,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure          => 'Absent',
     :DestinationPath => dsc_props[:dsc_destinationpath]
   )
@@ -40,6 +42,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure          => dsc_props[:dsc_ensure],
     :DestinationPath => dsc_props[:dsc_destinationpath],
     :Contents        => dsc_props[:dsc_contents],

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_valid_path_source.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_valid_path_source.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_destinationpath => 'C:\test.file',
@@ -27,6 +28,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure          => 'Absent',
     :DestinationPath => dsc_props[:dsc_destinationpath]
   )
@@ -34,6 +36,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure          => 'Absent',
     :DestinationPath => dsc_props[:dsc_sourcepath]
   )
@@ -43,6 +46,7 @@ end
 set_dsc_resource(
   agents,
   dsc_type,
+  dsc_module,
   :Ensure          => 'Present',
   :DestinationPath => dsc_props[:dsc_sourcepath],
   :Contents        => source_file_contents
@@ -59,6 +63,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure          => dsc_props[:dsc_ensure],
     :DestinationPath => dsc_props[:dsc_destinationpath],
     :Contents        => source_file_contents,

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_contents.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_contents.rb
@@ -12,6 +12,7 @@ test_file_contents = "\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158\u31
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_destinationpath => "C:\\#{test_file_name}"

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_path.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_path.rb
@@ -11,6 +11,7 @@ test_file_name = "\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158\u3140\u
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_destinationpath => "C:\\#{test_file_name}"

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_source.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_source.rb
@@ -12,6 +12,7 @@ source_file_name = "\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158\u3140
 
 # ERB Manifest
 dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_destinationpath => "C:\\#{test_file_name}",

--- a/tests/acceptance/tests/basic_dsc_resources/group/group_valid_members.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/group/group_valid_members.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'group'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_groupname => 'TestGroupMembers',
@@ -24,6 +25,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure    => 'Absent',
     :GroupName  => dsc_props[:dsc_groupname]
   )
@@ -40,6 +42,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure    => dsc_props[:dsc_ensure],
     :GroupName => dsc_props[:dsc_groupname],
     :Members   => '@("Administrator","Guest")'

--- a/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
@@ -20,14 +20,14 @@ dsc_file {'bad_test_dir_2':
 MANIFEST
 
 # Verify
-error_msg = /Error:/
+error_msg_1 = /Error: The system cannot find the path specified\. The related file\/directory is: Q:\/not\/here_1\./
+error_msg_2 = /Error: The system cannot find the path specified\. The related file\/directory is: Q:\/not\/here_2\./
 
 # Tests
 agents.each do |agent|
   step 'Apply Manifest'
   on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
-    expect_failure('Expected to fail because of MODULES-2194') do
-      assert_no_match(error_msg, result.stderr, 'Expected error was not detected!')
-    end
+    assert_match(error_msg_1, result.stderr, 'Expected error was not detected!')
+    assert_match(error_msg_2, result.stderr, 'Expected error was not detected!')
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_force_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_force_value.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'registry'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
@@ -26,6 +27,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure    => 'Absent',
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename]
@@ -53,6 +55,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure    => dsc_props[:dsc_ensure],
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename],

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_remove_value.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_remove_value.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'registry'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
@@ -40,6 +41,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure    => dsc_props[:dsc_ensure],
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename],

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_binary_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_binary_valuedata.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'registry'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
@@ -26,6 +27,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure    => 'Absent',
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename]
@@ -43,6 +45,7 @@ agents.each do |agent|
     assert_dsc_resource(
       agent,
       dsc_type,
+      dsc_module,
       :Ensure    => dsc_props[:dsc_ensure],
       :Key       => dsc_props[:dsc_key],
       :ValueName => dsc_props[:dsc_valuename],

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_hex_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_hex_valuedata.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'registry'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
@@ -27,6 +28,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure    => 'Absent',
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename]
@@ -44,6 +46,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure    => dsc_props[:dsc_ensure],
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename],

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_dword_valuedata.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'registry'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
@@ -26,6 +27,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure    => 'Absent',
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename]
@@ -43,6 +45,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure    => dsc_props[:dsc_ensure],
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename],

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_implicit_valuedata.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_implicit_valuedata.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'registry'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
@@ -25,6 +26,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure    => 'Absent',
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename]
@@ -42,6 +44,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure    => dsc_props[:dsc_ensure],
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename],

--- a/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_key_valuename.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/registry/reg_valid_key_valuename.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'registry'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_key       => 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey',
@@ -24,6 +25,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Ensure    => 'Absent',
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename]
@@ -41,6 +43,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Ensure    => dsc_props[:dsc_ensure],
     :Key       => dsc_props[:dsc_key],
     :ValueName => dsc_props[:dsc_valuename]

--- a/tests/acceptance/tests/basic_dsc_resources/service/service_valid_name_startuptype_state.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/service/service_valid_name_startuptype_state.rb
@@ -9,6 +9,7 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'service'
+dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_name        => 'w32time',
   :dsc_state       => 'Running',
@@ -24,6 +25,7 @@ teardown do
   set_dsc_resource(
     agents,
     dsc_type,
+    dsc_module,
     :Name        => 'w32time',
     :State       => 'Stopped',
     :StartupType => 'Manual'
@@ -41,6 +43,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     dsc_type,
+    dsc_module,
     :Name        => dsc_props[:dsc_name],
     :State       => dsc_props[:dsc_state],
     :StartupType => dsc_props[:dsc_startuptype]

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -24,7 +24,7 @@ dsc_file {'bad_test_dir':
 MANIFEST
 
 # Verify
-error_msg = /Error:/
+error_msg = /Error: The system cannot find the path specified. The related file\/directory is: Q:\/not\/here/m
 
 # Teardown
 teardown do
@@ -36,8 +36,6 @@ end
 agents.each do |agent|
   step 'Apply Manifest'
   on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
-    expect_failure('Expected to fail because of MODULES-2194') do
-      assert_no_match(error_msg, result.stderr, 'Expected error was not detected!')
-    end
+    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
   end
 end

--- a/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
+++ b/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
@@ -33,6 +33,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     'File',
+    'PSDesiredStateConfiguration',
     :DestinationPath => test_file_path.gsub("\\", '/'),
     :Contents => test_file_contents
   )

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
@@ -37,6 +37,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     'File',
+    'PSDesiredStateConfiguration',
     :DestinationPath => test_file_path,
     :Contents => test_file_contents
   )

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
@@ -33,6 +33,7 @@ agents.each do |agent|
   assert_dsc_resource(
     agent,
     'File',
+    'PSDesiredStateConfiguration',
     :DestinationPath => test_file_path,
     :Contents => test_file_contents
   )

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
@@ -28,6 +28,7 @@ agents.each do |agent|
     assert_dsc_resource(
       agent,
       'File',
+      'PSDesiredStateConfiguration',
       :DestinationPath => test_file_path,
       :Contents => test_file_contents
     )

--- a/tests/integration/tests/basic_functionality/puppet_agent_debug_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_debug_dsc_manifest.rb
@@ -44,6 +44,7 @@ confine_block(:to, :platform => 'windows') do
     assert_dsc_resource(
       agent,
       'File',
+      'PSDesiredStateConfiguration',
       :DestinationPath => test_file_path,
       :Contents => test_file_contents
     )

--- a/tests/integration/tests/basic_functionality/puppet_agent_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_dsc_manifest.rb
@@ -40,6 +40,7 @@ confine_block(:to, :platform => 'windows') do
     assert_dsc_resource(
       agent,
       'File',
+      'PSDesiredStateConfiguration',
       :DestinationPath => test_file_path,
       :Contents => test_file_contents
     )

--- a/tests/integration/tests/basic_functionality/puppet_agent_noop_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_noop_dsc_manifest.rb
@@ -33,6 +33,7 @@ confine_block(:to, :platform => 'windows') do
       assert_dsc_resource(
         agent,
         'File',
+        'PSDesiredStateConfiguration',
         :DestinationPath => test_file_path,
         :Contents => test_file_contents
       )


### PR DESCRIPTION
Changed the methods in "dsc_utils" to accept a module name which is necessary
for "x" DSC resources. Also updated the tests "multi_failing_dsc_resources.rb"
and "some_failing_dsc_resources.rb" to remove the "expect_failure" now that
DSC resources fail gracefully.