### PR TITLE
(MODULES-2520) set readme parameters and clean up generated type docs

### DIFF
--- a/build/dsc.rake
+++ b/build/dsc.rake
@@ -26,6 +26,7 @@ namespace :dsc do
     Rake::Task['dsc:resources:import'].invoke unless File.exists?(default_dsc_resources_path)
     Rake::Task['dsc:types:clean'].invoke(dsc_module_path)
     Rake::Task['dsc:types:build'].invoke(dsc_module_path)
+    Rake::Task['dsc:types:document'].invoke(dsc_module_path)
   end
 
   desc "Cleanup all"
@@ -115,6 +116,15 @@ eod
       m.target_module_path = module_path
       msgs = m.build_dsc_types
       msgs.each{|m| puts "#{m}"}
+      dsc_types = m.get_dsc_types
+    end
+
+    desc "Document #{item_name}"
+    task :document, [:module_path] do |t, args|
+      module_path = args[:module_path] || default_dsc_module_path
+      m = Dsc::Manager.new
+      m.target_module_path = module_path
+      m.document_types("#{default_dsc_module_path}/Types.md",m.get_dsc_types)
     end
 
     desc "Cleanup #{item_name}"

--- a/build/dsc/manager.rb
+++ b/build/dsc/manager.rb
@@ -148,6 +148,25 @@ module Dsc
       type_pathes
     end
 
+    def get_dsc_types
+      dsc_types = []
+      resources.each do |resource|
+        dsc_types << "dsc_#{resource.friendlyname.downcase}"
+      end
+      dsc_types
+    end
+
+    def document_types(markdown_file_path,dsc_types)
+      puts "Creating #{markdown_file_path}"
+      File.open("#{markdown_file_path}", 'w+') do |file|
+        file.write("## Resource Types included with dsc module\n")
+        file.write("For any system you have this installed on you can use\n`Puppet describe typename` for more information.\n\n")
+        dsc_types.each do |dsc_type|
+          file.write("* #{dsc_type}\n")
+        end
+      end
+    end
+
     def clean_dsc_types
       puppet_type_path = "#{@target_module_path}/#{@puppet_type_subpath}"
       clean_folder(["#{puppet_type_path}/dsc_*.rb"])

--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -74,15 +74,28 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
   <%  end -%>
   end
 
-  newparam(:dscmeta_resource_friendly_name) do
+  newproperty(:dscmeta_resource_friendly_name) do
     desc "A read-only value that is the DSC Resource Friendly Name ('<%= resource.friendlyname %>')."
-    defaultto "<%= resource.friendlyname %>"
 
+    def retrieve
+      '<%= resource.friendlyname %>'
+    end
+
+    validate do |value|
+      fail 'dscmeta_resource_friendly_name is read-only'
+    end
   end
 
-  newparam(:dscmeta_resource_name) do
+  newproperty(:dscmeta_resource_name) do
     desc "A read-only value that is the DSC Resource Name ('<%= resource.name %>')."
-    defaultto "<%= resource.name %>"
+
+    def retrieve
+      '<%= resource.name %>'
+    end
+
+    validate do |value|
+      fail 'dscmeta_resource_name is read-only'
+    end
   end
 
   newparam(:dscmeta_import_resource) do
@@ -97,17 +110,31 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     defaultto true
   end
 
-  newparam(:dscmeta_module_name) do
+  newproperty(:dscmeta_module_name) do
     desc "A read-only value that is the DSC Module Name ('<%= resource.ps_module.name %>')."
-    defaultto "<%= resource.ps_module.name %>"
+
+    def retrieve
+      '<%= resource.ps_module.name %>'
+    end
+
+    validate do |value|
+      fail 'dscmeta_module_name is read-only'
+    end
   end
 <%  if resource.ps_module.name != 'PSDesiredStateConfiguration' %>
-  newparam(:dscmeta_module_version) do
+  newproperty(:dscmeta_module_version) do
     desc "A read-only value for the DSC Module Version ('<%= resource.ps_module.version %>').
       This is the supported version of the PowerShell module that this
       type was built on. When Puppet runs this resource, it will explicitly
       use this version."
-    defaultto "<%= resource.ps_module.version %>"
+
+    def retrieve
+      '<%= resource.ps_module.version %>'
+    end
+
+    validate do |value|
+      fail 'dscmeta_module_version is read-only'
+    end
   end
 <%  end %>
   newparam(:name, :namevar => true ) do

--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -55,8 +55,17 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
 
   @doc = %q{
     The DSC <%= resource.friendlyname%> resource type.
-    Originally generated from the following schema.mof file:
-      <%= resource.relative_mof_path %>
+    Automatically generated from
+    '<%= resource.relative_mof_path.gsub('import/dsc_resources/','') %>'
+
+    To learn more about PowerShell Desired State Configuration, please
+    visit https://technet.microsoft.com/en-us/library/dn249912.aspx.
+
+    For more information about built-in DSC Resources, please visit
+    https://technet.microsoft.com/en-us/library/dn249921.aspx.
+
+    For more information about xDsc Resources, please visit
+    https://github.com/PowerShell/DscResources.
   }
 
   validate do
@@ -66,14 +75,19 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
   end
 
   newparam(:dscmeta_resource_friendly_name) do
+    desc "A read-only value that is the DSC Resource Friendly Name ('<%= resource.friendlyname %>')."
     defaultto "<%= resource.friendlyname %>"
+
   end
 
   newparam(:dscmeta_resource_name) do
+    desc "A read-only value that is the DSC Resource Name ('<%= resource.name %>')."
     defaultto "<%= resource.name %>"
   end
 
   newparam(:dscmeta_import_resource) do
+    desc "Please ignore this parameter.
+      Defaults to `true`."
     newvalues(true, false)
 
     munge do |value|
@@ -84,10 +98,15 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
   end
 
   newparam(:dscmeta_module_name) do
+    desc "A read-only value that is the DSC Module Name ('<%= resource.ps_module.name %>')."
     defaultto "<%= resource.ps_module.name %>"
   end
 <%  if resource.ps_module.name != 'PSDesiredStateConfiguration' %>
   newparam(:dscmeta_module_version) do
+    desc "A read-only value for the DSC Module Version ('<%= resource.ps_module.version %>').
+      This is the supported version of the PowerShell module that this
+      type was built on. When Puppet runs this resource, it will explicitly
+      use this version."
     defaultto "<%= resource.ps_module.version %>"
   end
 <%  end %>
@@ -130,9 +149,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
       <%= type_map.to_s %>
     end
 <%    end -%>
-<%    if property.description -%>
-    desc "<%= property.description %>"
-<%    end -%>
+    desc "<%= property.name %><% if property.description -%> - <%= property.description %><% end %><% if property.values -%><% unless property.description -%> -<% end %> Valid values are <%= property.values.join(', ') %>.<% end -%>"
 <%    if property.required? -%>
     isrequired
 <%    end -%>

--- a/lib/puppet/type/base_dsc.rb
+++ b/lib/puppet/type/base_dsc.rb
@@ -1,7 +1,13 @@
 # This is the base type for dsc.
 # Used to inherit the providers for the generated DSC resources
 Puppet::Type.newtype(:base_dsc) do
+  @doc = %q{
+    The base Puppet DSC type that all of the types inherit from.
+    Do not use this directly.
+
+  }
 
   newparam(:name, :namevar => true ) do
+    desc 'A name to describe your resource, used for uniqueness.'
   end
 end


### PR DESCRIPTION
Clean up the documentation that can be queried with
puppet describe.

This should clean up https://forge.puppetlabs.com/puppetlabs/dsc/types into something more usable.