### PR TITLE
(DO NOT MERGE)(MODULES-2479) Allow Different Ensure Values

### DIFF
--- a/build/dsc/resource.rb
+++ b/build/dsc/resource.rb
@@ -82,7 +82,26 @@ module Dsc
 
     def absentable?
       properties.detect do |p|
-        p.is_ensure? && p.values.any? { |v| v.casecmp('absent') == 0 }
+        return 'absent' if p.is_ensure? && p.values.any? { |v| v.casecmp('absent') }
+        return 'disable' if p.is_ensure? && p.values.any? { |v| v.casecmp('disable') }
+      end
+    end
+
+     def absent_value
+      properties.detect do |p|
+        p.is_ensure? && p.values.each do |v|
+          return 'absent' if v.casecmp('absent') == 0
+          return 'disable' if v.casecmp('disable') == 0
+        end
+      end
+    end
+
+    def ensure_value
+      properties.detect do |p|
+        p.is_ensure? && p.values.each do |v|
+          return 'present' if v.casecmp('present') == 0
+          return 'enable' if v.casecmp('enable') == 0
+        end
       end
     end
 

--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -5,6 +5,19 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
+
+<% if resource.ensurable? -%>
+    def ensure_value
+        '<%= resource.ensure_value %>'
+    end
+<% end -%>
+
+<% if resource.absentable? -%>
+    def absent_value
+        '<%= resource.absent_value %>'
+    end
+<% end -%>
+
   end
 
   @doc = %q{
@@ -71,7 +84,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
 <%    end -%>
     validate do |value|
 <%    if property.name.downcase == 'ensure' -%>
-      resource[:ensure] = value.downcase
+      resource[:ensure] = provider.munge_ensure(value)
 <%    end -%>
 <%    case -%>
 <%    when property.array? -%>

--- a/build/dsc/templates/dsc_type_spec.rb.erb
+++ b/build/dsc/templates/dsc_type_spec.rb.erb
@@ -78,7 +78,7 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
 
   it 'should accept dsc_ensure predefined value <%= value.downcase %> and update ensure with this value (ensure end value should be a symbol)' do
     dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure] = '<%= value.downcase %>'
-    expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq(dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure].downcase.to_sym)
+    expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq(dsc_<%= resource.friendlyname.downcase %>.provider.munge_ensure(dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure].downcase).to_sym)
   end
 <%        end # if property.name.downcase.... -%>
 <%      end # property.values.each....-%>
@@ -203,11 +203,11 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
 <%  end # unless ['msft_filedirectoryconfiguration'].... -%>
 <%  if resource.ensurable? -%>
 
-    describe "when dsc_ensure is 'present'" do
+    describe "when dsc_ensure is '<%= resource.ensure_value %>'" do
 
       before(:each) do
-        dsc_<%= resource.friendlyname.downcase %>.original_parameters[:dsc_ensure] = 'present'
-        dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure] = 'present'
+        dsc_<%= resource.friendlyname.downcase %>.original_parameters[:dsc_ensure] = '<%= resource.ensure_value %>'
+        dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure] = '<%= resource.ensure_value %>'
         @provider = described_class.provider(:powershell).new(dsc_<%= resource.friendlyname.downcase %>)
       end
 
@@ -215,23 +215,22 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
         expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq(:present)
       end
 
-      it "should compute powershell dsc test script in which ensure value is 'present'" do
-        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      it "should compute powershell dsc test script in which ensure value is '<%= resource.ensure_value %>'" do
+        expect(@provider.ps_script_content('test')).to match(/ensure = '<%= resource.ensure_value %>'/)
       end
 
-      it "should compute powershell dsc set script in which ensure value is 'present'" do
-        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      it "should compute powershell dsc set script in which ensure value is '<%= resource.ensure_value %>'" do
+        expect(@provider.ps_script_content('set')).to match(/ensure = '<%= resource.ensure_value %>'/)
       end
 
     end
 
 <%  end # if resource.ensurable? -%>
 <%  if resource.absentable? -%>
-    describe "when dsc_ensure is 'absent'" do
-
+    describe "when dsc_ensure is '<%= resource.absent_value %>'" do
       before(:each) do
-        dsc_<%= resource.friendlyname.downcase %>.original_parameters[:dsc_ensure] = 'absent'
-        dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure] = 'absent'
+        dsc_<%= resource.friendlyname.downcase %>.original_parameters[:dsc_ensure] = '<%= resource.absent_value %>'
+        dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure] = '<%= resource.absent_value %>'
         @provider = described_class.provider(:powershell).new(dsc_<%= resource.friendlyname.downcase %>)
       end
 
@@ -239,12 +238,12 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
         expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq(:absent)
       end
 
-      it "should compute powershell dsc test script in which ensure value is 'present'" do
-        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      it "should compute powershell dsc test script in which ensure value is '<%= resource.ensure_value %>'" do
+        expect(@provider.ps_script_content('test')).to match(/ensure = '<%= resource.ensure_value %>'/)
       end
 
-      it "should compute powershell dsc set script in which ensure value is 'absent'" do
-        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      it "should compute powershell dsc set script in which ensure value is '<%= resource.absent_value %>'" do
+        expect(@provider.ps_script_content('set')).to match(/ensure = '<%= resource.absent_value %>'/)
       end
 
     end

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -76,6 +76,13 @@ EOT
     raise ArgumentError.new "invalid value: #{value}"
   end
 
+  def munge_ensure(value)
+    return 'absent' if value.downcase =~ (/^(absent|disable)$/i)
+    return 'present' if value.downcase =~ (/^(present|enable)$/i)
+
+    raise ArgumentError.new "invalid value: #{value}"
+  end
+
   def format_dsc_value(dsc_value)
     case
     when dsc_value.class.name == 'String'

--- a/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
@@ -21,7 +21,7 @@ $invokeParams = @{
 <% dsc_parameters.each do |p| -%>
     <%- name = p.name.to_s.gsub(/^dsc_/,'')
     value = format_dsc_value(p.value)
-    value = '\'present\'' if name == 'ensure' && dsc_invoke_method == 'test'
+    value = "'#{resource.provider.ensure_value}'" if name == 'ensure' && dsc_invoke_method == 'test'
     -%>
     <%= name %> = <%= value %>
 <% end -%>


### PR DESCRIPTION
Some xDscResources use different values of Ensure than the standard
present/absent. Add new logic to detect when different values are used
and use them for generating the type, the spec, and the powershell
script.