### PR TITLE
(MODULES-2514) Update module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,11 +39,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 2.3.0 < 5.0.0"
     },
     {
       "name": "puppetlabs-powershell",
-      "version_requirement": ">= 1.0.1"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
The module dependencies do not have an upper bound to the next
major version, which leaves a possibility for compatibility
issues across a major version boundary, where incompatible
changes are known to occur due to semantic versioning. It is
better to be conservative and set an upper bound, then release
a newer version once a major version has been released and found
compatible than to suddenly need to fix a broken dependency.

The lower bound of stdlib was not correct, as the version we
should have started with is 2.3.0. This is the first version that
allowed messages to be passed with validate_re. See
https://github.com/puppetlabs/puppetlabs-stdlib/commit/41b07232e464f25403a8f9c786ec0061bf6dc40e
for details.