### PR TITLE
(MODULES-2575) Remove LCM Refresh Mode checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,6 @@ puppet module install puppetlabs-dsc
 
 ## Usage
 
-### LCM RefreshMode Must be Disabled
-
-You must set the Local Configuration Mananger `RefreshMode` to `Disabled` before you can use this module to apply any resources.
-
-~~~puppet
-dsc::lcm_config {'disable_lcm':
-  refresh_mode => 'Disabled',
-}
-~~~
-
 ### Using DSC Resources with Puppet
 
 You can use a DSC Resource by prefixing each DSC Resource name and parameter with 'dsc_'.
@@ -133,6 +123,18 @@ class fourthcoffee(
 
 As you can see, you can mix and match dsc resources with common puppet resources.
 All [puppet metaparameters](https://docs.puppetlabs.com/references/latest/metaparameter.html) should also be supported.
+
+### Optionally configuring the Systems LCM Refresh Mode
+
+Prior to the WMF5 production preview, the global LCM refresh mode had to be set
+to 'Disabled' for the module to work.  That limitation has been removed, but the
+module still supports configuring this setting if you wish to change it.
+
+~~~puppet
+dsc::lcm_config {'disable_lcm':
+  refresh_mode => 'Disabled',
+}
+~~~
 
 ## Limitations
 

--- a/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
@@ -7,13 +7,6 @@ $response = @{
   errormessage   = ''
 }
 
-$currentState = Get-DscLocalConfigurationManager
-
-if ($currentState.RefreshMode -ne 'Disabled') {
-  $response.errormessage = "DSC LCM RefreshMode must be set to Disabled for Puppet to execute DSC Resources! Please run dsc::lcm_config first"
-  return ($response | ConvertTo-Json -Compress)
-}
-
 $invokeParams = @{
   Name          = '<%= resource[:dscmeta_resource_friendly_name] %>'
   Method        = '<%= dsc_invoke_method %>'


### PR DESCRIPTION
 - As of the 8/31/2015 production preview release of WMF5, the global
   LCM RefreshMode no longer needs to be set to 'Disabled' to apply DSC
   resources.

   Update the Invoke-DscResource PowerShell template to remove the check
   and update documentation / tests accordingly