### PR TITLE
(MODULES-2485) Remove LCM Pull RefreshMode

### DIFF
--- a/manifests/lcm_config.pp
+++ b/manifests/lcm_config.pp
@@ -2,7 +2,7 @@ define dsc::lcm_config (
   $refresh_mode = 'Disabled'
 ) {
 
-  validate_re($refresh_mode, '^(Disabled|Pull|Push)$', 'refresh_mode must be one of \'Disabled\', \'Push\', \'Pull\'')
+  validate_re($refresh_mode, '^(Disabled|Push)$', 'refresh_mode must be one of \'Disabled\', \'Push\'')
 
   exec { "dsc_provider_set_lcm_refreshmode_${refresh_mode}":
     provider => 'powershell',

--- a/spec/defines/lcm_config_spec.rb
+++ b/spec/defines/lcm_config_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'dsc::lcm_config', :type => :define do
     }
   end
 
-  ['Disabled', 'Push', 'Pull'].each do |mode|
+  ['Disabled', 'Push'].each do |mode|
     context "when refresh_mode => #{mode}" do
       let (:title)  { "lcm_#{mode}" }
       let (:params) { {:refresh_mode => mode} }
@@ -31,7 +31,7 @@ RSpec.describe 'dsc::lcm_config', :type => :define do
     end
   end
 
-  ['disabled', 'push', 'pull', 'foo', 'bar'].each do |mode|
+  ['disabled', 'push', 'pull', 'Pull', 'foo', 'bar'].each do |mode|
     context "when refresh_mode => #{mode}" do
       let (:title)  { "lcm_#{mode}" }
       let (:params) { {:refresh_mode => mode} }


### PR DESCRIPTION
Remove the ability to set the LCM RefreshMode to Pull, as it will cause
errors during execution without setting more information than we
currently support in the dsc::lcm_config type. Since this type is no
longer needed in our module, this is not a loss.