### PR TITLE
(MODULES-2615) Handle Empty Passwords for PSCredentials

### DIFF
--- a/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
@@ -44,6 +44,7 @@ module PuppetX
         required.each do |key|
           if value[key]
             fail "#{key} for #{name} should be a String" unless value[key].is_a? String
+            fail "#{key} must not be empty" if value[key].empty?
           end
         end
 
@@ -57,10 +58,6 @@ module PuppetX
         extraneous = specified_keys - required
         unless extraneous.empty?
           fail "#{name} includes invalid keys: #{extraneous.join(',')}"
-        end
-
-        if value.values.any?{|v| v.nil? || v.length == 0}
-          fail "Both User and Password must not be empty"
         end
       end
 

--- a/tests/acceptance/tests/basic_dsc_resources/user/negative/user_invalid_password.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/user/negative/user_invalid_password.rb
@@ -20,7 +20,7 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resourc
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
 # Verify
-error_msg = /Error:.*Both User and Password must not be empty/m
+error_msg = /Error:.*password must not be empty/m
 
 # Tests
 agents.each do |agent|


### PR DESCRIPTION
Handle checking if a username or password is not provided better by
checking in the first iteration and not a second time.