### PR TITLE
(MODULES-2388) Warning Output breaks JSON Parsing

### DIFF
--- a/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
@@ -1,4 +1,6 @@
 $script:ErrorActionPreference = 'Stop'
+$script:WarningPreference     = 'SilentlyContinue'
+
 $response = @{
   indesiredstate = $false
   rebootrequired = $false


### PR DESCRIPTION
Invoke-DscResource does not respect WarningAction or WarningVariable and
so sends output to the Warning stream regardlees of user setting. This
Warning output is caught and sent back along with our objects, and
breaks the JSON parser.

We set $WarningPreference to 'SilentlyContinue' to work around this.