### PR TITLE
(MODULES-2399) Create Tests for "WaitFor*" Resources

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/waitforall/negative/waitforall_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforall/negative/waitforall_blacklist.rb
@@ -1,0 +1,29 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2399 - C68777 - Attempt to Apply DSC WaitForAll Resource'
+
+confine(:to, :platform => 'windows')
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'waitforall'
+dsc_props = {
+  :dsc_nodename     => 'localhost',
+  :dsc_resourcename => 'does_not_matter'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Verify
+error_msg = /Error:.*Invalid resource type dsc_waitforall/
+
+# Tests
+agents.each do |agent|
+  step 'Attempt to Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 1) do |result|
+    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/waitforany/negative/waitforany_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforany/negative/waitforany_blacklist.rb
@@ -1,0 +1,29 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2399 - C71648 - Attempt to Apply DSC WaitForAny Resource'
+
+confine(:to, :platform => 'windows')
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'waitforany'
+dsc_props = {
+  :dsc_nodename     => 'localhost',
+  :dsc_resourcename => 'does_not_matter'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Verify
+error_msg = /Error:.*Invalid resource type dsc_waitforany/
+
+# Tests
+agents.each do |agent|
+  step 'Attempt to Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 1) do |result|
+    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/waitforsome/negative/waitforsome_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforsome/negative/waitforsome_blacklist.rb
@@ -1,0 +1,29 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2399 - C71647 - Attempt to Apply DSC WaitForSome Resource'
+
+confine(:to, :platform => 'windows')
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'waitforsome'
+dsc_props = {
+  :dsc_nodename     => 'localhost',
+  :dsc_resourcename => 'does_not_matter'
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Verify
+error_msg = /Error:.*Invalid resource type dsc_waitforsome/
+
+# Tests
+agents.each do |agent|
+  step 'Attempt to Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 1) do |result|
+    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+  end
+end


### PR DESCRIPTION
The "WaitFor*" resources are not supported by the DSC module. This set of
tests verifies that the resources have been blacklisted by the module.