### PR TITLE
(MODULES-2480) Create Negative Test for LCM Configuration

### DIFF
--- a/tests/acceptance/pre-suite/03_configure_lcm.rb
+++ b/tests/acceptance/pre-suite/03_configure_lcm.rb
@@ -1,16 +1,7 @@
+require 'dsc_utils'
 test_name 'FM-2626 - C70297 - Configure LCM for "Disabled" Refresh Mode'
 
 confine(:to, :platform => 'windows')
 
-# Init
-dsc_conf_manifest = <<-MANIFEST
-dsc::lcm_config {'disable_lcm':
-  refresh_mode => 'Disabled'
-}
-MANIFEST
-
-# Configure
 step 'Disable LCM on Windows Agents'
-on(agent, puppet('apply'), :stdin => dsc_conf_manifest, :acceptable_exit_codes => [0,2]) do |result|
-  assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-end
+configure_lcm(agents, refresh_mode = 'Disabled')

--- a/tests/acceptance/tests/basic_functionality/negative/misconfigure_lcm.rb
+++ b/tests/acceptance/tests/basic_functionality/negative/misconfigure_lcm.rb
@@ -9,7 +9,6 @@ local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
 dsc_type = 'file'
-dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_destinationpath => 'C:\test.file',

--- a/tests/acceptance/tests/basic_functionality/negative/misconfigure_lcm.rb
+++ b/tests/acceptance/tests/basic_functionality/negative/misconfigure_lcm.rb
@@ -1,0 +1,41 @@
+require 'erb'
+require 'dsc_utils'
+test_name 'MODULES-2480 - C89505 - Misconfigure LCM and Attempt to Apply DSC Manifest'
+
+confine(:to, :platform => 'windows')
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+dsc_props = {
+  :dsc_ensure          => 'Present',
+  :dsc_destinationpath => 'C:\test.file',
+  :dsc_contents        => 'Cats go meow!',
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  step 'Disable LCM on Windows Agents'
+  configure_lcm(agents, refresh_mode = 'Disabled')
+end
+
+# Verify
+error_msg = /Error:.*DSC LCM RefreshMode must be set to Disabled/
+
+# Setup
+step 'Enable LCM on Windows Agents'
+configure_lcm(agents, refresh_mode = 'Push')
+
+# Tests
+agents.each do |agent|
+  step 'Attempt to Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
+    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+  end
+end

--- a/tests/lib/dsc_utils.rb
+++ b/tests/lib/dsc_utils.rb
@@ -1,3 +1,35 @@
+# Configure the DSC LCM on a host.
+#
+# ==== Attributes
+#
+# * +hosts+ - A Windows Beaker host(s) running PowerShell DSC.
+# * +refresh_mode+ - The desired LCM refresh mode. (Disabled, Push, Pull)
+#
+# ==== Returns
+#
+# +nil+
+#
+# ==== Raises
+#
+# +nil+
+#
+# ==== Examples
+#
+# configure_lcm(agents, 'Disabled')
+def configure_lcm(hosts, refresh_mode = 'Disabled')
+  # Init
+  dsc_conf_manifest = <<-MANIFEST
+  dsc::lcm_config {'configure_lcm':
+    refresh_mode => '#{refresh_mode}'
+  }
+  MANIFEST
+
+  # Configure
+  on(hosts, puppet('apply'), :stdin => dsc_conf_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Failed to configure the DSC LCM!')
+  end
+end
+
 # Build a PowerShell DSC command string.
 #
 # ==== Attributes


### PR DESCRIPTION
Add an acceptance test for misconfiguring the LCM before running DSC manifests.
I added a new method to the "dsc_utils" helper library to allow for easy
transition between refresh modes.