### PR TITLE
(MODULES-2615) Prevent empty password for PSCredential

### DIFF
--- a/build/dsc/templates/dsc_type_spec.rb.erb
+++ b/build/dsc/templates/dsc_type_spec.rb.erb
@@ -34,6 +34,12 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
   end
 <%  end # resource.ensurable? -%>
 <%  resource.properties.each do |property| -%>
+<%    if property.credential? -%>
+
+  it "should not accept empty password for dsc_<%= property.name.downcase %>" do
+    expect{dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+<%    end # if property.credential? -%>
 <%    if property.required? -%>
 
   it 'should require that dsc_<%= property.name.downcase %> is specified' do

--- a/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
@@ -58,6 +58,10 @@ module PuppetX
         unless extraneous.empty?
           fail "#{name} includes invalid keys: #{extraneous.join(',')}"
         end
+
+        if value.values.any?{|v| v.nil? || v.length == 0}
+          fail "Both User and Password must not be empty"
+        end
       end
 
       def self.validate_mof_type(mof_type, embeddedinstance_name, name, value)

--- a/spec/unit/puppet/type/dsc_archive_spec.rb
+++ b/spec/unit/puppet/type/dsc_archive_spec.rb
@@ -291,6 +291,10 @@ describe Puppet::Type.type(:dsc_archive) do
     expect{dsc_archive[:dsc_force] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_archive[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_archive[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_file_spec.rb
+++ b/spec/unit/puppet/type/dsc_file_spec.rb
@@ -339,6 +339,10 @@ describe Puppet::Type.type(:dsc_file) do
     expect{dsc_file[:dsc_force] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_file[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_file[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -478,6 +482,10 @@ describe Puppet::Type.type(:dsc_file) do
 
   it 'should not accept uint for dsc_matchsource' do
     expect{dsc_file[:dsc_matchsource] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_psdscrunascredential" do
+    expect{dsc_file[:dsc_psdscrunascredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_psdscrunascredential' do

--- a/spec/unit/puppet/type/dsc_group_spec.rb
+++ b/spec/unit/puppet/type/dsc_group_spec.rb
@@ -164,6 +164,10 @@ describe Puppet::Type.type(:dsc_group) do
     expect{dsc_group[:dsc_memberstoexclude] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_group[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_group[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_package_spec.rb
+++ b/spec/unit/puppet/type/dsc_package_spec.rb
@@ -173,6 +173,10 @@ describe Puppet::Type.type(:dsc_package) do
     expect{dsc_package[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_package[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_package[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_script_spec.rb
+++ b/spec/unit/puppet/type/dsc_script_spec.rb
@@ -97,6 +97,10 @@ describe Puppet::Type.type(:dsc_script) do
     expect{dsc_script[:dsc_testscript] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_script[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_script[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_service_spec.rb
+++ b/spec/unit/puppet/type/dsc_service_spec.rb
@@ -191,6 +191,10 @@ describe Puppet::Type.type(:dsc_service) do
     expect{dsc_service[:dsc_builtinaccount] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_service[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_service[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_user_spec.rb
+++ b/spec/unit/puppet/type/dsc_user_spec.rb
@@ -131,6 +131,10 @@ describe Puppet::Type.type(:dsc_user) do
     expect{dsc_user[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_password" do
+    expect{dsc_user[:dsc_password] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_password' do
     expect{dsc_user[:dsc_password] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_windowsfeature_spec.rb
+++ b/spec/unit/puppet/type/dsc_windowsfeature_spec.rb
@@ -192,6 +192,10 @@ describe Puppet::Type.type(:dsc_windowsfeature) do
     expect{dsc_windowsfeature[:dsc_logpath] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_windowsfeature[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_windowsfeature[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_windowsprocess_spec.rb
+++ b/spec/unit/puppet/type/dsc_windowsprocess_spec.rb
@@ -89,6 +89,10 @@ describe Puppet::Type.type(:dsc_windowsprocess) do
     expect{dsc_windowsprocess[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_windowsprocess[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_windowsprocess[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xadcscertificationauthority_spec.rb
+++ b/spec/unit/puppet/type/dsc_xadcscertificationauthority_spec.rb
@@ -106,6 +106,10 @@ describe Puppet::Type.type(:dsc_xadcscertificationauthority) do
     expect{dsc_xadcscertificationauthority[:dsc_catype] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xadcscertificationauthority[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xadcscertificationauthority[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -218,6 +222,10 @@ describe Puppet::Type.type(:dsc_xadcscertificationauthority) do
 
   it 'should not accept uint for dsc_certfile' do
     expect{dsc_xadcscertificationauthority[:dsc_certfile] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_certfilepassword" do
+    expect{dsc_xadcscertificationauthority[:dsc_certfilepassword] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_certfilepassword' do

--- a/spec/unit/puppet/type/dsc_xadcswebenrollment_spec.rb
+++ b/spec/unit/puppet/type/dsc_xadcswebenrollment_spec.rb
@@ -34,6 +34,10 @@ describe Puppet::Type.type(:dsc_xadcswebenrollment) do
     expect{dsc_xadcswebenrollment[:dsc_caconfig] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xadcswebenrollment[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xadcswebenrollment[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xaddomain_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaddomain_spec.rb
@@ -77,6 +77,10 @@ describe Puppet::Type.type(:dsc_xaddomain) do
     expect{dsc_xaddomain[:dsc_domainnetbiosname] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_domainadministratorcredential" do
+    expect{dsc_xaddomain[:dsc_domainadministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_domainadministratorcredential' do
     expect{dsc_xaddomain[:dsc_domainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -93,6 +97,10 @@ describe Puppet::Type.type(:dsc_xaddomain) do
     expect{dsc_xaddomain[:dsc_domainadministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_safemodeadministratorpassword" do
+    expect{dsc_xaddomain[:dsc_safemodeadministratorpassword] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_safemodeadministratorpassword' do
     expect{dsc_xaddomain[:dsc_safemodeadministratorpassword] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -107,6 +115,10 @@ describe Puppet::Type.type(:dsc_xaddomain) do
 
   it 'should not accept uint for dsc_safemodeadministratorpassword' do
     expect{dsc_xaddomain[:dsc_safemodeadministratorpassword] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_dnsdelegationcredential" do
+    expect{dsc_xaddomain[:dsc_dnsdelegationcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_dnsdelegationcredential' do

--- a/spec/unit/puppet/type/dsc_xaddomaincontroller_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaddomaincontroller_spec.rb
@@ -42,6 +42,10 @@ describe Puppet::Type.type(:dsc_xaddomaincontroller) do
     expect{dsc_xaddomaincontroller[:dsc_domainname] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_domainadministratorcredential" do
+    expect{dsc_xaddomaincontroller[:dsc_domainadministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_domainadministratorcredential' do
     expect{dsc_xaddomaincontroller[:dsc_domainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -56,6 +60,10 @@ describe Puppet::Type.type(:dsc_xaddomaincontroller) do
 
   it 'should not accept uint for dsc_domainadministratorcredential' do
     expect{dsc_xaddomaincontroller[:dsc_domainadministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_safemodeadministratorpassword" do
+    expect{dsc_xaddomaincontroller[:dsc_safemodeadministratorpassword] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_safemodeadministratorpassword' do

--- a/spec/unit/puppet/type/dsc_xaddomaintrust_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaddomaintrust_spec.rb
@@ -69,6 +69,10 @@ describe Puppet::Type.type(:dsc_xaddomaintrust) do
     expect{dsc_xaddomaintrust[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_targetdomainadministratorcredential" do
+    expect{dsc_xaddomaintrust[:dsc_targetdomainadministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_targetdomainadministratorcredential' do
     expect{dsc_xaddomaintrust[:dsc_targetdomainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xadrecyclebin_spec.rb
+++ b/spec/unit/puppet/type/dsc_xadrecyclebin_spec.rb
@@ -40,6 +40,10 @@ describe Puppet::Type.type(:dsc_xadrecyclebin) do
     expect{dsc_xadrecyclebin[:dsc_forestfqdn] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_enterpriseadministratorcredential" do
+    expect{dsc_xadrecyclebin[:dsc_enterpriseadministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_enterpriseadministratorcredential' do
     expect{dsc_xadrecyclebin[:dsc_enterpriseadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xaduser_spec.rb
+++ b/spec/unit/puppet/type/dsc_xaduser_spec.rb
@@ -123,6 +123,10 @@ describe Puppet::Type.type(:dsc_xaduser) do
     expect{dsc_xaduser[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_password" do
+    expect{dsc_xaduser[:dsc_password] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_password' do
     expect{dsc_xaduser[:dsc_password] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -137,6 +141,10 @@ describe Puppet::Type.type(:dsc_xaduser) do
 
   it 'should not accept uint for dsc_password' do
     expect{dsc_xaduser[:dsc_password] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_domainadministratorcredential" do
+    expect{dsc_xaduser[:dsc_domainadministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_domainadministratorcredential' do

--- a/spec/unit/puppet/type/dsc_xazurepackadmin_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackadmin_spec.rb
@@ -95,6 +95,10 @@ describe Puppet::Type.type(:dsc_xazurepackadmin) do
     expect{dsc_xazurepackadmin[:dsc_principal] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_azurepackadmincredential" do
+    expect{dsc_xazurepackadmin[:dsc_azurepackadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_azurepackadmincredential' do
     expect{dsc_xazurepackadmin[:dsc_azurepackadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xazurepackdatabasesetting_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackdatabasesetting_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xazurepackdatabasesetting) do
     expect{dsc_xazurepackdatabasesetting[:dsc_value] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_azurepackadmincredential" do
+    expect{dsc_xazurepackdatabasesetting[:dsc_azurepackadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_azurepackadmincredential' do
     expect{dsc_xazurepackdatabasesetting[:dsc_azurepackadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xazurepackfqdn_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackfqdn_spec.rb
@@ -137,6 +137,10 @@ describe Puppet::Type.type(:dsc_xazurepackfqdn) do
     expect(dsc_xazurepackfqdn[:dsc_port]).to eq(64)
   end
 
+  it "should not accept empty password for dsc_azurepackadmincredential" do
+    expect{dsc_xazurepackfqdn[:dsc_azurepackadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_azurepackadmincredential' do
     expect{dsc_xazurepackfqdn[:dsc_azurepackadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xazurepackidentityprovider_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackidentityprovider_spec.rb
@@ -117,6 +117,10 @@ describe Puppet::Type.type(:dsc_xazurepackidentityprovider) do
     expect(dsc_xazurepackidentityprovider[:dsc_port]).to eq(64)
   end
 
+  it "should not accept empty password for dsc_azurepackadmincredential" do
+    expect{dsc_xazurepackidentityprovider[:dsc_azurepackadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_azurepackadmincredential' do
     expect{dsc_xazurepackidentityprovider[:dsc_azurepackadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xazurepackrelyingparty_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackrelyingparty_spec.rb
@@ -117,6 +117,10 @@ describe Puppet::Type.type(:dsc_xazurepackrelyingparty) do
     expect(dsc_xazurepackrelyingparty[:dsc_port]).to eq(64)
   end
 
+  it "should not accept empty password for dsc_azurepackadmincredential" do
+    expect{dsc_xazurepackrelyingparty[:dsc_azurepackadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_azurepackadmincredential' do
     expect{dsc_xazurepackrelyingparty[:dsc_azurepackadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xazurepackresourceprovider_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackresourceprovider_spec.rb
@@ -104,6 +104,10 @@ describe Puppet::Type.type(:dsc_xazurepackresourceprovider) do
     expect{dsc_xazurepackresourceprovider[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_azurepackadmincredential" do
+    expect{dsc_xazurepackresourceprovider[:dsc_azurepackadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_azurepackadmincredential' do
     expect{dsc_xazurepackresourceprovider[:dsc_azurepackadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -390,6 +394,10 @@ describe Puppet::Type.type(:dsc_xazurepackresourceprovider) do
     expect{dsc_xazurepackresourceprovider[:dsc_adminauthenticationmode] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_adminauthenticationuser" do
+    expect{dsc_xazurepackresourceprovider[:dsc_adminauthenticationuser] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_adminauthenticationuser' do
     expect{dsc_xazurepackresourceprovider[:dsc_adminauthenticationuser] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -486,6 +494,10 @@ describe Puppet::Type.type(:dsc_xazurepackresourceprovider) do
 
   it 'should not accept uint for dsc_tenantauthenticationmode' do
     expect{dsc_xazurepackresourceprovider[:dsc_tenantauthenticationmode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_tenantauthenticationuser" do
+    expect{dsc_xazurepackresourceprovider[:dsc_tenantauthenticationuser] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_tenantauthenticationuser' do
@@ -618,6 +630,10 @@ describe Puppet::Type.type(:dsc_xazurepackresourceprovider) do
     expect{dsc_xazurepackresourceprovider[:dsc_usageauthenticationmode] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_usageauthenticationuser" do
+    expect{dsc_xazurepackresourceprovider[:dsc_usageauthenticationuser] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_usageauthenticationuser' do
     expect{dsc_xazurepackresourceprovider[:dsc_usageauthenticationuser] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -716,6 +732,10 @@ describe Puppet::Type.type(:dsc_xazurepackresourceprovider) do
     expect{dsc_xazurepackresourceprovider[:dsc_healthcheckauthenticationmode] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_healthcheckauthenticationuser" do
+    expect{dsc_xazurepackresourceprovider[:dsc_healthcheckauthenticationuser] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_healthcheckauthenticationuser' do
     expect{dsc_xazurepackresourceprovider[:dsc_healthcheckauthenticationuser] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -812,6 +832,10 @@ describe Puppet::Type.type(:dsc_xazurepackresourceprovider) do
 
   it 'should not accept uint for dsc_notificationauthenticationmode' do
     expect{dsc_xazurepackresourceprovider[:dsc_notificationauthenticationmode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_notificationauthenticationuser" do
+    expect{dsc_xazurepackresourceprovider[:dsc_notificationauthenticationuser] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_notificationauthenticationuser' do

--- a/spec/unit/puppet/type/dsc_xazurepacksetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepacksetup_spec.rb
@@ -229,6 +229,10 @@ describe Puppet::Type.type(:dsc_xazurepacksetup) do
     expect{dsc_xazurepacksetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xazurepacksetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xazurepacksetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -243,6 +247,10 @@ describe Puppet::Type.type(:dsc_xazurepacksetup) do
 
   it 'should not accept uint for dsc_setupcredential' do
     expect{dsc_xazurepacksetup[:dsc_setupcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_passphrase" do
+    expect{dsc_xazurepacksetup[:dsc_passphrase] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_passphrase' do
@@ -291,6 +299,10 @@ describe Puppet::Type.type(:dsc_xazurepacksetup) do
 
   it 'should not accept uint for dsc_sqlinstance' do
     expect{dsc_xazurepacksetup[:dsc_sqlinstance] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_dbuser" do
+    expect{dsc_xazurepacksetup[:dsc_dbuser] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_dbuser' do

--- a/spec/unit/puppet/type/dsc_xazurepackupdate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackupdate_spec.rb
@@ -166,6 +166,10 @@ describe Puppet::Type.type(:dsc_xazurepackupdate) do
     expect{dsc_xazurepackupdate[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xazurepackupdate[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xazurepackupdate[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xazuresqldatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazuresqldatabase_spec.rb
@@ -116,6 +116,10 @@ describe Puppet::Type.type(:dsc_xazuresqldatabase) do
     expect{dsc_xazuresqldatabase[:dsc_edition] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_servercredential" do
+    expect{dsc_xazuresqldatabase[:dsc_servercredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_servercredential' do
     expect{dsc_xazuresqldatabase[:dsc_servercredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xazurevm_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurevm_spec.rb
@@ -260,6 +260,10 @@ describe Puppet::Type.type(:dsc_xazurevm) do
     expect{dsc_xazurevm[:dsc_windows] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xazurevm[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xazurevm[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xblautobitlocker_spec.rb
+++ b/spec/unit/puppet/type/dsc_xblautobitlocker_spec.rb
@@ -398,6 +398,10 @@ describe Puppet::Type.type(:dsc_xblautobitlocker) do
     expect{dsc_xblautobitlocker[:dsc_hardwareencryption] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_password" do
+    expect{dsc_xblautobitlocker[:dsc_password] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_password' do
     expect{dsc_xblautobitlocker[:dsc_password] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -459,6 +463,10 @@ describe Puppet::Type.type(:dsc_xblautobitlocker) do
 
   it 'should not accept uint for dsc_passwordprotector' do
     expect{dsc_xblautobitlocker[:dsc_passwordprotector] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_pin" do
+    expect{dsc_xblautobitlocker[:dsc_pin] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_pin' do

--- a/spec/unit/puppet/type/dsc_xblbitlocker_spec.rb
+++ b/spec/unit/puppet/type/dsc_xblbitlocker_spec.rb
@@ -360,6 +360,10 @@ describe Puppet::Type.type(:dsc_xblbitlocker) do
     expect{dsc_xblbitlocker[:dsc_hardwareencryption] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_password" do
+    expect{dsc_xblbitlocker[:dsc_password] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_password' do
     expect{dsc_xblbitlocker[:dsc_password] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -421,6 +425,10 @@ describe Puppet::Type.type(:dsc_xblbitlocker) do
 
   it 'should not accept uint for dsc_passwordprotector' do
     expect{dsc_xblbitlocker[:dsc_passwordprotector] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_pin" do
+    expect{dsc_xblbitlocker[:dsc_pin] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_pin' do

--- a/spec/unit/puppet/type/dsc_xcertreq_spec.rb
+++ b/spec/unit/puppet/type/dsc_xcertreq_spec.rb
@@ -73,6 +73,10 @@ describe Puppet::Type.type(:dsc_xcertreq) do
     expect{dsc_xcertreq[:dsc_carootname] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xcertreq[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xcertreq[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xcluster_spec.rb
+++ b/spec/unit/puppet/type/dsc_xcluster_spec.rb
@@ -55,6 +55,10 @@ describe Puppet::Type.type(:dsc_xcluster) do
     expect{dsc_xcluster[:dsc_staticipaddress] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_domainadministratorcredential" do
+    expect{dsc_xcluster[:dsc_domainadministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_domainadministratorcredential' do
     expect{dsc_xcluster[:dsc_domainadministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xcomputer_spec.rb
+++ b/spec/unit/puppet/type/dsc_xcomputer_spec.rb
@@ -57,6 +57,10 @@ describe Puppet::Type.type(:dsc_xcomputer) do
     expect{dsc_xcomputer[:dsc_domainname] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xcomputer[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xcomputer[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -71,6 +75,10 @@ describe Puppet::Type.type(:dsc_xcomputer) do
 
   it 'should not accept uint for dsc_credential' do
     expect{dsc_xcomputer[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_unjoincredential" do
+    expect{dsc_xcomputer[:dsc_unjoincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_unjoincredential' do

--- a/spec/unit/puppet/type/dsc_xdatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdatabase_spec.rb
@@ -18,6 +18,10 @@ describe Puppet::Type.type(:dsc_xdatabase) do
     expect(dsc_xdatabase[:ensure]).to eq :present
   end
 
+  it "should not accept empty password for dsc_credentials" do
+    expect{dsc_xdatabase[:dsc_credentials] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credentials' do
     expect{dsc_xdatabase[:dsc_credentials] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xdatabaselogin_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdatabaselogin_spec.rb
@@ -168,6 +168,10 @@ describe Puppet::Type.type(:dsc_xdatabaselogin) do
     expect{dsc_xdatabaselogin[:dsc_sqlserver] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_sqlconnectioncredential" do
+    expect{dsc_xdatabaselogin[:dsc_sqlconnectioncredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_sqlconnectioncredential' do
     expect{dsc_xdatabaselogin[:dsc_sqlconnectioncredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xdbpackage_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdbpackage_spec.rb
@@ -14,6 +14,10 @@ describe Puppet::Type.type(:dsc_xdbpackage) do
     expect(dsc_xdbpackage.to_s).to eq("Dsc_xdbpackage[foo]")
   end
 
+  it "should not accept empty password for dsc_credentials" do
+    expect{dsc_xdbpackage[:dsc_credentials] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credentials' do
     expect{dsc_xdbpackage[:dsc_credentials] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchactivesyncvirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchactivesyncvirtualdirectory_spec.rb
@@ -51,6 +51,10 @@ describe Puppet::Type.type(:dsc_xexchactivesyncvirtualdirectory) do
     expect{dsc_xexchactivesyncvirtualdirectory[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchactivesyncvirtualdirectory[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchactivesyncvirtualdirectory[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchantimalwarescanning_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchantimalwarescanning_spec.rb
@@ -70,6 +70,10 @@ describe Puppet::Type.type(:dsc_xexchantimalwarescanning) do
     expect{dsc_xexchantimalwarescanning[:dsc_enabled] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchantimalwarescanning[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchantimalwarescanning[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchautodiscovervirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchautodiscovervirtualdirectory_spec.rb
@@ -44,6 +44,10 @@ describe Puppet::Type.type(:dsc_xexchautodiscovervirtualdirectory) do
     expect{dsc_xexchautodiscovervirtualdirectory[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchautodiscovervirtualdirectory[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchautodiscovervirtualdirectory[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchclientaccessserver_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchclientaccessserver_spec.rb
@@ -41,6 +41,10 @@ describe Puppet::Type.type(:dsc_xexchclientaccessserver) do
     expect{dsc_xexchclientaccessserver[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchclientaccessserver[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchclientaccessserver[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchdatabaseavailabilitygroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchdatabaseavailabilitygroup_spec.rb
@@ -59,6 +59,10 @@ describe Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroup) do
     expect{dsc_xexchdatabaseavailabilitygroup[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchdatabaseavailabilitygroup[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchdatabaseavailabilitygroup[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchdatabaseavailabilitygroupmember_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchdatabaseavailabilitygroupmember_spec.rb
@@ -41,6 +41,10 @@ describe Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroupmember) do
     expect{dsc_xexchdatabaseavailabilitygroupmember[:dsc_mailboxserver] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchdatabaseavailabilitygroupmember[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchdatabaseavailabilitygroupmember[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork_spec.rb
@@ -48,6 +48,10 @@ describe Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroupnetwork) do
     expect{dsc_xexchdatabaseavailabilitygroupnetwork[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchdatabaseavailabilitygroupnetwork[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchdatabaseavailabilitygroupnetwork[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchecpvirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchecpvirtualdirectory_spec.rb
@@ -48,6 +48,10 @@ describe Puppet::Type.type(:dsc_xexchecpvirtualdirectory) do
     expect{dsc_xexchecpvirtualdirectory[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchecpvirtualdirectory[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchecpvirtualdirectory[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchexchangecertificate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchexchangecertificate_spec.rb
@@ -48,6 +48,10 @@ describe Puppet::Type.type(:dsc_xexchexchangecertificate) do
     expect{dsc_xexchexchangecertificate[:dsc_thumbprint] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchexchangecertificate[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchexchangecertificate[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -159,6 +163,10 @@ describe Puppet::Type.type(:dsc_xexchexchangecertificate) do
 
   it 'should not accept uint for dsc_allowextraservices' do
     expect{dsc_xexchexchangecertificate[:dsc_allowextraservices] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_certcreds" do
+    expect{dsc_xexchexchangecertificate[:dsc_certcreds] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_certcreds' do

--- a/spec/unit/puppet/type/dsc_xexchexchangeserver_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchexchangeserver_spec.rb
@@ -45,6 +45,10 @@ describe Puppet::Type.type(:dsc_xexchexchangeserver) do
     expect{dsc_xexchexchangeserver[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchexchangeserver[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchexchangeserver[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchimapsettings_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchimapsettings_spec.rb
@@ -43,6 +43,10 @@ describe Puppet::Type.type(:dsc_xexchimapsettings) do
     expect{dsc_xexchimapsettings[:dsc_server] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchimapsettings[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchimapsettings[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchinstall_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchinstall_spec.rb
@@ -55,6 +55,10 @@ describe Puppet::Type.type(:dsc_xexchinstall) do
     expect{dsc_xexchinstall[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchinstall[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchinstall[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchmailboxdatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchmailboxdatabase_spec.rb
@@ -66,6 +66,10 @@ describe Puppet::Type.type(:dsc_xexchmailboxdatabase) do
     expect{dsc_xexchmailboxdatabase[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchmailboxdatabase[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchmailboxdatabase[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchmailboxdatabasecopy_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchmailboxdatabasecopy_spec.rb
@@ -46,6 +46,10 @@ describe Puppet::Type.type(:dsc_xexchmailboxdatabasecopy) do
     expect{dsc_xexchmailboxdatabasecopy[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchmailboxdatabasecopy[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchmailboxdatabasecopy[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchmapivirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchmapivirtualdirectory_spec.rb
@@ -43,6 +43,10 @@ describe Puppet::Type.type(:dsc_xexchmapivirtualdirectory) do
     expect{dsc_xexchmapivirtualdirectory[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchmapivirtualdirectory[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchmapivirtualdirectory[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchoabvirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchoabvirtualdirectory_spec.rb
@@ -50,6 +50,10 @@ describe Puppet::Type.type(:dsc_xexchoabvirtualdirectory) do
     expect{dsc_xexchoabvirtualdirectory[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchoabvirtualdirectory[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchoabvirtualdirectory[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchoutlookanywhere_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchoutlookanywhere_spec.rb
@@ -51,6 +51,10 @@ describe Puppet::Type.type(:dsc_xexchoutlookanywhere) do
     expect{dsc_xexchoutlookanywhere[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchoutlookanywhere[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchoutlookanywhere[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchowavirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchowavirtualdirectory_spec.rb
@@ -55,6 +55,10 @@ describe Puppet::Type.type(:dsc_xexchowavirtualdirectory) do
     expect{dsc_xexchowavirtualdirectory[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchowavirtualdirectory[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchowavirtualdirectory[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchpopsettings_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchpopsettings_spec.rb
@@ -43,6 +43,10 @@ describe Puppet::Type.type(:dsc_xexchpopsettings) do
     expect{dsc_xexchpopsettings[:dsc_server] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchpopsettings[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchpopsettings[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchpowershellvirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchpowershellvirtualdirectory_spec.rb
@@ -46,6 +46,10 @@ describe Puppet::Type.type(:dsc_xexchpowershellvirtualdirectory) do
     expect{dsc_xexchpowershellvirtualdirectory[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchpowershellvirtualdirectory[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchpowershellvirtualdirectory[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchreceiveconnector_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchreceiveconnector_spec.rb
@@ -92,6 +92,10 @@ describe Puppet::Type.type(:dsc_xexchreceiveconnector) do
     expect{dsc_xexchreceiveconnector[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchreceiveconnector[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchreceiveconnector[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchumcallroutersettings_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchumcallroutersettings_spec.rb
@@ -40,6 +40,10 @@ describe Puppet::Type.type(:dsc_xexchumcallroutersettings) do
     expect{dsc_xexchumcallroutersettings[:dsc_server] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchumcallroutersettings[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchumcallroutersettings[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchumservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchumservice_spec.rb
@@ -40,6 +40,10 @@ describe Puppet::Type.type(:dsc_xexchumservice) do
     expect{dsc_xexchumservice[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchumservice[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchumservice[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchwaitforadprep_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchwaitforadprep_spec.rb
@@ -44,6 +44,10 @@ describe Puppet::Type.type(:dsc_xexchwaitforadprep) do
     expect{dsc_xexchwaitforadprep[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchwaitforadprep[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchwaitforadprep[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchwaitfordag_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchwaitfordag_spec.rb
@@ -41,6 +41,10 @@ describe Puppet::Type.type(:dsc_xexchwaitfordag) do
     expect{dsc_xexchwaitfordag[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchwaitfordag[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchwaitfordag[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchwaitformailboxdatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchwaitformailboxdatabase_spec.rb
@@ -42,6 +42,10 @@ describe Puppet::Type.type(:dsc_xexchwaitformailboxdatabase) do
     expect{dsc_xexchwaitformailboxdatabase[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchwaitformailboxdatabase[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchwaitformailboxdatabase[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xexchwebservicesvirtualdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchwebservicesvirtualdirectory_spec.rb
@@ -49,6 +49,10 @@ describe Puppet::Type.type(:dsc_xexchwebservicesvirtualdirectory) do
     expect{dsc_xexchwebservicesvirtualdirectory[:dsc_identity] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xexchwebservicesvirtualdirectory[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xexchwebservicesvirtualdirectory[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xgroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xgroup_spec.rb
@@ -164,6 +164,10 @@ describe Puppet::Type.type(:dsc_xgroup) do
     expect{dsc_xgroup[:dsc_memberstoexclude] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xgroup[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xgroup[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xhotfix_spec.rb
+++ b/spec/unit/puppet/type/dsc_xhotfix_spec.rb
@@ -127,6 +127,10 @@ describe Puppet::Type.type(:dsc_xhotfix) do
     expect{dsc_xhotfix[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xhotfix[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xhotfix[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xmysqldatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqldatabase_spec.rb
@@ -93,6 +93,10 @@ describe Puppet::Type.type(:dsc_xmysqldatabase) do
     expect{dsc_xmysqldatabase[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_connectioncredential" do
+    expect{dsc_xmysqldatabase[:dsc_connectioncredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_connectioncredential' do
     expect{dsc_xmysqldatabase[:dsc_connectioncredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xmysqlgrant_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqlgrant_spec.rb
@@ -73,6 +73,10 @@ describe Puppet::Type.type(:dsc_xmysqlgrant) do
     expect{dsc_xmysqlgrant[:dsc_databasename] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_connectioncredential" do
+    expect{dsc_xmysqlgrant[:dsc_connectioncredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_connectioncredential' do
     expect{dsc_xmysqlgrant[:dsc_connectioncredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xmysqlserver_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqlserver_spec.rb
@@ -93,6 +93,10 @@ describe Puppet::Type.type(:dsc_xmysqlserver) do
     expect{dsc_xmysqlserver[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_rootpassword" do
+    expect{dsc_xmysqlserver[:dsc_rootpassword] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_rootpassword' do
     expect{dsc_xmysqlserver[:dsc_rootpassword] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xmysqluser_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmysqluser_spec.rb
@@ -44,6 +44,10 @@ describe Puppet::Type.type(:dsc_xmysqluser) do
     expect{dsc_xmysqluser[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xmysqluser[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xmysqluser[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -58,6 +62,10 @@ describe Puppet::Type.type(:dsc_xmysqluser) do
 
   it 'should not accept uint for dsc_credential' do
     expect{dsc_xmysqluser[:dsc_credential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_connectioncredential" do
+    expect{dsc_xmysqluser[:dsc_connectioncredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_connectioncredential' do

--- a/spec/unit/puppet/type/dsc_xpackage_spec.rb
+++ b/spec/unit/puppet/type/dsc_xpackage_spec.rb
@@ -193,6 +193,10 @@ describe Puppet::Type.type(:dsc_xpackage) do
     expect{dsc_xpackage[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xpackage[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xpackage[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -386,6 +390,10 @@ describe Puppet::Type.type(:dsc_xpackage) do
 
   it 'should not accept uint for dsc_installed' do
     expect{dsc_xpackage[:dsc_installed] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_runascredential" do
+    expect{dsc_xpackage[:dsc_runascredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_runascredential' do

--- a/spec/unit/puppet/type/dsc_xpsendpoint_spec.rb
+++ b/spec/unit/puppet/type/dsc_xpsendpoint_spec.rb
@@ -112,6 +112,10 @@ describe Puppet::Type.type(:dsc_xpsendpoint) do
     expect{dsc_xpsendpoint[:dsc_startupscript] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_runascredential" do
+    expect{dsc_xpsendpoint[:dsc_runascredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_runascredential' do
     expect{dsc_xpsendpoint[:dsc_runascredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xremotefile_spec.rb
+++ b/spec/unit/puppet/type/dsc_xremotefile_spec.rb
@@ -95,6 +95,10 @@ describe Puppet::Type.type(:dsc_xremotefile) do
     expect{dsc_xremotefile[:dsc_headers] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xremotefile[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xremotefile[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscdpmconsolesetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscdpmconsolesetup_spec.rb
@@ -110,6 +110,10 @@ describe Puppet::Type.type(:dsc_xscdpmconsolesetup) do
     expect{dsc_xscdpmconsolesetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscdpmconsolesetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscdpmconsolesetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscdpmdatabaseserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscdpmdatabaseserversetup_spec.rb
@@ -110,6 +110,10 @@ describe Puppet::Type.type(:dsc_xscdpmdatabaseserversetup) do
     expect{dsc_xscdpmdatabaseserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscdpmdatabaseserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscdpmdatabaseserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscdpmserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscdpmserversetup_spec.rb
@@ -120,6 +120,10 @@ describe Puppet::Type.type(:dsc_xscdpmserversetup) do
     expect{dsc_xscdpmserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscdpmserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscdpmserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -232,6 +236,10 @@ describe Puppet::Type.type(:dsc_xscdpmserversetup) do
     expect{dsc_xscdpmserversetup[:dsc_yukoninstancename] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_yukonmachinecredential" do
+    expect{dsc_xscdpmserversetup[:dsc_yukonmachinecredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_yukonmachinecredential' do
     expect{dsc_xscdpmserversetup[:dsc_yukonmachinecredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -278,6 +286,10 @@ describe Puppet::Type.type(:dsc_xscdpmserversetup) do
 
   it 'should not accept uint for dsc_reportinginstancename' do
     expect{dsc_xscdpmserversetup[:dsc_reportinginstancename] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_reportingmachinecredential" do
+    expect{dsc_xscdpmserversetup[:dsc_reportingmachinecredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_reportingmachinecredential' do

--- a/spec/unit/puppet/type/dsc_xscomadmin_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomadmin_spec.rb
@@ -121,6 +121,10 @@ describe Puppet::Type.type(:dsc_xscomadmin) do
     expect{dsc_xscomadmin[:dsc_userrole] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_scomadmincredential" do
+    expect{dsc_xscomadmin[:dsc_scomadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_scomadmincredential' do
     expect{dsc_xscomadmin[:dsc_scomadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscomconsolesetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomconsolesetup_spec.rb
@@ -115,6 +115,10 @@ describe Puppet::Type.type(:dsc_xscomconsolesetup) do
     expect{dsc_xscomconsolesetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscomconsolesetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscomconsolesetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscomconsoleupdate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomconsoleupdate_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xscomconsoleupdate) do
     expect{dsc_xscomconsoleupdate[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscomconsoleupdate[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscomconsoleupdate[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscommanagementpack_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscommanagementpack_spec.rb
@@ -75,6 +75,10 @@ describe Puppet::Type.type(:dsc_xscommanagementpack) do
     expect{dsc_xscommanagementpack[:dsc_minversion] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_scomadmincredential" do
+    expect{dsc_xscommanagementpack[:dsc_scomadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_scomadmincredential' do
     expect{dsc_xscommanagementpack[:dsc_scomadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscommanagementserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscommanagementserversetup_spec.rb
@@ -133,6 +133,10 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect{dsc_xscommanagementserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscommanagementserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscommanagementserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -279,6 +283,10 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect(dsc_xscommanagementserversetup[:dsc_managementserviceport]).to eq(64)
   end
 
+  it "should not accept empty password for dsc_actionaccount" do
+    expect{dsc_xscommanagementserversetup[:dsc_actionaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_actionaccount' do
     expect{dsc_xscommanagementserversetup[:dsc_actionaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -309,6 +317,10 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
 
   it 'should not accept uint for dsc_actionaccountusername' do
     expect{dsc_xscommanagementserversetup[:dsc_actionaccountusername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_dasaccount" do
+    expect{dsc_xscommanagementserversetup[:dsc_dasaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_dasaccount' do
@@ -343,6 +355,10 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect{dsc_xscommanagementserversetup[:dsc_dasaccountusername] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_datareader" do
+    expect{dsc_xscommanagementserversetup[:dsc_datareader] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_datareader' do
     expect{dsc_xscommanagementserversetup[:dsc_datareader] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -373,6 +389,10 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
 
   it 'should not accept uint for dsc_datareaderusername' do
     expect{dsc_xscommanagementserversetup[:dsc_datareaderusername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_datawriter" do
+    expect{dsc_xscommanagementserversetup[:dsc_datawriter] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_datawriter' do

--- a/spec/unit/puppet/type/dsc_xscommanagementserverupdate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscommanagementserverupdate_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xscommanagementserverupdate) do
     expect{dsc_xscommanagementserverupdate[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscommanagementserverupdate[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscommanagementserverupdate[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscomreportingserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomreportingserversetup_spec.rb
@@ -119,6 +119,10 @@ describe Puppet::Type.type(:dsc_xscomreportingserversetup) do
     expect{dsc_xscomreportingserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscomreportingserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscomreportingserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -181,6 +185,10 @@ describe Puppet::Type.type(:dsc_xscomreportingserversetup) do
 
   it 'should not accept uint for dsc_srsinstance' do
     expect{dsc_xscomreportingserversetup[:dsc_srsinstance] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_datareader" do
+    expect{dsc_xscomreportingserversetup[:dsc_datareader] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_datareader' do

--- a/spec/unit/puppet/type/dsc_xscomwebconsoleserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomwebconsoleserversetup_spec.rb
@@ -119,6 +119,10 @@ describe Puppet::Type.type(:dsc_xscomwebconsoleserversetup) do
     expect{dsc_xscomwebconsoleserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscomwebconsoleserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscomwebconsoleserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscomwebconsoleserverupdate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomwebconsoleserverupdate_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xscomwebconsoleserverupdate) do
     expect{dsc_xscomwebconsoleserverupdate[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscomwebconsoleserverupdate[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscomwebconsoleserverupdate[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscsmapowershellsetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscsmapowershellsetup_spec.rb
@@ -110,6 +110,10 @@ describe Puppet::Type.type(:dsc_xscsmapowershellsetup) do
     expect{dsc_xscsmapowershellsetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscsmapowershellsetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscsmapowershellsetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscsmarunbookworkerserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscsmarunbookworkerserversetup_spec.rb
@@ -120,6 +120,10 @@ describe Puppet::Type.type(:dsc_xscsmarunbookworkerserversetup) do
     expect{dsc_xscsmarunbookworkerserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscsmarunbookworkerserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscsmarunbookworkerserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -134,6 +138,10 @@ describe Puppet::Type.type(:dsc_xscsmarunbookworkerserversetup) do
 
   it 'should not accept uint for dsc_setupcredential' do
     expect{dsc_xscsmarunbookworkerserversetup[:dsc_setupcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_service" do
+    expect{dsc_xscsmarunbookworkerserversetup[:dsc_service] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_service' do

--- a/spec/unit/puppet/type/dsc_xscsmawebserviceserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscsmawebserviceserversetup_spec.rb
@@ -128,6 +128,10 @@ describe Puppet::Type.type(:dsc_xscsmawebserviceserversetup) do
     expect{dsc_xscsmawebserviceserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscsmawebserviceserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscsmawebserviceserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -189,6 +193,10 @@ describe Puppet::Type.type(:dsc_xscsmawebserviceserversetup) do
 
   it 'should not accept uint for dsc_firstwebserviceserver' do
     expect{dsc_xscsmawebserviceserversetup[:dsc_firstwebserviceserver] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_appool" do
+    expect{dsc_xscsmawebserviceserversetup[:dsc_appool] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_appool' do

--- a/spec/unit/puppet/type/dsc_xscspfserver_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscspfserver_spec.rb
@@ -184,6 +184,10 @@ describe Puppet::Type.type(:dsc_xscspfserver) do
     expect{dsc_xscspfserver[:dsc_servertype] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_scspfadmincredential" do
+    expect{dsc_xscspfserver[:dsc_scspfadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_scspfadmincredential' do
     expect{dsc_xscspfserver[:dsc_scspfadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscspfserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscspfserversetup_spec.rb
@@ -130,6 +130,10 @@ describe Puppet::Type.type(:dsc_xscspfserversetup) do
     expect{dsc_xscspfserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscspfserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscspfserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -343,6 +347,10 @@ describe Puppet::Type.type(:dsc_xscspfserversetup) do
     expect(dsc_xscspfserversetup[:dsc_websiteportnumber]).to eq(64)
   end
 
+  it "should not accept empty password for dsc_scvmm" do
+    expect{dsc_xscspfserversetup[:dsc_scvmm] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_scvmm' do
     expect{dsc_xscspfserversetup[:dsc_scvmm] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -373,6 +381,10 @@ describe Puppet::Type.type(:dsc_xscspfserversetup) do
 
   it 'should not accept uint for dsc_scvmmusername' do
     expect{dsc_xscspfserversetup[:dsc_scvmmusername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_scadmin" do
+    expect{dsc_xscspfserversetup[:dsc_scadmin] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_scadmin' do
@@ -407,6 +419,10 @@ describe Puppet::Type.type(:dsc_xscspfserversetup) do
     expect{dsc_xscspfserversetup[:dsc_scadminusername] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_scprovider" do
+    expect{dsc_xscspfserversetup[:dsc_scprovider] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_scprovider' do
     expect{dsc_xscspfserversetup[:dsc_scprovider] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -437,6 +453,10 @@ describe Puppet::Type.type(:dsc_xscspfserversetup) do
 
   it 'should not accept uint for dsc_scproviderusername' do
     expect{dsc_xscspfserversetup[:dsc_scproviderusername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_scusage" do
+    expect{dsc_xscspfserversetup[:dsc_scusage] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_scusage' do

--- a/spec/unit/puppet/type/dsc_xscspfserverupdate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscspfserverupdate_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xscspfserverupdate) do
     expect{dsc_xscspfserverupdate[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscspfserverupdate[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscspfserverupdate[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscspfsetting_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscspfsetting_spec.rb
@@ -181,6 +181,10 @@ describe Puppet::Type.type(:dsc_xscspfsetting) do
     expect{dsc_xscspfsetting[:dsc_value] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_scspfadmincredential" do
+    expect{dsc_xscspfsetting[:dsc_scspfadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_scspfadmincredential' do
     expect{dsc_xscspfsetting[:dsc_scspfadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscspfstamp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscspfstamp_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xscspfstamp) do
     expect{dsc_xscspfstamp[:dsc_servers] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_scspfadmincredential" do
+    expect{dsc_xscspfstamp[:dsc_scspfadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_scspfadmincredential' do
     expect{dsc_xscspfstamp[:dsc_scspfadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscsrserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscsrserversetup_spec.rb
@@ -121,6 +121,10 @@ describe Puppet::Type.type(:dsc_xscsrserversetup) do
     expect{dsc_xscsrserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscsrserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscsrserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscsrserverupdate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscsrserverupdate_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xscsrserverupdate) do
     expect{dsc_xscsrserverupdate[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscsrserverupdate[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscsrserverupdate[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscvmmadmin_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscvmmadmin_spec.rb
@@ -121,6 +121,10 @@ describe Puppet::Type.type(:dsc_xscvmmadmin) do
     expect{dsc_xscvmmadmin[:dsc_userrole] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_scvmmadmincredential" do
+    expect{dsc_xscvmmadmin[:dsc_scvmmadmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_scvmmadmincredential' do
     expect{dsc_xscvmmadmin[:dsc_scvmmadmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscvmmconsolesetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscvmmconsolesetup_spec.rb
@@ -113,6 +113,10 @@ describe Puppet::Type.type(:dsc_xscvmmconsolesetup) do
     expect{dsc_xscvmmconsolesetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscvmmconsolesetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscvmmconsolesetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscvmmconsoleupdate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscvmmconsoleupdate_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xscvmmconsoleupdate) do
     expect{dsc_xscvmmconsoleupdate[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscvmmconsoleupdate[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscvmmconsoleupdate[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xscvmmmanagementserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscvmmmanagementserversetup_spec.rb
@@ -139,6 +139,10 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscvmmmanagementserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscvmmmanagementserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -153,6 +157,10 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
 
   it 'should not accept uint for dsc_setupcredential' do
     expect{dsc_xscvmmmanagementserversetup[:dsc_setupcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_vmmservice" do
+    expect{dsc_xscvmmmanagementserversetup[:dsc_vmmservice] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_vmmservice' do

--- a/spec/unit/puppet/type/dsc_xscvmmmanagementserverupdate_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscvmmmanagementserverupdate_spec.rb
@@ -111,6 +111,10 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserverupdate) do
     expect{dsc_xscvmmmanagementserverupdate[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xscvmmmanagementserverupdate[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xscvmmmanagementserverupdate[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xservice_spec.rb
@@ -191,6 +191,10 @@ describe Puppet::Type.type(:dsc_xservice) do
     expect{dsc_xservice[:dsc_builtinaccount] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xservice[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xservice[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspbcsserviceapp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspbcsserviceapp_spec.rb
@@ -89,6 +89,10 @@ describe Puppet::Type.type(:dsc_xspbcsserviceapp) do
     expect{dsc_xspbcsserviceapp[:dsc_databaseserver] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspbcsserviceapp[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspbcsserviceapp[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspcacheaccounts_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspcacheaccounts_spec.rb
@@ -72,6 +72,10 @@ describe Puppet::Type.type(:dsc_xspcacheaccounts) do
     expect{dsc_xspcacheaccounts[:dsc_superreaderalias] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspcacheaccounts[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspcacheaccounts[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspcreatefarm_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspcreatefarm_spec.rb
@@ -71,6 +71,10 @@ describe Puppet::Type.type(:dsc_xspcreatefarm) do
     expect{dsc_xspcreatefarm[:dsc_databaseserver] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_farmaccount" do
+    expect{dsc_xspcreatefarm[:dsc_farmaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_farmaccount' do
     expect{dsc_xspcreatefarm[:dsc_farmaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -85,6 +89,10 @@ describe Puppet::Type.type(:dsc_xspcreatefarm) do
 
   it 'should not accept uint for dsc_farmaccount' do
     expect{dsc_xspcreatefarm[:dsc_farmaccount] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspcreatefarm[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_installaccount' do

--- a/spec/unit/puppet/type/dsc_xspdiagnosticloggingsettings_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspdiagnosticloggingsettings_spec.rb
@@ -758,6 +758,10 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_scripterrorreportingrequireauth] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspdiagnosticloggingsettings[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspdistributedcacheservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspdistributedcacheservice_spec.rb
@@ -147,6 +147,10 @@ describe Puppet::Type.type(:dsc_xspdistributedcacheservice) do
     expect{dsc_xspdistributedcacheservice[:dsc_serviceaccount] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspdistributedcacheservice[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspdistributedcacheservice[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspfeature_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspfeature_spec.rb
@@ -133,6 +133,10 @@ describe Puppet::Type.type(:dsc_xspfeature) do
     expect{dsc_xspfeature[:dsc_url] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspfeature[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspfeature[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspjoinfarm_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspjoinfarm_spec.rb
@@ -73,6 +73,10 @@ describe Puppet::Type.type(:dsc_xspjoinfarm) do
     expect{dsc_xspjoinfarm[:dsc_databaseserver] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_farmaccount" do
+    expect{dsc_xspjoinfarm[:dsc_farmaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_farmaccount' do
     expect{dsc_xspjoinfarm[:dsc_farmaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -87,6 +91,10 @@ describe Puppet::Type.type(:dsc_xspjoinfarm) do
 
   it 'should not accept uint for dsc_farmaccount' do
     expect{dsc_xspjoinfarm[:dsc_farmaccount] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspjoinfarm[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_installaccount' do

--- a/spec/unit/puppet/type/dsc_xspmanagedaccount_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspmanagedaccount_spec.rb
@@ -42,6 +42,10 @@ describe Puppet::Type.type(:dsc_xspmanagedaccount) do
     expect{dsc_xspmanagedaccount[:dsc_accountname] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_account" do
+    expect{dsc_xspmanagedaccount[:dsc_account] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_account' do
     expect{dsc_xspmanagedaccount[:dsc_account] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -56,6 +60,10 @@ describe Puppet::Type.type(:dsc_xspmanagedaccount) do
 
   it 'should not accept uint for dsc_account' do
     expect{dsc_xspmanagedaccount[:dsc_account] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspmanagedaccount[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_installaccount' do

--- a/spec/unit/puppet/type/dsc_xspmanagedmetadataserviceapp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspmanagedmetadataserviceapp_spec.rb
@@ -41,6 +41,10 @@ describe Puppet::Type.type(:dsc_xspmanagedmetadataserviceapp) do
     expect{dsc_xspmanagedmetadataserviceapp[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspmanagedmetadataserviceapp[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspmanagedmetadataserviceapp[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspmanagedpath_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspmanagedpath_spec.rb
@@ -42,6 +42,10 @@ describe Puppet::Type.type(:dsc_xspmanagedpath) do
     expect{dsc_xspmanagedpath[:dsc_webappurl] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspmanagedpath[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspmanagedpath[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspsearchserviceapp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspsearchserviceapp_spec.rb
@@ -89,6 +89,10 @@ describe Puppet::Type.type(:dsc_xspsearchserviceapp) do
     expect{dsc_xspsearchserviceapp[:dsc_databaseserver] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspsearchserviceapp[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspsearchserviceapp[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspsecurestoreserviceapp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspsecurestoreserviceapp_spec.rb
@@ -147,6 +147,10 @@ describe Puppet::Type.type(:dsc_xspsecurestoreserviceapp) do
     expect(dsc_xspsecurestoreserviceapp[:dsc_auditlogmaxsize]).to eq(64)
   end
 
+  it "should not accept empty password for dsc_databasecredentials" do
+    expect{dsc_xspsecurestoreserviceapp[:dsc_databasecredentials] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_databasecredentials' do
     expect{dsc_xspsecurestoreserviceapp[:dsc_databasecredentials] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -335,6 +339,10 @@ describe Puppet::Type.type(:dsc_xspsecurestoreserviceapp) do
 
   it 'should not accept uint for dsc_sharing' do
     expect{dsc_xspsecurestoreserviceapp[:dsc_sharing] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspsecurestoreserviceapp[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_installaccount' do

--- a/spec/unit/puppet/type/dsc_xspserviceapppool_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspserviceapppool_spec.rb
@@ -55,6 +55,10 @@ describe Puppet::Type.type(:dsc_xspserviceapppool) do
     expect{dsc_xspserviceapppool[:dsc_serviceaccount] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspserviceapppool[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspserviceapppool[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspserviceinstance_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspserviceinstance_spec.rb
@@ -43,6 +43,10 @@ describe Puppet::Type.type(:dsc_xspserviceinstance) do
     expect{dsc_xspserviceinstance[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspserviceinstance[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspserviceinstance[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspsite_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspsite_spec.rb
@@ -280,6 +280,10 @@ describe Puppet::Type.type(:dsc_xspsite) do
     expect{dsc_xspsite[:dsc_template] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspsite[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspsite[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspstateserviceapp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspstateserviceapp_spec.rb
@@ -41,6 +41,10 @@ describe Puppet::Type.type(:dsc_xspstateserviceapp) do
     expect{dsc_xspstateserviceapp[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_databasecredentials" do
+    expect{dsc_xspstateserviceapp[:dsc_databasecredentials] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_databasecredentials' do
     expect{dsc_xspstateserviceapp[:dsc_databasecredentials] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -87,6 +91,10 @@ describe Puppet::Type.type(:dsc_xspstateserviceapp) do
 
   it 'should not accept uint for dsc_databaseserver' do
     expect{dsc_xspstateserviceapp[:dsc_databaseserver] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspstateserviceapp[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_installaccount' do

--- a/spec/unit/puppet/type/dsc_xspusageapplication_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspusageapplication_spec.rb
@@ -47,6 +47,10 @@ describe Puppet::Type.type(:dsc_xspusageapplication) do
     expect{dsc_xspusageapplication[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspusageapplication[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspusageapplication[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xspuserprofileserviceapp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspuserprofileserviceapp_spec.rb
@@ -63,6 +63,10 @@ describe Puppet::Type.type(:dsc_xspuserprofileserviceapp) do
     expect{dsc_xspuserprofileserviceapp[:dsc_applicationpool] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_farmaccount" do
+    expect{dsc_xspuserprofileserviceapp[:dsc_farmaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_farmaccount' do
     expect{dsc_xspuserprofileserviceapp[:dsc_farmaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -77,6 +81,10 @@ describe Puppet::Type.type(:dsc_xspuserprofileserviceapp) do
 
   it 'should not accept uint for dsc_farmaccount' do
     expect{dsc_xspuserprofileserviceapp[:dsc_farmaccount] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspuserprofileserviceapp[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_installaccount' do

--- a/spec/unit/puppet/type/dsc_xspuserprofilesyncservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspuserprofilesyncservice_spec.rb
@@ -94,6 +94,10 @@ describe Puppet::Type.type(:dsc_xspuserprofilesyncservice) do
     expect{dsc_xspuserprofilesyncservice[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_farmaccount" do
+    expect{dsc_xspuserprofilesyncservice[:dsc_farmaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_farmaccount' do
     expect{dsc_xspuserprofilesyncservice[:dsc_farmaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -108,6 +112,10 @@ describe Puppet::Type.type(:dsc_xspuserprofilesyncservice) do
 
   it 'should not accept uint for dsc_farmaccount' do
     expect{dsc_xspuserprofilesyncservice[:dsc_farmaccount] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspuserprofilesyncservice[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_installaccount' do

--- a/spec/unit/puppet/type/dsc_xspwebapplication_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspwebapplication_spec.rb
@@ -263,6 +263,10 @@ describe Puppet::Type.type(:dsc_xspwebapplication) do
     expect{dsc_xspwebapplication[:dsc_port] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_installaccount" do
+    expect{dsc_xspwebapplication[:dsc_installaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_installaccount' do
     expect{dsc_xspwebapplication[:dsc_installaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xsqlhagroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlhagroup_spec.rb
@@ -125,6 +125,10 @@ describe Puppet::Type.type(:dsc_xsqlhagroup) do
     expect{dsc_xsqlhagroup[:dsc_endpointname] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_domaincredential" do
+    expect{dsc_xsqlhagroup[:dsc_domaincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_domaincredential' do
     expect{dsc_xsqlhagroup[:dsc_domaincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -139,6 +143,10 @@ describe Puppet::Type.type(:dsc_xsqlhagroup) do
 
   it 'should not accept uint for dsc_domaincredential' do
     expect{dsc_xsqlhagroup[:dsc_domaincredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_sqladministratorcredential" do
+    expect{dsc_xsqlhagroup[:dsc_sqladministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_sqladministratorcredential' do

--- a/spec/unit/puppet/type/dsc_xsqlhaservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlhaservice_spec.rb
@@ -39,6 +39,10 @@ describe Puppet::Type.type(:dsc_xsqlhaservice) do
     expect{dsc_xsqlhaservice[:dsc_instancename] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_sqladministratorcredential" do
+    expect{dsc_xsqlhaservice[:dsc_sqladministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_sqladministratorcredential' do
     expect{dsc_xsqlhaservice[:dsc_sqladministratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -53,6 +57,10 @@ describe Puppet::Type.type(:dsc_xsqlhaservice) do
 
   it 'should not accept uint for dsc_sqladministratorcredential' do
     expect{dsc_xsqlhaservice[:dsc_sqladministratorcredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_servicecredential" do
+    expect{dsc_xsqlhaservice[:dsc_servicecredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_servicecredential' do

--- a/spec/unit/puppet/type/dsc_xsqlserverfailoverclustersetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlserverfailoverclustersetup_spec.rb
@@ -137,6 +137,10 @@ describe Puppet::Type.type(:dsc_xsqlserverfailoverclustersetup) do
     expect{dsc_xsqlserverfailoverclustersetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xsqlserverfailoverclustersetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xsqlserverfailoverclustersetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -427,6 +431,10 @@ describe Puppet::Type.type(:dsc_xsqlserverfailoverclustersetup) do
     expect{dsc_xsqlserverfailoverclustersetup[:dsc_instancedir] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_sqlsvcaccount" do
+    expect{dsc_xsqlserverfailoverclustersetup[:dsc_sqlsvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_sqlsvcaccount' do
     expect{dsc_xsqlserverfailoverclustersetup[:dsc_sqlsvcaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -457,6 +465,10 @@ describe Puppet::Type.type(:dsc_xsqlserverfailoverclustersetup) do
 
   it 'should not accept uint for dsc_sqlsvcaccountusername' do
     expect{dsc_xsqlserverfailoverclustersetup[:dsc_sqlsvcaccountusername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_agtsvcaccount" do
+    expect{dsc_xsqlserverfailoverclustersetup[:dsc_agtsvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_agtsvcaccount' do
@@ -538,6 +550,10 @@ describe Puppet::Type.type(:dsc_xsqlserverfailoverclustersetup) do
 
   it 'should not accept uint for dsc_securitymode' do
     expect{dsc_xsqlserverfailoverclustersetup[:dsc_securitymode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_sapwd" do
+    expect{dsc_xsqlserverfailoverclustersetup[:dsc_sapwd] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_sapwd' do
@@ -650,6 +666,10 @@ describe Puppet::Type.type(:dsc_xsqlserverfailoverclustersetup) do
 
   it 'should not accept uint for dsc_sqlbackupdir' do
     expect{dsc_xsqlserverfailoverclustersetup[:dsc_sqlbackupdir] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_assvcaccount" do
+    expect{dsc_xsqlserverfailoverclustersetup[:dsc_assvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_assvcaccount' do
@@ -795,6 +815,10 @@ describe Puppet::Type.type(:dsc_xsqlserverfailoverclustersetup) do
 
   it 'should not accept uint for dsc_asconfigdir' do
     expect{dsc_xsqlserverfailoverclustersetup[:dsc_asconfigdir] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_issvcaccount" do
+    expect{dsc_xsqlserverfailoverclustersetup[:dsc_issvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_issvcaccount' do

--- a/spec/unit/puppet/type/dsc_xsqlserverinstall_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlserverinstall_spec.rb
@@ -61,6 +61,10 @@ describe Puppet::Type.type(:dsc_xsqlserverinstall) do
     expect{dsc_xsqlserverinstall[:dsc_sourcepath] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_sourcepathcredential" do
+    expect{dsc_xsqlserverinstall[:dsc_sourcepathcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_sourcepathcredential' do
     expect{dsc_xsqlserverinstall[:dsc_sourcepathcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -91,6 +95,10 @@ describe Puppet::Type.type(:dsc_xsqlserverinstall) do
 
   it 'should not accept uint for dsc_features' do
     expect{dsc_xsqlserverinstall[:dsc_features] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_sqladministratorcredential" do
+    expect{dsc_xsqlserverinstall[:dsc_sqladministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_sqladministratorcredential' do

--- a/spec/unit/puppet/type/dsc_xsqlserverrsconfig_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlserverrsconfig_spec.rb
@@ -73,6 +73,10 @@ describe Puppet::Type.type(:dsc_xsqlserverrsconfig) do
     expect{dsc_xsqlserverrsconfig[:dsc_rssqlinstancename] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_sqladmincredential" do
+    expect{dsc_xsqlserverrsconfig[:dsc_sqladmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_sqladmincredential' do
     expect{dsc_xsqlserverrsconfig[:dsc_sqladmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xsqlserverrssecureconnectionlevel_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlserverrssecureconnectionlevel_spec.rb
@@ -84,6 +84,10 @@ describe Puppet::Type.type(:dsc_xsqlserverrssecureconnectionlevel) do
     expect(dsc_xsqlserverrssecureconnectionlevel[:dsc_secureconnectionlevel]).to eq(64)
   end
 
+  it "should not accept empty password for dsc_sqladmincredential" do
+    expect{dsc_xsqlserverrssecureconnectionlevel[:dsc_sqladmincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_sqladmincredential' do
     expect{dsc_xsqlserverrssecureconnectionlevel[:dsc_sqladmincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xsqlserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlserversetup_spec.rb
@@ -46,6 +46,10 @@ describe Puppet::Type.type(:dsc_xsqlserversetup) do
     expect{dsc_xsqlserversetup[:dsc_sourcefolder] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_setupcredential" do
+    expect{dsc_xsqlserversetup[:dsc_setupcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_setupcredential' do
     expect{dsc_xsqlserversetup[:dsc_setupcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -287,6 +291,10 @@ describe Puppet::Type.type(:dsc_xsqlserversetup) do
     expect{dsc_xsqlserversetup[:dsc_instancedir] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_sqlsvcaccount" do
+    expect{dsc_xsqlserversetup[:dsc_sqlsvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_sqlsvcaccount' do
     expect{dsc_xsqlserversetup[:dsc_sqlsvcaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -317,6 +325,10 @@ describe Puppet::Type.type(:dsc_xsqlserversetup) do
 
   it 'should not accept uint for dsc_sqlsvcaccountusername' do
     expect{dsc_xsqlserversetup[:dsc_sqlsvcaccountusername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_agtsvcaccount" do
+    expect{dsc_xsqlserversetup[:dsc_agtsvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_agtsvcaccount' do
@@ -398,6 +410,10 @@ describe Puppet::Type.type(:dsc_xsqlserversetup) do
 
   it 'should not accept uint for dsc_securitymode' do
     expect{dsc_xsqlserversetup[:dsc_securitymode] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_sapwd" do
+    expect{dsc_xsqlserversetup[:dsc_sapwd] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_sapwd' do
@@ -512,6 +528,10 @@ describe Puppet::Type.type(:dsc_xsqlserversetup) do
     expect{dsc_xsqlserversetup[:dsc_sqlbackupdir] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_ftsvcaccount" do
+    expect{dsc_xsqlserversetup[:dsc_ftsvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_ftsvcaccount' do
     expect{dsc_xsqlserversetup[:dsc_ftsvcaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -544,6 +564,10 @@ describe Puppet::Type.type(:dsc_xsqlserversetup) do
     expect{dsc_xsqlserversetup[:dsc_ftsvcaccountusername] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_rssvcaccount" do
+    expect{dsc_xsqlserversetup[:dsc_rssvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_rssvcaccount' do
     expect{dsc_xsqlserversetup[:dsc_rssvcaccount] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -574,6 +598,10 @@ describe Puppet::Type.type(:dsc_xsqlserversetup) do
 
   it 'should not accept uint for dsc_rssvcaccountusername' do
     expect{dsc_xsqlserversetup[:dsc_rssvcaccountusername] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_assvcaccount" do
+    expect{dsc_xsqlserversetup[:dsc_assvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_assvcaccount' do
@@ -719,6 +747,10 @@ describe Puppet::Type.type(:dsc_xsqlserversetup) do
 
   it 'should not accept uint for dsc_asconfigdir' do
     expect{dsc_xsqlserversetup[:dsc_asconfigdir] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_issvcaccount" do
+    expect{dsc_xsqlserversetup[:dsc_issvcaccount] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_issvcaccount' do

--- a/spec/unit/puppet/type/dsc_xwaitforaddomain_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitforaddomain_spec.rb
@@ -40,6 +40,10 @@ describe Puppet::Type.type(:dsc_xwaitforaddomain) do
     expect{dsc_xwaitforaddomain[:dsc_domainname] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_domainusercredential" do
+    expect{dsc_xwaitforaddomain[:dsc_domainusercredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_domainusercredential' do
     expect{dsc_xwaitforaddomain[:dsc_domainusercredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xwaitforsqlhagroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitforsqlhagroup_spec.rb
@@ -145,6 +145,10 @@ describe Puppet::Type.type(:dsc_xwaitforsqlhagroup) do
     expect{dsc_xwaitforsqlhagroup[:dsc_instancename] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_domaincredential" do
+    expect{dsc_xwaitforsqlhagroup[:dsc_domaincredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_domaincredential' do
     expect{dsc_xwaitforsqlhagroup[:dsc_domaincredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end
@@ -159,6 +163,10 @@ describe Puppet::Type.type(:dsc_xwaitforsqlhagroup) do
 
   it 'should not accept uint for dsc_domaincredential' do
     expect{dsc_xwaitforsqlhagroup[:dsc_domaincredential] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it "should not accept empty password for dsc_sqladministratorcredential" do
+    expect{dsc_xwaitforsqlhagroup[:dsc_sqladministratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
   end
 
   it 'should not accept array for dsc_sqladministratorcredential' do

--- a/spec/unit/puppet/type/dsc_xwindowsprocess_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwindowsprocess_spec.rb
@@ -89,6 +89,10 @@ describe Puppet::Type.type(:dsc_xwindowsprocess) do
     expect{dsc_xwindowsprocess[:dsc_arguments] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_credential" do
+    expect{dsc_xwindowsprocess[:dsc_credential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_credential' do
     expect{dsc_xwindowsprocess[:dsc_credential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end

--- a/spec/unit/puppet/type/dsc_xwordpresssite_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwordpresssite_spec.rb
@@ -61,6 +61,10 @@ describe Puppet::Type.type(:dsc_xwordpresssite) do
     expect{dsc_xwordpresssite[:dsc_title] = 16}.to raise_error(Puppet::ResourceError)
   end
 
+  it "should not accept empty password for dsc_administratorcredential" do
+    expect{dsc_xwordpresssite[:dsc_administratorcredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should not accept array for dsc_administratorcredential' do
     expect{dsc_xwordpresssite[:dsc_administratorcredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
   end


### PR DESCRIPTION
If an empty password is provided to any paramter that is a PSCredential
then we will fail.

Detect an empty password and warn the user it needs to be provided.