### PR TITLE
(WIP)(MODULES-2641) Notify on RebootRequired

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
     powershell: "puppetlabs/powershell"
+    reboot: "puppetlabs/reboot"
   symlinks:
     "dsc": "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ dsc_windowsfeature {'IIS':
 
 All DSC Resource names and parameters have to be in lowercase, e.g: `dsc_windowsfeature` or `dsc_name`.
 
+### Handling Reboots with DSC
+
+You will need to add the following `reboot` resource to your manifest. It must have the name `dsc_reboot` for the `dsc` module to find and use it.
+
+~~~puppet
+reboot { 'dsc_reboot' :
+    message => 'DSC has requested a reboot',
+    when => 'refreshed'
+}
+~~~
+
 ### Installing Packages with DSC
 
 You can install MSIs or EXEs with DSC using the Puppet type `dsc_package` which maps to the `Package` DSC Resource.

--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -103,6 +103,10 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     defaultto { :<%= begin resource.ensure_value rescue 'present' end %> }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
 <%  resource.properties.each do |property| -%>
   # Name:         <%= property.name %>
   # Type:         <%= property.type %>

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -48,6 +48,10 @@ Puppet::Type.newtype(:dsc_archive) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -47,6 +47,10 @@ Puppet::Type.newtype(:dsc_environment) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -47,6 +47,10 @@ Puppet::Type.newtype(:dsc_file) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DestinationPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -47,6 +47,10 @@ Puppet::Type.newtype(:dsc_group) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -45,6 +45,10 @@ Puppet::Type.newtype(:dsc_log) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Message
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -48,6 +48,10 @@ Puppet::Type.newtype(:dsc_package) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -48,6 +48,10 @@ Puppet::Type.newtype(:dsc_registry) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Key
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -48,6 +48,10 @@ Puppet::Type.newtype(:dsc_script) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         GetScript
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -47,6 +47,10 @@ Puppet::Type.newtype(:dsc_service) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -47,6 +47,10 @@ Puppet::Type.newtype(:dsc_user) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         UserName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -47,6 +47,10 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_windowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_windowsoptionalfeature.rb
@@ -47,6 +47,10 @@ Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
     defaultto { :enable }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -48,6 +48,10 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xadcscertificationauthority.rb
+++ b/lib/puppet/type/dsc_xadcscertificationauthority.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         CAType
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xadcswebenrollment.rb
+++ b/lib/puppet/type/dsc_xadcswebenrollment.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xadcswebenrollment) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         CAConfig
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xaddomain) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xadrecyclebin.rb
+++ b/lib/puppet/type/dsc_xadrecyclebin.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xadrecyclebin) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         ForestFQDN
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xaduser) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xarchive) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Destination
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackadmin.rb
+++ b/lib/puppet/type/dsc_xazurepackadmin.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazurepackadmin) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
+++ b/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Namespace
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackfqdn.rb
+++ b/lib/puppet/type/dsc_xazurepackfqdn.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Namespace
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackidentityprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackidentityprovider.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Target
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackrelyingparty.rb
+++ b/lib/puppet/type/dsc_xazurepackrelyingparty.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Target
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackresourceprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackresourceprovider.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         AuthenticationSite
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xazurepacksetup.rb
+++ b/lib/puppet/type/dsc_xazurepacksetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Role
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackupdate.rb
+++ b/lib/puppet/type/dsc_xazurepackupdate.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xazurepackupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Role
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazureservice) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         ServiceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         RuleName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazurestorageaccount) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         StorageAccountName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazuresubscription) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazurevm) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         StorageAccountName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurevmdscextension.rb
+++ b/lib/puppet/type/dsc_xazurevmdscextension.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xazurevmdscextension) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         VMName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xblautobitlocker.rb
+++ b/lib/puppet/type/dsc_xblautobitlocker.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DriveType
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xblbitlocker.rb
+++ b/lib/puppet/type/dsc_xblbitlocker.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         MountPoint
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xbltpm.rb
+++ b/lib/puppet/type/dsc_xbltpm.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xbltpm) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcertreq.rb
+++ b/lib/puppet/type/dsc_xcertreq.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xcertreq) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Subject
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xcluster) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xcomputer) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcredssp.rb
+++ b/lib/puppet/type/dsc_xcredssp.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xcredssp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdatabase) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Credentials
   # Type:         MSFT_Credential
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdatabaselogin.rb
+++ b/lib/puppet/type/dsc_xdatabaselogin.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdatabaselogin) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdatabaseserver.rb
+++ b/lib/puppet/type/dsc_xdatabaseserver.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xdatabaseserver) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         LoginMode
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Credentials
   # Type:         MSFT_Credential
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
+++ b/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdefaultgatewayaddress) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Address
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         ScopeID
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         ScopeID
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xdhcpserverscope) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         IPStartRange
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdisk.rb
+++ b/lib/puppet/type/dsc_xdisk.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xdisk) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DriveLetter
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdismfeature.rb
+++ b/lib/puppet/type/dsc_xdismfeature.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdismfeature) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdnsarecord.rb
+++ b/lib/puppet/type/dsc_xdnsarecord.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdnsarecord) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Address
   # Type:         string[]
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         EndpointName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchantimalwarescanning.rb
+++ b/lib/puppet/type/dsc_xexchantimalwarescanning.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Enabled
   # Type:         boolean
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchautomountpoint.rb
+++ b/lib/puppet/type/dsc_xexchautomountpoint.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchclientaccessserver.rb
+++ b/lib/puppet/type/dsc_xexchclientaccessserver.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         MailboxServer
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexcheventloglevel.rb
+++ b/lib/puppet/type/dsc_xexcheventloglevel.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexcheventloglevel) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchexchangecertificate.rb
+++ b/lib/puppet/type/dsc_xexchexchangecertificate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Thumbprint
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchexchangeserver.rb
+++ b/lib/puppet/type/dsc_xexchexchangeserver.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchimapsettings.rb
+++ b/lib/puppet/type/dsc_xexchimapsettings.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchimapsettings) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Server
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchinstall.rb
+++ b/lib/puppet/type/dsc_xexchinstall.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xexchinstall) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchjetstress.rb
+++ b/lib/puppet/type/dsc_xexchjetstress.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchjetstress) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Type
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchjetstresscleanup.rb
+++ b/lib/puppet/type/dsc_xexchjetstresscleanup.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         JetstressPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchmailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabase.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchoutlookanywhere.rb
+++ b/lib/puppet/type/dsc_xexchoutlookanywhere.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchpopsettings.rb
+++ b/lib/puppet/type/dsc_xexchpopsettings.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchpopsettings) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Server
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchreceiveconnector.rb
+++ b/lib/puppet/type/dsc_xexchreceiveconnector.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchumcallroutersettings.rb
+++ b/lib/puppet/type/dsc_xexchumcallroutersettings.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchumcallroutersettings) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Server
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchumservice.rb
+++ b/lib/puppet/type/dsc_xexchumservice.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchumservice) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchwaitforadprep.rb
+++ b/lib/puppet/type/dsc_xexchwaitforadprep.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchwaitfordag.rb
+++ b/lib/puppet/type/dsc_xexchwaitfordag.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xfirewall) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xgroup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xhotfix.rb
+++ b/lib/puppet/type/dsc_xhotfix.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xhotfix) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiisfeaturedelegation.rb
+++ b/lib/puppet/type/dsc_xiisfeaturedelegation.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xiisfeaturedelegation) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         SectionName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiishandler.rb
+++ b/lib/puppet/type/dsc_xiishandler.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xiishandler) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiismimetypemapping.rb
+++ b/lib/puppet/type/dsc_xiismimetypemapping.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xiismimetypemapping) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Extension
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xiismodule) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
+++ b/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xinternetexplorerhomepage) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         StartPage
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xipaddress) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         IPAddress
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmicrosoftupdate.rb
+++ b/lib/puppet/type/dsc_xmicrosoftupdate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xmicrosoftupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmountimage.rb
+++ b/lib/puppet/type/dsc_xmountimage.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xmountimage) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmppreference.rb
+++ b/lib/puppet/type/dsc_xmppreference.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         UserName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         ServiceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xpackage) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xpendingreboot.rb
+++ b/lib/puppet/type/dsc_xpendingreboot.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
+++ b/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xpowershellexecutionpolicy) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         ExecutionPolicy
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdremoteapp.rb
+++ b/lib/puppet/type/dsc_xrdremoteapp.rb
@@ -53,6 +53,10 @@ Puppet::Type.newtype(:dsc_xrdremoteapp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Alias
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xrdsessioncollection) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         CollectionName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         CollectionName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         SessionHost
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xremotefile) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DestinationPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrobocopy.rb
+++ b/lib/puppet/type/dsc_xrobocopy.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Source
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscdpmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscdpmconsolesetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscdpmconsolesetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscdpmdatabaseserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscdpmserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomadmin.rb
+++ b/lib/puppet/type/dsc_xscomadmin.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xscomadmin) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscomconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscomconsolesetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscomconsoleupdate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscomconsoleupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscommanagementpack.rb
+++ b/lib/puppet/type/dsc_xscommanagementpack.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xscommanagementpack) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscommanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscommanagementserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscommanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscommanagementserverupdate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscommanagementserverupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomreportingserversetup.rb
+++ b/lib/puppet/type/dsc_xscomreportingserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserverupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscsmapowershellsetup.rb
+++ b/lib/puppet/type/dsc_xscsmapowershellsetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscsmapowershellsetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscspfserver.rb
+++ b/lib/puppet/type/dsc_xscspfserver.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscspfserver) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscspfserversetup.rb
+++ b/lib/puppet/type/dsc_xscspfserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscspfserverupdate.rb
+++ b/lib/puppet/type/dsc_xscspfserverupdate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscspfserverupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscspfsetting.rb
+++ b/lib/puppet/type/dsc_xscspfsetting.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xscspfsetting) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscspfstamp.rb
+++ b/lib/puppet/type/dsc_xscspfstamp.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscspfstamp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscsrserversetup.rb
+++ b/lib/puppet/type/dsc_xscsrserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscsrserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscsrserverupdate.rb
+++ b/lib/puppet/type/dsc_xscsrserverupdate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscsrserverupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscvmmadmin.rb
+++ b/lib/puppet/type/dsc_xscvmmadmin.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xscvmmadmin) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscvmmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscvmmconsolesetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscvmmconsoleupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserverupdate) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xservice) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspbcsserviceapp.rb
+++ b/lib/puppet/type/dsc_xspbcsserviceapp.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspbcsserviceapp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspcacheaccounts.rb
+++ b/lib/puppet/type/dsc_xspcacheaccounts.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspcacheaccounts) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspcreatefarm.rb
+++ b/lib/puppet/type/dsc_xspcreatefarm.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xspcreatefarm) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         FarmConfigDatabaseName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspdiagnosticloggingsettings.rb
+++ b/lib/puppet/type/dsc_xspdiagnosticloggingsettings.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         LogPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspdistributedcacheservice.rb
+++ b/lib/puppet/type/dsc_xspdistributedcacheservice.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xspdistributedcacheservice) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspfeature.rb
+++ b/lib/puppet/type/dsc_xspfeature.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xspfeature) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspinstall.rb
+++ b/lib/puppet/type/dsc_xspinstall.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xspinstall) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         BinaryDir
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspinstallprereqs.rb
+++ b/lib/puppet/type/dsc_xspinstallprereqs.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xspinstallprereqs) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         InstallerPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspjoinfarm.rb
+++ b/lib/puppet/type/dsc_xspjoinfarm.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xspjoinfarm) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         FarmConfigDatabaseName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspmanagedaccount.rb
+++ b/lib/puppet/type/dsc_xspmanagedaccount.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspmanagedaccount) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         AccountName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspmanagedmetadataserviceapp.rb
+++ b/lib/puppet/type/dsc_xspmanagedmetadataserviceapp.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspmanagedmetadataserviceapp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspmanagedpath.rb
+++ b/lib/puppet/type/dsc_xspmanagedpath.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xspmanagedpath) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspsearchserviceapp.rb
+++ b/lib/puppet/type/dsc_xspsearchserviceapp.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspsearchserviceapp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspsecurestoreserviceapp.rb
+++ b/lib/puppet/type/dsc_xspsecurestoreserviceapp.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspsecurestoreserviceapp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspserviceapppool.rb
+++ b/lib/puppet/type/dsc_xspserviceapppool.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspserviceapppool) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspserviceinstance.rb
+++ b/lib/puppet/type/dsc_xspserviceinstance.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xspserviceinstance) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspsite.rb
+++ b/lib/puppet/type/dsc_xspsite.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspsite) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspstateserviceapp.rb
+++ b/lib/puppet/type/dsc_xspstateserviceapp.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspstateserviceapp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspusageapplication.rb
+++ b/lib/puppet/type/dsc_xspusageapplication.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspusageapplication) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspuserprofileserviceapp.rb
+++ b/lib/puppet/type/dsc_xspuserprofileserviceapp.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspuserprofileserviceapp) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspuserprofilesyncservice.rb
+++ b/lib/puppet/type/dsc_xspuserprofilesyncservice.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xspuserprofilesyncservice) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         UserProfileServiceAppName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xspwebapplication.rb
+++ b/lib/puppet/type/dsc_xspwebapplication.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xspwebapplication) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverfailoverclustersetup.rb
+++ b/lib/puppet/type/dsc_xsqlserverfailoverclustersetup.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xsqlserverfailoverclustersetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Action
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverfirewall.rb
+++ b/lib/puppet/type/dsc_xsqlserverfirewall.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverrsconfig.rb
+++ b/lib/puppet/type/dsc_xsqlserverrsconfig.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xsqlserverrsconfig) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
+++ b/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xsqlserverrssecureconnectionlevel) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserversetup.rb
+++ b/lib/puppet/type/dsc_xsqlserversetup.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xsqlserversetup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         SourcePath
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xsystemrestore.rb
+++ b/lib/puppet/type/dsc_xsystemrestore.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xsystemrestore) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsystemrestorepoint.rb
+++ b/lib/puppet/type/dsc_xsystemrestorepoint.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xsystemrestorepoint) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Description
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xtimezone.rb
+++ b/lib/puppet/type/dsc_xtimezone.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xtimezone) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         IsSingleInstance
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xvhd) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -73,6 +73,10 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         VhdPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitfordisk.rb
+++ b/lib/puppet/type/dsc_xwaitfordisk.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xwaitfordisk) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         DiskNumber
   # Type:         uint32
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xwebapplication) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Website
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebapppooldefaults.rb
+++ b/lib/puppet/type/dsc_xwebapppooldefaults.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xwebapppooldefaults) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         ApplyTo
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -53,6 +53,10 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         WebsitePath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebpackagedeploy.rb
+++ b/lib/puppet/type/dsc_xwebpackagedeploy.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xwebpackagedeploy) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         SourcePath
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -74,6 +74,10 @@ Puppet::Type.newtype(:dsc_xwebsite) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebsitedefaults.rb
+++ b/lib/puppet/type/dsc_xwebsitedefaults.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xwebsitedefaults) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         ApplyTo
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -53,6 +53,10 @@ Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Website
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwefcollector.rb
+++ b/lib/puppet/type/dsc_xwefcollector.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xwefcollector) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xwefsubscription.rb
+++ b/lib/puppet/type/dsc_xwefsubscription.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         SubscriptionID
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         LogName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -51,6 +51,10 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
     defaultto { :present }
   end
 
+if Puppet.version >= '4.0.0'
+  autonotify(:reboot) { ['dsc_reboot'] }
+end
+
   # Name:         Uri
   # Type:         string
   # IsMandatory:  True


### PR DESCRIPTION
Initiate a reboot when a DSC Resource requires a reboot after execution.

- [x] Detect `rebootrequired` property returned from DSC
- [ ] Add `autonotify` to all dsc types
- [x] Query the catalog to find `dsc_reboot` defined resource if present
- [x] Call method on `dsc_reboot`, if present, to initiate a reboot

*Note*: Tests are failing currently because `autonotify` on puppet < 4.0
