### PR TITLE
(MODULES-2506) Fix Failing Tests

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/waitforall/negative/waitforall_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforall/negative/waitforall_blacklist.rb
@@ -23,7 +23,9 @@ error_msg = /Error:.*Invalid resource type dsc_waitforall/
 # Tests
 agents.each do |agent|
   step 'Attempt to Apply Manifest'
-  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 1) do |result|
-    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
+    expect_failure('Expected to fail because of MODULES-2504') do
+      assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+    end
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/waitforany/negative/waitforany_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforany/negative/waitforany_blacklist.rb
@@ -23,7 +23,9 @@ error_msg = /Error:.*Invalid resource type dsc_waitforany/
 # Tests
 agents.each do |agent|
   step 'Attempt to Apply Manifest'
-  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 1) do |result|
-    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
+    expect_failure('Expected to fail because of MODULES-2504') do
+      assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+    end
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/waitforsome/negative/waitforsome_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforsome/negative/waitforsome_blacklist.rb
@@ -23,7 +23,9 @@ error_msg = /Error:.*Invalid resource type dsc_waitforsome/
 # Tests
 agents.each do |agent|
   step 'Attempt to Apply Manifest'
-  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 1) do |result|
-    assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
+    expect_failure('Expected to fail because of MODULES-2504') do
+      assert_match(error_msg, result.stderr, 'Expected error was not detected!')
+    end
   end
 end


### PR DESCRIPTION
The "WaitFor*" tests are failing because they are no longer black listed.
The tests have been updated to expect the failure.