### PR TITLE
(MODULES-2643) Fix DSC Linux Test Case

### DIFF
--- a/tests/integration/tests/basic_functionality/negative/dsc_on_linux.rb
+++ b/tests/integration/tests/basic_functionality/negative/dsc_on_linux.rb
@@ -16,7 +16,7 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionali
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Verify
-error_msg = /Could not evaluate: Command powershell is missing/
+error_msg = /Could not find a suitable provider for dsc_file/
 
 # Setup
 step 'Inject "site.pp" on Master'


### PR DESCRIPTION
The test case for testing the DSC module on linux expects a certain
error message. Since we have now constrained ourselves to only running
on systems with PowerShell 5 the error message has changed.

Update the test case with the correct error message.