### PR TITLE
(MODULES-2299) Ensure DSC runs under Puppet 4.2.0

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', '<%= @module_path.basename.to_s.split('-').last %>','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/feature/vendors_dsc.rb
+++ b/lib/puppet/feature/vendors_dsc.rb
@@ -1,74 +1,11 @@
-require 'puppet/util/feature'
-require 'puppet/file_system'
-require 'fileutils'
-require 'win32/registry' if Puppet::Util::Platform.windows?
+require 'pathname'
+require Pathname.new(__FILE__).dirname + '../../' + 'puppet_x/puppetlabs/dsc_symlink'
 
-Puppet.features.add(:vendors_dsc?) do
-  return false if !Puppet::Util::Platform.windows?
-
-  module DscSymlink
-    # Ensure the symlink folder exists and is pointing to the proper location.
-    # This also ensures the directory structure is in place prior to creating
-    # the symlink, otherwise the symlink creation fails.
-    def self.set_symlink_folder
-      puppet_modules_vendor_folder = "#{get_program_files_dir}\\WindowsPowerShell\\Modules\\PuppetVendoredModules"
-
-      return if Puppet::FileSystem.symlink?(puppet_modules_vendor_folder) &&
-                Puppet::FileSystem.readlink(puppet_modules_vendor_folder) == vendored_modules_path
-
-      if Puppet::FileSystem.symlink?(puppet_modules_vendor_folder)
-        unlink(puppet_modules_vendor_folder)
-      elsif Puppet::FileSystem.exist?(puppet_modules_vendor_folder)
-        append_location_with_current_date_time puppet_modules_vendor_folder
-      end
-
-      Puppet.debug "Creating symlink at '#{puppet_modules_vendor_folder}' \n pointed to '#{vendored_modules_path}'."
-      Puppet::FileSystem.dir_mkpath(puppet_modules_vendor_folder) if !Puppet::FileSystem.dir_exist?(puppet_modules_vendor_folder)
-      Puppet::FileSystem.symlink(vendored_modules_path, puppet_modules_vendor_folder,{ :force => true})
-    end
-
-    # Add the current date time as a string to the end of an existing location.
-    def self.append_location_with_current_date_time(existing_location)
-      FileUtils.mv existing_location, "#{existing_location}.#{Time.now.utc.strftime("%Y%m%d_%H%M%S_%L")}"
-    end
-
-    # If the target path doesn't exist, unlinking will fail.
-    # Read the link and determine if the location exists prior
-    # to attempting unlink. If the path doesn't exist, just move
-    # the link and issue a warning. This will be fixed by
-    # https://tickets.puppetlabs.com/browse/PUP-5018.
-    def self.unlink(path)
-      if Puppet::FileSystem.exist?(Puppet::FileSystem.readlink(path))
-        Puppet::FileSystem.unlink(path)
-      else
-        Puppet.warning "Unable to remove existing conflicting symlink. The target path no longer exists. Renaming the link instead."
-        append_location_with_current_date_time path
-      end
-    end
-
-    # Get the non-x86 program files path, no matter whether the process is
-    # a 32 bit or 64 bit process. Shut off registry redirection and query
-    # the ProgramFilesDir key to retrieve the program files value.
-    def self.get_program_files_dir
-      program_files_dir = nil
-      begin
-        hive = Win32::Registry::HKEY_LOCAL_MACHINE
-        hive.open('SOFTWARE\Microsoft\Windows\CurrentVersion', Win32::Registry::KEY_READ | 0x100) do |reg|
-          program_files_dir = reg['ProgramFilesDir']
-        end
-      rescue Win32::Registry::Error => e
-        Puppet.warning "Error occurred attempting to read program files directory from registry, using default. \n Message: #{e.message}"
-        program_files_dir = 'C:\Program Files'
-      end
-
-      program_files_dir
-    end
-
-    def self.vendored_modules_path
-      File.expand_path(File.join(__FILE__, '..', '..', '..', 'puppet_x', 'dsc_resources')).gsub(/\//,'\\')
-    end
+Puppet.features.add(:vendors_dsc) do
+  if Puppet::Util::Platform.windows?
+    DscSymlink.set_symlink_folder
+    true
+  else
+    false
   end
-
-  DscSymlink.set_symlink_folder
-  true
 end

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -4,7 +4,7 @@ require 'json'
 Puppet::Type.type(:base_dsc).provide(:powershell) do
   confine :operatingsystem => :windows
   defaultfor :operatingsystem => :windows
-  has_features :vendors_dsc?
+  has_features :vendors_dsc
 
   commands :powershell =>
     if File.exists?("#{ENV['SYSTEMROOT']}\\sysnative\\WindowsPowershell\\v1.0\\powershell.exe")

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -1,4 +1,5 @@
-require 'puppet/feature/vendors_dsc'
+require 'pathname'
+require Pathname.new(__FILE__).dirname + '../../../' + 'puppet/feature/vendors_dsc'
 require 'json'
 
 Puppet::Type.type(:base_dsc).provide(:powershell) do

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_archive) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_environment) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_file) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_group) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_log) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_package) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_registry) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_script) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_service) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_user) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_webdeploy.rb
+++ b/lib/puppet/type/dsc_webdeploy.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_webdeploy) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_windowsfeature) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_windowsprocess) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xaddomain) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xaddomaincontroller) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xaddomaintrust) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xaduser) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xarchive) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurequickvm) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazureservice) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazuresqldatabase) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurestorageaccount) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazuresubscription) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurevm) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xcluster) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xcomputer) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdatabase) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdbpackage) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdhcpserveroption) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdhcpserverscope) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdnsserveraddress) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdscwebservice) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xfirewall) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xgroup) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xiismodule) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xipaddress) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xjeaendpoint) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xjeatoolkit) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmysqldatabase) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmysqlgrant) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmysqlserver) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmysqluser) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xpackage) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xpsendpoint) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xrdremoteapp.rb
+++ b/lib/puppet/type/dsc_xrdremoteapp.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrdremoteapp) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrdsessioncollection) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xremotefile) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xservice) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsmbshare) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlhagroup) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlhaservice) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlserverinstall) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xvhd) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xvhdfile) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xvmhyperv) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xvmswitch) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwaitforaddomain) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwaitforcluster) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebapplication) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebapppool) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebsite) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwindowsprocess) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwineventlog) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -1,9 +1,7 @@
-# workaround for cross modules dependencies
-master_path = File.expand_path(File.join(__FILE__, '..', '..', '..', '..', '..', 'dsc','lib'))
-$:.push(master_path) if File.directory?(master_path)
-require 'puppet/type/base_dsc'
+require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwordpresssite) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows

--- a/lib/puppet_x/puppetlabs/dsc_symlink.rb
+++ b/lib/puppet_x/puppetlabs/dsc_symlink.rb
@@ -1,0 +1,73 @@
+require 'puppet/util/feature'
+require 'puppet/file_system'
+require 'fileutils'
+
+module DscSymlink; end
+
+if Puppet::Util::Platform.windows?
+
+  require 'win32/registry'
+
+  module DscSymlink
+    # Ensure the symlink folder exists and is pointing to the proper location.
+    # This also ensures the directory structure is in place prior to creating
+    # the symlink, otherwise the symlink creation fails.
+    def self.set_symlink_folder
+      puppet_modules_vendor_folder = "#{get_program_files_dir}\\WindowsPowerShell\\Modules\\PuppetVendoredModules"
+
+      return if Puppet::FileSystem.symlink?(puppet_modules_vendor_folder) &&
+                Puppet::FileSystem.readlink(puppet_modules_vendor_folder) == vendored_modules_path
+
+      if Puppet::FileSystem.symlink?(puppet_modules_vendor_folder)
+        unlink(puppet_modules_vendor_folder)
+      elsif Puppet::FileSystem.exist?(puppet_modules_vendor_folder)
+        append_location_with_current_date_time puppet_modules_vendor_folder
+      end
+
+      Puppet.debug "Creating symlink at '#{puppet_modules_vendor_folder}' \n pointed to '#{vendored_modules_path}'."
+      Puppet::FileSystem.dir_mkpath(puppet_modules_vendor_folder) if !Puppet::FileSystem.dir_exist?(puppet_modules_vendor_folder)
+      Puppet::FileSystem.symlink(vendored_modules_path, puppet_modules_vendor_folder,{ :force => true})
+    end
+
+    # Add the current date time as a string to the end of an existing location.
+    def self.append_location_with_current_date_time(existing_location)
+      FileUtils.mv existing_location, "#{existing_location}.#{Time.now.utc.strftime("%Y%m%d_%H%M%S_%L")}"
+    end
+
+    # If the target path doesn't exist, unlinking will fail.
+    # Read the link and determine if the location exists prior
+    # to attempting unlink. If the path doesn't exist, just move
+    # the link and issue a warning. This will be fixed by
+    # https://tickets.puppetlabs.com/browse/PUP-5018.
+    def self.unlink(path)
+      if Puppet::FileSystem.exist?(Puppet::FileSystem.readlink(path))
+        Puppet::FileSystem.unlink(path)
+      else
+        Puppet.warning "Unable to remove existing conflicting symlink. The target path no longer exists. Renaming the link instead."
+        append_location_with_current_date_time path
+      end
+    end
+
+    # Get the non-x86 program files path, no matter whether the process is
+    # a 32 bit or 64 bit process. Shut off registry redirection and query
+    # the ProgramFilesDir key to retrieve the program files value.
+    def self.get_program_files_dir
+      program_files_dir = nil
+      begin
+        hive = Win32::Registry::HKEY_LOCAL_MACHINE
+        hive.open('SOFTWARE\Microsoft\Windows\CurrentVersion', Win32::Registry::KEY_READ | 0x100) do |reg|
+          program_files_dir = reg['ProgramFilesDir']
+        end
+      rescue Win32::Registry::Error => e
+        Puppet.warning "Error occurred attempting to read program files directory from registry, using default. \n Message: #{e.message}"
+        program_files_dir = 'C:\Program Files'
+      end
+
+      program_files_dir
+    end
+
+    def self.vendored_modules_path
+      File.expand_path(File.join(__FILE__, '..', '..', '..', 'puppet_x', 'dsc_resources')).gsub(/\//,'\\')
+    end
+  end
+end

--- a/spec/integration/puppet_x/puppetlabs/dsc_symlink_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/dsc_symlink_spec.rb
@@ -5,8 +5,6 @@ require 'fileutils'
 require 'puppet/file_system'
 require 'puppet/feature/vendors_dsc'
 
-module DscSymlink; end # for tests on non-Windows
-
 describe DscSymlink, :if => Puppet::Util::Platform.windows? do
 
   let (:top_level_path) do

--- a/spec/unit/puppet_x/puppetlabs/dsc_symlink_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/dsc_symlink_spec.rb
@@ -5,8 +5,6 @@ require 'fileutils'
 require 'puppet/file_system'
 require 'puppet/feature/vendors_dsc'
 
-module DscSymlink; end # for tests on non-Windows
-
 describe DscSymlink, :if => Puppet::Util::Platform.windows? do
 
   context ".set_symlink_folder" do


### PR DESCRIPTION
The current method of pushing a directory to the loadpath that is used
in the types is considered non-standard and may cause unintended
consequences. Instead of adjusting the load path, require using a
relative location from the current source file directory.

`vendors_dsc?` should not include the question mark in the name. That
can confuse Puppet when it creates the predicate
`Puppet.features.featurename?` where in this case it may end up
creating `Puppet.features.vendors_dsc??`. Rename the feature to
`vendors_dsc` instead.

Additionally, having the symlink module code inside the feature is
confusing Linux Masters, with the failure happening on the early return
false at
https://github.com/puppetlabs/puppetlabs-dsc/blob/662a2961cd4f20e2e11fb82ae4778ca53071e9e5/lib/puppet/feature/vendors_dsc.rb#L7
Instead, move the symlink code out to it's own module and require that
in the feature add.

Paired with James Pogran
Paired with Josh Cooper