### PR TITLE
(MODULES-2400) Create Kitchen Sink User Scenario

### DIFF
--- a/tests/integration/tests/user_scenarios/kitchen_sink.rb
+++ b/tests/integration/tests/user_scenarios/kitchen_sink.rb
@@ -1,0 +1,181 @@
+require 'erb'
+require 'master_manipulator'
+require 'dsc_utils'
+test_name 'MODULES-2400 - C89536 - Apply DSC Basic Resource Kitchen Sink Manifest'
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+dsc_module = 'PSDesiredStateConfiguration'
+
+# ERB Manifest
+temp_dl_path = 'C:\Windows\Temp\kitchen_sink'
+
+seven_zip_url = 'http://int-resources.ops.puppetlabs.net/QA_resources/7zip/7z920.exe'
+seven_zip_dl_path = "#{temp_dl_path}\\7zip.exe"
+seven_zip_product_name = '7-Zip 9.20'
+seven_zip_install_path = 'C:\7zip'
+
+seven_zip_test_archive_path = 'C:\Windows\Temp\test_archive.7z'
+seven_zip_exe_path = "#{seven_zip_install_path}\\7z.exe"
+seven_zip_command_args = "a -t7z #{seven_zip_test_archive_path} #{temp_dl_path}\\*"
+
+env_var_name  = 'Test'
+env_var_value = 'TestValue'
+
+nssm_url = 'http://int-resources.ops.puppetlabs.net/QA_resources/nssm/nssm-2.24.zip'
+nssm_dl_path = "#{temp_dl_path}\\nssm.zip"
+
+ftp_feature_name = 'Web-Ftp-Server'
+ftp_service_name = 'FTPSVC'
+ftp_service_startup_type = 'Disabled'
+ftp_service_state = 'Stopped'
+
+user_name = 'TestUser'
+group_name = 'TestGroup'
+
+registry_key = 'HKEY_LOCAL_MACHINE\SOFTWARE\TestKey'
+registry_value = 'TestValueName'
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'user_scenarios', 'kitchen_sink.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Uninstall 7-zip'
+    on(agents, "cmd /c \"#{seven_zip_install_path}\\Uninstall.exe /S\"")
+
+    step 'Unset Environment Variable'
+    set_dsc_resource(
+      agents,
+      'Environment',
+      dsc_module,
+      :Ensure => 'Absent',
+      :Name   => env_var_name
+    )
+
+    step 'Remove Registry Value'
+    set_dsc_resource(
+      agents,
+      'Registry',
+      dsc_module,
+      :Ensure    => 'Absent',
+      :Key       => registry_key,
+      :ValueName => registry_value
+    )
+
+    step 'Remove Group'
+    set_dsc_resource(
+      agents,
+      'Group',
+      dsc_module,
+      :Ensure    => 'Absent',
+      :GroupName => group_name
+    )
+
+    step 'Remove User'
+    set_dsc_resource(
+      agents,
+      'User',
+      dsc_module,
+      :Ensure   => 'Absent',
+      :UserName => user_name
+    )
+
+    step 'Remove Temporary Directory'
+    set_dsc_resource(
+      agents,
+      'File',
+      dsc_module,
+      :Ensure          => 'Absent',
+      :Type            => 'Directory',
+      :Force           => '$true',
+      :DestinationPath => temp_dl_path,
+    )
+
+    step 'Remove Test Archive'
+    set_dsc_resource(
+      agents,
+      'File',
+      dsc_module,
+      :Ensure          => 'Absent',
+      :Type            => 'File',
+      :DestinationPath => seven_zip_test_archive_path,
+    )
+  end
+end
+
+# Setup
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Run Puppet Agent'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Environment Variable'
+    assert_dsc_resource(
+      agent,
+      'Environment',
+      dsc_module,
+      :Ensure => 'Present',
+      :Name   => env_var_name,
+      :Value  => env_var_value
+    )
+
+    step 'Verify NSSM Extracted'
+    assert_dsc_resource(
+      agent,
+      'File',
+      dsc_module,
+      :Ensure          => 'Present',
+      :Type            => 'Directory',
+      :DestinationPath => "#{temp_dl_path}\\nssm-2.24",
+    )
+
+    step 'Verify FTP Service State'
+    assert_dsc_resource(
+      agent,
+      'Service',
+      dsc_module,
+      :Name        => ftp_service_name,
+      :StartupType => ftp_service_startup_type,
+      :State       => ftp_service_state
+    )
+
+    step 'Verify Group Membership'
+    assert_dsc_resource(
+      agent,
+      'Group',
+      dsc_module,
+      :Ensure    => 'Present',
+      :GroupName => group_name,
+      :Members   => "@(\"#{user_name}\")"
+    )
+
+    step 'Verify Registry Value'
+    assert_dsc_resource(
+      agent,
+      'Registry',
+      dsc_module,
+      :Ensure    => 'Present',
+      :Key       => registry_key,
+      :ValueName => registry_value
+    )
+
+    step 'Verify 7-zip Archive'
+    assert_dsc_resource(
+      agent,
+      'File',
+      dsc_module,
+      :Ensure          => 'Present',
+      :Type            => 'File',
+      :DestinationPath => seven_zip_test_archive_path
+    )
+  end
+end

--- a/tests/lib/dsc_utils.rb
+++ b/tests/lib/dsc_utils.rb
@@ -40,7 +40,7 @@ def _build_dsc_command(dsc_method, dsc_resource_type, dsc_module, dsc_properties
       dsc_prop_merge << "\\#{v};"
     elsif v =~ /^@/
       dsc_prop_merge << "#{v.gsub(/\"/, '\\\"')};"
-    elsif v =~ /^-?\d+/
+    elsif v =~ /^-?\d+$/
       dsc_prop_merge << "#{v};"
     else
       dsc_prop_merge << "\\\"#{v}\\\";"

--- a/tests/manifests/user_scenarios/kitchen_sink.pp.erb
+++ b/tests/manifests/user_scenarios/kitchen_sink.pp.erb
@@ -1,0 +1,101 @@
+$temp_dl_path        = '<%= temp_dl_path %>'
+
+$seven_zip_url          = '<%= seven_zip_url %>'
+$seven_zip_dl_path      = '<%= seven_zip_dl_path %>'
+$seven_zip_product_name = '<%= seven_zip_product_name %>'
+$seven_zip_install_path = '<%= seven_zip_install_path %>'
+
+$seven_zip_test_archive_path = '<%= seven_zip_test_archive_path %>'
+$seven_zip_exe_path          = '<%= seven_zip_exe_path %>'
+$seven_zip_command_args      = '<%= seven_zip_command_args %>'
+
+$env_var_name  = '<%= env_var_name %>'
+$env_var_value = '<%= env_var_value %>'
+
+$nssm_url     = '<%= nssm_url %>'
+$nssm_dl_path = '<%= nssm_dl_path %>'
+
+$ftp_feature_name         = '<%= ftp_feature_name %>'
+$ftp_service_name         = '<%= ftp_service_name %>'
+$ftp_service_startup_type = '<%= ftp_service_startup_type %>'
+$ftp_service_state        = '<%= ftp_service_state %>'
+
+$user_name  = '<%= user_name %>'
+$group_name = '<%= group_name %>'
+
+$registry_key   = '<%= registry_key %>'
+$registry_value = '<%= registry_value %>'
+
+dsc_file { 'temp_dl_path':
+  dsc_ensure          => 'Present',
+  dsc_type            => 'Directory',
+  dsc_destinationpath => $temp_dl_path
+}
+->
+dsc_script { 'download_7zip':
+  dsc_getscript  => 'return @{ 7zip = "Installed" }',
+  dsc_testscript => "Test-Path \"${seven_zip_dl_path}\"",
+  dsc_setscript  => "(New-Object Net.WebClient).DownloadFile(\"${seven_zip_url}\", \"${seven_zip_dl_path}\")"
+}
+->
+dsc_script { 'download_nssm':
+  dsc_getscript  => 'return @{ NSSM = "Installed" }',
+  dsc_testscript => "Test-Path \"${nssm_dl_path}\"",
+  dsc_setscript  => "(New-Object Net.WebClient).DownloadFile(\"${nssm_url}\", \"${nssm_dl_path}\")"
+}
+->
+dsc_package { 'install_7zip':
+  dsc_ensure    => 'Present',
+  dsc_path      => $seven_zip_dl_path,
+  dsc_name      => $seven_zip_product_name,
+  dsc_productid => '',
+  dsc_arguments => "/S /D=${seven_zip_install_path}"
+}
+dsc_environment { 'add_env_var':
+  dsc_ensure => 'Present',
+  dsc_name   => $env_var_name,
+  dsc_value  => $env_var_value
+}
+->
+dsc_archive { 'extract_nssm':
+  dsc_ensure      => 'Present',
+  dsc_path        => $nssm_dl_path,
+  dsc_destination => $temp_dl_path
+}
+->
+dsc_windowsfeature { 'ftp_server':
+  dsc_ensure  => 'Present',
+  dsc_name    => $ftp_feature_name,
+  dsc_logpath => "$temp_dl_path/ftp_install.log"
+}
+->
+dsc_service { 'disable_ftp_service':
+  dsc_name        => $ftp_service_name,
+  dsc_startuptype => $ftp_service_startup_type,
+  dsc_state       => $ftp_service_state
+}
+->
+dsc_user { 'create_test_user':
+  dsc_ensure   => 'Present',
+  dsc_disabled => 'false',
+  dsc_username => $user_name,
+}
+->
+dsc_group { 'create_test_group':
+  dsc_ensure    => 'Present',
+  dsc_groupname => $group_name,
+  dsc_members   => [$user_name]
+}
+->
+dsc_registry { 'create_registry_entry':
+  dsc_ensure    => 'Present',
+  dsc_key       => $registry_key,
+  dsc_valuename => $registry_value
+}
+->
+dsc_windowsprocess { 'create_7zip_archive':
+  dsc_ensure           => 'Present',
+  dsc_path             => $seven_zip_exe_path,
+  dsc_arguments        => $seven_zip_command_args,
+  dsc_workingdirectory => $seven_zip_install_path
+}


### PR DESCRIPTION
Add a test for running every available basic DSC resource type in a  single
manifest. Also, I made a small update to the "dsc_utils" helper to change
a regex to make it more strict. The change does not affect any test currently.
(I found it through visual inspection.)