### PR TITLE
(MODULES-2442) Mixing Quotes Causes Crash

### DIFF
--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -78,7 +78,7 @@ EOT
   def format_dsc_value(dsc_value)
     case
     when dsc_value.class.name == 'String'
-      "'#{dsc_value}'"
+      "'#{escape_quotes(dsc_value)}'"
     when dsc_value.class.ancestors.include?(Numeric)
       "#{dsc_value}"
     when [:true, :false].include?(dsc_value)
@@ -90,6 +90,10 @@ EOT
     else
       fail "unsupported type #{dsc_value.class} of value '#{dsc_value}'"
     end
+  end
+
+  def escape_quotes(text)
+    text.gsub("'", "''")
   end
 
   def ps_script_content(mode)

--- a/spec/unit/puppet/provider/powershell_spec.rb
+++ b/spec/unit/puppet/provider/powershell_spec.rb
@@ -10,3 +10,29 @@ describe Puppet::Type.type(:base_dsc).provider(:powershell) do
   end
 
 end
+
+describe Puppet::Type.type(:dsc_file).provider(:powershell) do
+
+  it "should be an instance of Puppet::Type::Base_dsc::ProviderPowershell" do
+    subject.must be_an_instance_of Puppet::Type::Dsc_file::ProviderPowershell
+  end
+
+  describe "when quotes are present" do
+
+    it "should handle single quotes" do
+      expect(subject.format_dsc_value("The 'Cats' go 'meow'!")).to match(/'The ''Cats'' go ''meow''!'/)
+    end
+
+    it "should handle double single quotes" do
+      expect(subject.format_dsc_value("The ''Cats'' go 'meow'!")).to match(/'The ''''Cats'''' go ''meow''!'/)
+    end
+
+    it "should handle double quotes" do
+      expect(subject.format_dsc_value("The 'Cats' go \"meow\"!")).to match(/'The ''Cats'' go "meow"!'/)
+    end
+
+    it "should handle dollar signs" do
+      expect(subject.format_dsc_value("This should show \$foo variable")).to match(/'This should show \$foo variable'/)
+    end
+  end
+end


### PR DESCRIPTION
If a user specifies single quotes inside any string in a puppet manifest our module
will produce an invalid quoted string. We can fix this by properly escaping the single quote
inside the string provided.