### PR TITLE
(maint) PowerShell provider helpers -> puppet_x

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -31,7 +32,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -122,7 +123,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     end
 <%    when property.bool? -%>
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 <%    when (property.int? || property.uint?) -%>
     munge do |value|

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -69,13 +69,6 @@ EOT
     true
   end
 
-  def munge_boolean(value)
-    return true if value =~ (/^(true|t|yes|y|1)$/i)
-    return false if value.empty? || value =~ (/^(false|f|no|n|0)$/i)
-
-    raise ArgumentError.new "invalid value: #{value}"
-  end
-
   def format_dsc_value(dsc_value)
     case
     when dsc_value.class.name == 'String'

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_archive) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_archive) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -101,7 +102,7 @@ Puppet::Type.newtype(:dsc_archive) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -129,7 +130,7 @@ Puppet::Type.newtype(:dsc_archive) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_environment) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_environment) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -99,7 +100,7 @@ Puppet::Type.newtype(:dsc_environment) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_file) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_file) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -141,7 +142,7 @@ Puppet::Type.newtype(:dsc_file) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -154,7 +155,7 @@ Puppet::Type.newtype(:dsc_file) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -219,7 +220,7 @@ Puppet::Type.newtype(:dsc_file) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_group) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_group) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_log) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -28,7 +29,7 @@ Puppet::Type.newtype(:dsc_log) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_package) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_package) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -227,7 +228,7 @@ Puppet::Type.newtype(:dsc_package) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_registry) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_registry) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -131,7 +132,7 @@ Puppet::Type.newtype(:dsc_registry) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -144,7 +145,7 @@ Puppet::Type.newtype(:dsc_registry) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_script) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -31,7 +32,7 @@ Puppet::Type.newtype(:dsc_script) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_service) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_service) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_user) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_user) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -123,7 +124,7 @@ Puppet::Type.newtype(:dsc_user) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -136,7 +137,7 @@ Puppet::Type.newtype(:dsc_user) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -149,7 +150,7 @@ Puppet::Type.newtype(:dsc_user) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -162,7 +163,7 @@ Puppet::Type.newtype(:dsc_user) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_waitforall.rb
+++ b/lib/puppet/type/dsc_waitforall.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_waitforall) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_waitforall) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_waitforany.rb
+++ b/lib/puppet/type/dsc_waitforany.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_waitforany) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_waitforany) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_waitforsome.rb
+++ b/lib/puppet/type/dsc_waitforsome.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_waitforsome) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_waitforsome) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_windowsfeature) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -112,7 +113,7 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_windowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_windowsoptionalfeature.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -102,7 +103,7 @@ Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -115,7 +116,7 @@ Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_windowsprocess) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xadcscertificationauthority.rb
+++ b/lib/puppet/type/dsc_xadcscertificationauthority.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -214,7 +215,7 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -283,7 +284,7 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -297,7 +298,7 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -311,7 +312,7 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xadcswebenrollment.rb
+++ b/lib/puppet/type/dsc_xadcswebenrollment.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xadcswebenrollment) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xadcswebenrollment) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xaddomain) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xaddomain) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xaddomaincontroller) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xaddomaintrust) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xadrecyclebin.rb
+++ b/lib/puppet/type/dsc_xadrecyclebin.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xadrecyclebin) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xadrecyclebin) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xaduser) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xaduser) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xarchive) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xarchive) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -123,7 +124,7 @@ Puppet::Type.newtype(:dsc_xarchive) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurepackadmin.rb
+++ b/lib/puppet/type/dsc_xazurepackadmin.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurepackadmin) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurepackadmin) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
+++ b/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurepackfqdn.rb
+++ b/lib/puppet/type/dsc_xazurepackfqdn.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurepackfqdn) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurepackidentityprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackidentityprovider.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurepackrelyingparty.rb
+++ b/lib/puppet/type/dsc_xazurepackrelyingparty.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurepackresourceprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackresourceprovider.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -128,7 +129,7 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -142,7 +143,7 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -156,7 +157,7 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -170,7 +171,7 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepacksetup.rb
+++ b/lib/puppet/type/dsc_xazurepacksetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurepacksetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurepackupdate.rb
+++ b/lib/puppet/type/dsc_xazurepackupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurepackupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurepackupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurequickvm) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -120,7 +121,7 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -147,7 +148,7 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazureservice) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazureservice) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazuresqldatabase) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurestorageaccount) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurestorageaccount) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazuresubscription) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazuresubscription) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurevm) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurevm) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -146,7 +147,7 @@ Puppet::Type.newtype(:dsc_xazurevm) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -160,7 +161,7 @@ Puppet::Type.newtype(:dsc_xazurevm) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xazurevmdscextension.rb
+++ b/lib/puppet/type/dsc_xazurevmdscextension.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xazurevmdscextension) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xazurevmdscextension) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -167,7 +168,7 @@ Puppet::Type.newtype(:dsc_xazurevmdscextension) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xblautobitlocker.rb
+++ b/lib/puppet/type/dsc_xblautobitlocker.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xblautobitlocker) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -107,7 +108,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -132,7 +133,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -160,7 +161,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -185,7 +186,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -222,7 +223,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -235,7 +236,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -248,7 +249,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -261,7 +262,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -286,7 +287,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -299,7 +300,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -312,7 +313,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xblbitlocker.rb
+++ b/lib/puppet/type/dsc_xblbitlocker.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xblbitlocker) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -89,7 +90,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -102,7 +103,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -127,7 +128,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -155,7 +156,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -180,7 +181,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -217,7 +218,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -230,7 +231,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -243,7 +244,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -256,7 +257,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -281,7 +282,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -294,7 +295,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -307,7 +308,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xbltpm.rb
+++ b/lib/puppet/type/dsc_xbltpm.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xbltpm) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xbltpm) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -74,7 +75,7 @@ Puppet::Type.newtype(:dsc_xbltpm) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -87,7 +88,7 @@ Puppet::Type.newtype(:dsc_xbltpm) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -100,7 +101,7 @@ Puppet::Type.newtype(:dsc_xbltpm) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xcertreq.rb
+++ b/lib/puppet/type/dsc_xcertreq.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xcertreq) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xcertreq) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -115,7 +116,7 @@ Puppet::Type.newtype(:dsc_xcertreq) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xcluster) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xcluster) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xcomputer) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xcomputer) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xcredssp.rb
+++ b/lib/puppet/type/dsc_xcredssp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xcredssp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xcredssp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdatabase) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdatabase) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdatabaselogin.rb
+++ b/lib/puppet/type/dsc_xdatabaselogin.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdatabaselogin) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdatabaselogin) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdatabaseserver.rb
+++ b/lib/puppet/type/dsc_xdatabaseserver.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdatabaseserver) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdatabaseserver) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdbpackage) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdhcpserveroption) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdhcpserverscope) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdhcpserverscope) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdisk.rb
+++ b/lib/puppet/type/dsc_xdisk.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdisk) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdisk) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdismfeature.rb
+++ b/lib/puppet/type/dsc_xdismfeature.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdismfeature) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdismfeature) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdnsarecord.rb
+++ b/lib/puppet/type/dsc_xdnsarecord.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdnsarecord) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xdnsarecord) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdnsserveraddress) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xdscwebservice) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -169,7 +170,7 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -206,7 +207,7 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -99,7 +100,7 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -139,7 +140,7 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -167,7 +168,7 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -246,7 +247,7 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchantimalwarescanning.rb
+++ b/lib/puppet/type/dsc_xexchantimalwarescanning.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -63,7 +64,7 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -90,7 +91,7 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -99,7 +100,7 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -112,7 +113,7 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -137,7 +138,7 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -150,7 +151,7 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchautomountpoint.rb
+++ b/lib/puppet/type/dsc_xexchautomountpoint.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchautomountpoint) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -128,7 +129,7 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -141,7 +142,7 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchclientaccessserver.rb
+++ b/lib/puppet/type/dsc_xexchclientaccessserver.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -125,7 +126,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -180,7 +181,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -262,7 +263,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -305,7 +306,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -333,7 +334,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -110,7 +111,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -127,7 +128,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -140,7 +141,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -99,7 +100,7 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -112,7 +113,7 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -125,7 +126,7 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -165,7 +166,7 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -202,7 +203,7 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchexchangecertificate.rb
+++ b/lib/puppet/type/dsc_xexchexchangecertificate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -103,7 +104,7 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchexchangeserver.rb
+++ b/lib/puppet/type/dsc_xexchexchangeserver.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchexchangeserver) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -99,7 +100,7 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchimapsettings.rb
+++ b/lib/puppet/type/dsc_xexchimapsettings.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchimapsettings) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchimapsettings) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchimapsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchinstall.rb
+++ b/lib/puppet/type/dsc_xexchinstall.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchinstall) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchinstall) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xexchjetstress.rb
+++ b/lib/puppet/type/dsc_xexchjetstress.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchjetstress) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchjetstress) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xexchjetstresscleanup.rb
+++ b/lib/puppet/type/dsc_xexchjetstresscleanup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -105,7 +106,7 @@ Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -148,7 +149,7 @@ Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabase.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -149,7 +150,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -162,7 +163,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -175,7 +176,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -188,7 +189,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -213,7 +214,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -277,7 +278,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -290,7 +291,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -315,7 +316,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -352,7 +353,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -425,7 +426,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -110,7 +111,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -162,7 +163,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -101,7 +102,7 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -114,7 +115,7 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -223,7 +224,7 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -236,7 +237,7 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchoutlookanywhere.rb
+++ b/lib/puppet/type/dsc_xexchoutlookanywhere.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -111,7 +112,7 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -226,7 +227,7 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -251,7 +252,7 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -99,7 +100,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -112,7 +113,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -125,7 +126,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -138,7 +139,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -190,7 +191,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -215,7 +216,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -267,7 +268,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -280,7 +281,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -293,7 +294,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchpopsettings.rb
+++ b/lib/puppet/type/dsc_xexchpopsettings.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchpopsettings) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchpopsettings) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchpopsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -99,7 +100,7 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -112,7 +113,7 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -161,7 +162,7 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -174,7 +175,7 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchreceiveconnector.rb
+++ b/lib/puppet/type/dsc_xexchreceiveconnector.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -103,7 +104,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -143,7 +144,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -156,7 +157,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -184,7 +185,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -245,7 +246,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -270,7 +271,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -283,7 +284,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -296,7 +297,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -309,7 +310,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -322,7 +323,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -362,7 +363,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -549,7 +550,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -577,7 +578,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -620,7 +621,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -633,7 +634,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -673,7 +674,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchumcallroutersettings.rb
+++ b/lib/puppet/type/dsc_xexchumcallroutersettings.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchumcallroutersettings) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchumcallroutersettings) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xexchumservice.rb
+++ b/lib/puppet/type/dsc_xexchumservice.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchumservice) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchumservice) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xexchwaitforadprep.rb
+++ b/lib/puppet/type/dsc_xexchwaitforadprep.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xexchwaitfordag.rb
+++ b/lib/puppet/type/dsc_xexchwaitfordag.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchwaitfordag) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -99,7 +100,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -112,7 +113,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -125,7 +126,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -186,7 +187,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -199,7 +200,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -212,7 +213,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xfirewall) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xfirewall) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xgroup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xgroup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xhotfix.rb
+++ b/lib/puppet/type/dsc_xhotfix.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xhotfix) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xhotfix) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xiisfeaturedelegation.rb
+++ b/lib/puppet/type/dsc_xiisfeaturedelegation.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xiisfeaturedelegation) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xiisfeaturedelegation) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xiishandler.rb
+++ b/lib/puppet/type/dsc_xiishandler.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xiishandler) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xiishandler) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xiismimetypemapping.rb
+++ b/lib/puppet/type/dsc_xiismimetypemapping.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xiismimetypemapping) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xiismimetypemapping) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xiismodule) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xiismodule) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -165,7 +166,7 @@ Puppet::Type.newtype(:dsc_xiismodule) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
+++ b/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xinternetexplorerhomepage) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xinternetexplorerhomepage) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xipaddress) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xipaddress) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xjeaendpoint) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -137,7 +138,7 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xjeatoolkit) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmicrosoftupdate.rb
+++ b/lib/puppet/type/dsc_xmicrosoftupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmicrosoftupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xmicrosoftupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmountimage.rb
+++ b/lib/puppet/type/dsc_xmountimage.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmountimage) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xmountimage) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmppreference.rb
+++ b/lib/puppet/type/dsc_xmppreference.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmppreference) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -249,7 +250,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -279,7 +280,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -396,7 +397,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -500,7 +501,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -514,7 +515,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -528,7 +529,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -542,7 +543,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -556,7 +557,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -570,7 +571,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -584,7 +585,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -598,7 +599,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -612,7 +613,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -626,7 +627,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -640,7 +641,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -654,7 +655,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -668,7 +669,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -682,7 +683,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -696,7 +697,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -710,7 +711,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -724,7 +725,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmysqldatabase) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmysqlgrant) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmysqlserver) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xmysqluser) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xpackage) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xpackage) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -231,7 +232,7 @@ Puppet::Type.newtype(:dsc_xpackage) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xpendingreboot.rb
+++ b/lib/puppet/type/dsc_xpendingreboot.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xpendingreboot) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -74,7 +75,7 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -87,7 +88,7 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -100,7 +101,7 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -113,7 +114,7 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -126,7 +127,7 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
+++ b/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xpowershellexecutionpolicy) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xpowershellexecutionpolicy) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xpsendpoint) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xrdremoteapp.rb
+++ b/lib/puppet/type/dsc_xrdremoteapp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrdremoteapp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -32,7 +33,7 @@ Puppet::Type.newtype(:dsc_xrdremoteapp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -215,7 +216,7 @@ Puppet::Type.newtype(:dsc_xrdremoteapp) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrdsessioncollection) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollection) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -92,7 +93,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -106,7 +107,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -146,7 +147,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -160,7 +161,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -274,7 +275,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -301,7 +302,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -31,7 +32,7 @@ Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xremotefile) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xremotefile) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xrobocopy.rb
+++ b/lib/puppet/type/dsc_xrobocopy.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xrobocopy) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -136,7 +137,7 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -150,7 +151,7 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -164,7 +165,7 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -204,7 +205,7 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xscdpmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscdpmconsolesetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscdpmconsolesetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscdpmconsolesetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscdpmdatabaseserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscdpmdatabaseserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscdpmserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscdpmserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscomadmin.rb
+++ b/lib/puppet/type/dsc_xscomadmin.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscomadmin) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xscomadmin) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscomconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscomconsolesetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscomconsolesetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscomconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscomconsoleupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscomconsoleupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscomconsoleupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscommanagementpack.rb
+++ b/lib/puppet/type/dsc_xscommanagementpack.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscommanagementpack) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscommanagementpack) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscommanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscommanagementserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -159,7 +160,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xscommanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscommanagementserverupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscommanagementserverupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserverupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscomreportingserversetup.rb
+++ b/lib/puppet/type/dsc_xscomreportingserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -175,7 +176,7 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscomwebconsoleserverupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserverupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscsmapowershellsetup.rb
+++ b/lib/puppet/type/dsc_xscsmapowershellsetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscsmapowershellsetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscsmapowershellsetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -120,7 +121,7 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xscspfserver.rb
+++ b/lib/puppet/type/dsc_xscspfserver.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscspfserver) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscspfserver) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscspfserversetup.rb
+++ b/lib/puppet/type/dsc_xscspfserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscspfserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -146,7 +147,7 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xscspfserverupdate.rb
+++ b/lib/puppet/type/dsc_xscspfserverupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscspfserverupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscspfserverupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscspfsetting.rb
+++ b/lib/puppet/type/dsc_xscspfsetting.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscspfsetting) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xscspfsetting) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscspfstamp.rb
+++ b/lib/puppet/type/dsc_xscspfstamp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscspfstamp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscspfstamp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscsrserversetup.rb
+++ b/lib/puppet/type/dsc_xscsrserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscsrserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscsrserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscsrserverupdate.rb
+++ b/lib/puppet/type/dsc_xscsrserverupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscsrserverupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscsrserverupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscvmmadmin.rb
+++ b/lib/puppet/type/dsc_xscvmmadmin.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscvmmadmin) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xscvmmadmin) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscvmmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscvmmconsolesetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscvmmconsoleupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscvmmconsoleupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -198,7 +199,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -212,7 +213,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xscvmmmanagementserverupdate) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserverupdate) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xservice) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xservice) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsmbshare) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -135,7 +136,7 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xspbcsserviceapp.rb
+++ b/lib/puppet/type/dsc_xspbcsserviceapp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspbcsserviceapp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspbcsserviceapp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspcacheaccounts.rb
+++ b/lib/puppet/type/dsc_xspcacheaccounts.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspcacheaccounts) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspcacheaccounts) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspclearremotesessions.rb
+++ b/lib/puppet/type/dsc_xspclearremotesessions.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspclearremotesessions) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspclearremotesessions) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -62,7 +63,7 @@ Puppet::Type.newtype(:dsc_xspclearremotesessions) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xspcreatefarm.rb
+++ b/lib/puppet/type/dsc_xspcreatefarm.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspcreatefarm) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xspcreatefarm) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspdiagnosticloggingsettings.rb
+++ b/lib/puppet/type/dsc_xspdiagnosticloggingsettings.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -89,7 +90,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -102,7 +103,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -130,7 +131,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -143,7 +144,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -156,7 +157,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -169,7 +170,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -257,7 +258,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -285,7 +286,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -298,7 +299,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xspdistributedcacheservice.rb
+++ b/lib/puppet/type/dsc_xspdistributedcacheservice.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspdistributedcacheservice) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspdistributedcacheservice) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -130,7 +131,7 @@ Puppet::Type.newtype(:dsc_xspdistributedcacheservice) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xspfeature.rb
+++ b/lib/puppet/type/dsc_xspfeature.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspfeature) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xspfeature) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspinstall.rb
+++ b/lib/puppet/type/dsc_xspinstall.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspinstall) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspinstall) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspinstallprereqs.rb
+++ b/lib/puppet/type/dsc_xspinstallprereqs.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspinstallprereqs) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspinstallprereqs) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -74,7 +75,7 @@ Puppet::Type.newtype(:dsc_xspinstallprereqs) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xspjoinfarm.rb
+++ b/lib/puppet/type/dsc_xspjoinfarm.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspjoinfarm) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xspjoinfarm) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspmanagedaccount.rb
+++ b/lib/puppet/type/dsc_xspmanagedaccount.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspmanagedaccount) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspmanagedaccount) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspmanagedmetadataserviceapp.rb
+++ b/lib/puppet/type/dsc_xspmanagedmetadataserviceapp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspmanagedmetadataserviceapp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspmanagedmetadataserviceapp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspmanagedpath.rb
+++ b/lib/puppet/type/dsc_xspmanagedpath.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspmanagedpath) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xspmanagedpath) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -100,7 +101,7 @@ Puppet::Type.newtype(:dsc_xspmanagedpath) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -113,7 +114,7 @@ Puppet::Type.newtype(:dsc_xspmanagedpath) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xspsearchserviceapp.rb
+++ b/lib/puppet/type/dsc_xspsearchserviceapp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspsearchserviceapp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspsearchserviceapp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspsecurestoreserviceapp.rb
+++ b/lib/puppet/type/dsc_xspsecurestoreserviceapp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspsecurestoreserviceapp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspsecurestoreserviceapp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -86,7 +87,7 @@ Puppet::Type.newtype(:dsc_xspsecurestoreserviceapp) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -186,7 +187,7 @@ Puppet::Type.newtype(:dsc_xspsecurestoreserviceapp) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -199,7 +200,7 @@ Puppet::Type.newtype(:dsc_xspsecurestoreserviceapp) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xspserviceapppool.rb
+++ b/lib/puppet/type/dsc_xspserviceapppool.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspserviceapppool) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspserviceapppool) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspserviceinstance.rb
+++ b/lib/puppet/type/dsc_xspserviceinstance.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspserviceinstance) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspserviceinstance) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspsite.rb
+++ b/lib/puppet/type/dsc_xspsite.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspsite) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspsite) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspstateserviceapp.rb
+++ b/lib/puppet/type/dsc_xspstateserviceapp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspstateserviceapp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspstateserviceapp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspusageapplication.rb
+++ b/lib/puppet/type/dsc_xspusageapplication.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspusageapplication) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspusageapplication) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspuserprofileserviceapp.rb
+++ b/lib/puppet/type/dsc_xspuserprofileserviceapp.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspuserprofileserviceapp) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspuserprofileserviceapp) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspuserprofilesyncservice.rb
+++ b/lib/puppet/type/dsc_xspuserprofilesyncservice.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspuserprofilesyncservice) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspuserprofilesyncservice) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xspwebapplication.rb
+++ b/lib/puppet/type/dsc_xspwebapplication.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xspwebapplication) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xspwebapplication) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -110,7 +111,7 @@ Puppet::Type.newtype(:dsc_xspwebapplication) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlhagroup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlhaservice) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsqlserverfailoverclustersetup.rb
+++ b/lib/puppet/type/dsc_xsqlserverfailoverclustersetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlserverfailoverclustersetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xsqlserverfailoverclustersetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsqlserverfirewall.rb
+++ b/lib/puppet/type/dsc_xsqlserverfirewall.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -135,7 +136,7 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -149,7 +150,7 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -163,7 +164,7 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -177,7 +178,7 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -191,7 +192,7 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlserverinstall) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -128,7 +129,7 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlserverrsconfig.rb
+++ b/lib/puppet/type/dsc_xsqlserverrsconfig.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlserverrsconfig) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xsqlserverrsconfig) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -115,7 +116,7 @@ Puppet::Type.newtype(:dsc_xsqlserverrsconfig) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
+++ b/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlserverrssecureconnectionlevel) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xsqlserverrssecureconnectionlevel) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsqlserversetup.rb
+++ b/lib/puppet/type/dsc_xsqlserversetup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsqlserversetup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xsqlserversetup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsystemrestore.rb
+++ b/lib/puppet/type/dsc_xsystemrestore.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsystemrestore) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xsystemrestore) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xsystemrestorepoint.rb
+++ b/lib/puppet/type/dsc_xsystemrestorepoint.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xsystemrestorepoint) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xsystemrestorepoint) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xtimezone.rb
+++ b/lib/puppet/type/dsc_xtimezone.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xtimezone) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xtimezone) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xvhd) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xvhd) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -196,7 +197,7 @@ Puppet::Type.newtype(:dsc_xvhd) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xvhdfile) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xvmhyperv) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -225,7 +226,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -239,7 +240,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -367,7 +368,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xvmswitch) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -108,7 +109,7 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwaitforaddomain) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwaitforcluster) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwaitfordisk.rb
+++ b/lib/puppet/type/dsc_xwaitfordisk.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwaitfordisk) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwaitfordisk) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebapplication) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwebapplication) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebapppool) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebapppooldefaults.rb
+++ b/lib/puppet/type/dsc_xwebapppooldefaults.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebapppooldefaults) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwebapppooldefaults) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -31,7 +32,7 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -139,7 +140,7 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xwebpackagedeploy.rb
+++ b/lib/puppet/type/dsc_xwebpackagedeploy.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebpackagedeploy) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwebpackagedeploy) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebsite) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwebsite) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebsitedefaults.rb
+++ b/lib/puppet/type/dsc_xwebsitedefaults.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebsitedefaults) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwebsitedefaults) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -31,7 +32,7 @@ Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwefcollector.rb
+++ b/lib/puppet/type/dsc_xwefcollector.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwefcollector) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwefcollector) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwefsubscription.rb
+++ b/lib/puppet/type/dsc_xwefsubscription.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwefsubscription) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -106,7 +107,7 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 
@@ -119,7 +120,7 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwindowsprocess) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -30,7 +31,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwineventlog) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true
@@ -91,7 +92,7 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
     end
     newvalues(true, false)
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
   end
 

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -2,6 +2,7 @@ require 'pathname'
 
 Puppet::Type.newtype(:dsc_xwordpresssite) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
 
   provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
     defaultfor :operatingsystem => :windows
@@ -29,7 +30,7 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
     newvalues(true, false)
 
     munge do |value|
-      provider.munge_boolean(value.to_s)
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
     end
 
     defaultto true

--- a/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
@@ -1,0 +1,12 @@
+module PuppetX
+  module Dsc
+    class TypeHelpers
+      def self.munge_boolean(value)
+        return true if value =~ (/^(true|t|yes|y|1)$/i)
+        return false if value.empty? || value =~ (/^(false|f|no|n|0)$/i)
+
+        raise ArgumentError.new "invalid value: #{value}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
 - Previously the munge_boolean helper was a part of the PowerShell
   provider implementation, even though it had nothing to do with
   provider specifics and is effectively plain old Ruby code.

   Refactor that method to a helper class, that will be expanded in
   future ticket MODULES-2178, and is also necessary for MODULES-2521
   which confines the provider to only work against PowerShell 5 or
   higher.

   For the confine to work properly, either calls to the provider must
   be guarded in the event of a nil provider instance, or those methods
   must be moved to an area that is accessible regardless of provider.

   In this instance, it makes more sense to introduce Ruby helpers not
   bound to the provider.