### PR TITLE
(MODULES-2562) Handle uint arrays

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -168,9 +168,19 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
       PuppetX::Dsc::TypeHelpers.validate_<%= property.embeddedinstance_class_name %>(<%= !property.credential? ? 'mof_type_map, ' : '' %>"<%= property.name %>", value)
 <%      end -%>
 <%    when property.array? -%>
+<%      if property.int_array? -%>
+      unless value.kind_of?(Array) || value.kind_of?(Numeric) || value.to_i.to_s == value
+        fail("Invalid value '#{value}'. Should be an integer or an array of integers")
+      end
+<%      elsif property.uint_array? -%>
+      unless value.kind_of?(Array) || (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+        fail("Invalid value '#{value}'. Should be an integer or an array of integers")
+      end
+<%      else -%>
       unless value.kind_of?(Array) || value.kind_of?(String)
         fail("Invalid value '#{value}'. Should be a string or an array of strings")
       end
+<%      end -%>
 <%    when property.bool? -%>
 <%    when property.int? -%>
       unless value.kind_of?(Numeric) || value.to_i.to_s == value
@@ -215,6 +225,9 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
       value.kind_of?(Hash) ?
         [PuppetX::Dsc::TypeHelpers.munge_embeddedinstance(mof_type_map, value)] :
         value.map { |v| PuppetX::Dsc::TypeHelpers.munge_embeddedinstance(mof_type_map, v) }
+<%     elsif (property.int_array? || property.uint_array?) -%>
+      v = PuppetX::Dsc::TypeHelpers.munge_integer(value)
+      v.is_a?(Array) ? v : Array(v)
 <%      else -%>
       Array(value)
 <%      end -%>
@@ -229,7 +242,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     end
 <%    when (property.int? || property.uint?) -%>
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
 <%    else -%>
 <%    end -%>

--- a/build/dsc/templates/dsc_type_spec.rb.erb
+++ b/build/dsc/templates/dsc_type_spec.rb.erb
@@ -162,6 +162,12 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
   end
 <%      end #  @spec_test_values['munged_ints']... -%>
 
+<%    elsif property.int_array? || property.int? || property.uint? || property.uint_array?  # if property.int? -%>
+
+  it 'should accept int for dsc_<%= property.name.downcase %>' do
+    dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>] = <%= format_type_value(@spec_test_values[property.type]) %>
+    expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq(<%= format_type_value(@spec_test_values[property.type]) %>)
+  end
 <%    else # if property.int? -%>
 
   it 'should not accept int for dsc_<%= property.name.downcase %>' do
@@ -181,6 +187,12 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
     expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq(<%= format_type_value(munged_uint.to_i) %>)
   end
 <%      end #  @spec_test_values['munged_ints']... -%>
+<%    elsif property.int_array? || property.int? || property.uint? || property.uint_array? # if property.uint? or property.int? -%>
+
+  it 'should accept uint for dsc_<%= property.name.downcase %>' do
+    dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>] = <%= format_type_value(@spec_test_values[property.type]) %>
+    expect(dsc_<%= resource.friendlyname.downcase %>[:dsc_<%= property.name.downcase %>]).to eq(<%= format_type_value(@spec_test_values[property.type]) %>)
+  end
 <%    else # if property.uint? or property.int? -%>
 
   it 'should not accept uint for dsc_<%= property.name.downcase %>' do

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -147,12 +147,13 @@ Puppet::Type.newtype(:dsc_package) do
     def mof_type; 'uint32[]' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Array) || value.kind_of?(String)
-        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      unless value.kind_of?(Array) || (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+        fail("Invalid value '#{value}'. Should be an integer or an array of integers")
       end
     end
     munge do |value|
-      Array(value)
+      v = PuppetX::Dsc::TypeHelpers.munge_integer(value)
+      v.is_a?(Array) ? v : Array(v)
     end
   end
 
@@ -225,7 +226,7 @@ Puppet::Type.newtype(:dsc_package) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -180,7 +180,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -197,7 +197,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -214,7 +214,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -231,7 +231,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -248,7 +248,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadcscertificationauthority.rb
+++ b/lib/puppet/type/dsc_xadcscertificationauthority.rb
@@ -271,7 +271,7 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -400,7 +400,7 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -194,7 +194,7 @@ Puppet::Type.newtype(:dsc_xarchive) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackfqdn.rb
+++ b/lib/puppet/type/dsc_xazurepackfqdn.rb
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackidentityprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackidentityprovider.rb
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackrelyingparty.rb
+++ b/lib/puppet/type/dsc_xazurepackrelyingparty.rb
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xblautobitlocker.rb
+++ b/lib/puppet/type/dsc_xblautobitlocker.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xdisk.rb
+++ b/lib/puppet/type/dsc_xdisk.rb
@@ -78,7 +78,7 @@ Puppet::Type.newtype(:dsc_xdisk) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -95,7 +95,7 @@ Puppet::Type.newtype(:dsc_xdisk) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -93,7 +93,7 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchautomountpoint.rb
+++ b/lib/puppet/type/dsc_xexchautomountpoint.rb
@@ -123,7 +123,7 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
@@ -93,7 +93,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -153,7 +153,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -170,7 +170,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -216,7 +216,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -359,7 +359,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchjetstress.rb
+++ b/lib/puppet/type/dsc_xexchjetstress.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xexchjetstress) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_xexchjetstress) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabase.rb
@@ -93,7 +93,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
@@ -136,7 +136,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
@@ -233,7 +233,7 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchreceiveconnector.rb
+++ b/lib/puppet/type/dsc_xexchreceiveconnector.rb
@@ -454,7 +454,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -485,7 +485,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -516,7 +516,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -533,7 +533,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -578,7 +578,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchwaitforadprep.rb
+++ b/lib/puppet/type/dsc_xexchwaitforadprep.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -132,7 +132,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -168,7 +168,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -186,7 +186,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchwaitfordag.rb
+++ b/lib/puppet/type/dsc_xexchwaitfordag.rb
@@ -107,7 +107,7 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -124,7 +124,7 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
@@ -121,7 +121,7 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -138,7 +138,7 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -94,7 +94,7 @@ Puppet::Type.newtype(:dsc_xipaddress) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xmppreference.rb
+++ b/lib/puppet/type/dsc_xmppreference.rb
@@ -152,7 +152,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -203,7 +203,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -221,7 +221,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -239,7 +239,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -257,7 +257,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -291,7 +291,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -391,7 +391,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -409,7 +409,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -506,7 +506,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -524,7 +524,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -832,7 +832,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -151,12 +151,13 @@ Puppet::Type.newtype(:dsc_xpackage) do
     def mof_type; 'uint32[]' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Array) || value.kind_of?(String)
-        fail("Invalid value '#{value}'. Should be a string or an array of strings")
+      unless value.kind_of?(Array) || (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+        fail("Invalid value '#{value}'. Should be an integer or an array of integers")
       end
     end
     munge do |value|
-      Array(value)
+      v = PuppetX::Dsc::TypeHelpers.munge_integer(value)
+      v.is_a?(Array) ? v : Array(v)
     end
   end
 
@@ -229,7 +230,7 @@ Puppet::Type.newtype(:dsc_xpackage) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xrdremoteapp.rb
+++ b/lib/puppet/type/dsc_xrdremoteapp.rb
@@ -191,7 +191,7 @@ Puppet::Type.newtype(:dsc_xrdremoteapp) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -237,7 +237,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -270,7 +270,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -288,7 +288,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xrobocopy.rb
+++ b/lib/puppet/type/dsc_xrobocopy.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscomconsolesetup.rb
@@ -146,7 +146,7 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -200,7 +200,7 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscommanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscommanagementserversetup.rb
@@ -192,7 +192,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -364,7 +364,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -412,7 +412,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -430,7 +430,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -448,7 +448,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -484,7 +484,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomreportingserversetup.rb
+++ b/lib/puppet/type/dsc_xscomreportingserversetup.rb
@@ -207,7 +207,7 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -225,7 +225,7 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -261,7 +261,7 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
@@ -210,7 +210,7 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -228,7 +228,7 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -264,7 +264,7 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
@@ -253,7 +253,7 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscspfserversetup.rb
+++ b/lib/puppet/type/dsc_xscspfserversetup.rb
@@ -207,7 +207,7 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -240,7 +240,7 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscvmmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscvmmconsolesetup.rb
@@ -146,7 +146,7 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
@@ -314,7 +314,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -332,7 +332,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -350,7 +350,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -368,7 +368,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -386,7 +386,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -404,7 +404,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -527,7 +527,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -545,7 +545,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -563,7 +563,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -581,7 +581,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -218,7 +218,7 @@ Puppet::Type.newtype(:dsc_xservice) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xspcreatefarm.rb
+++ b/lib/puppet/type/dsc_xspcreatefarm.rb
@@ -152,7 +152,7 @@ Puppet::Type.newtype(:dsc_xspcreatefarm) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xspdiagnosticloggingsettings.rb
+++ b/lib/puppet/type/dsc_xspdiagnosticloggingsettings.rb
@@ -78,7 +78,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -125,7 +125,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -202,7 +202,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -219,7 +219,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -236,7 +236,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -253,7 +253,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -270,7 +270,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -302,7 +302,7 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xspdistributedcacheservice.rb
+++ b/lib/puppet/type/dsc_xspdistributedcacheservice.rb
@@ -97,7 +97,7 @@ Puppet::Type.newtype(:dsc_xspdistributedcacheservice) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xspmanagedaccount.rb
+++ b/lib/puppet/type/dsc_xspmanagedaccount.rb
@@ -108,7 +108,7 @@ Puppet::Type.newtype(:dsc_xspmanagedaccount) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -125,7 +125,7 @@ Puppet::Type.newtype(:dsc_xspmanagedaccount) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xspsecurestoreserviceapp.rb
+++ b/lib/puppet/type/dsc_xspsecurestoreserviceapp.rb
@@ -107,7 +107,7 @@ Puppet::Type.newtype(:dsc_xspsecurestoreserviceapp) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xspsite.rb
+++ b/lib/puppet/type/dsc_xspsite.rb
@@ -92,7 +92,7 @@ Puppet::Type.newtype(:dsc_xspsite) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -151,7 +151,7 @@ Puppet::Type.newtype(:dsc_xspsite) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xspusageapplication.rb
+++ b/lib/puppet/type/dsc_xspusageapplication.rb
@@ -163,7 +163,7 @@ Puppet::Type.newtype(:dsc_xspusageapplication) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -194,7 +194,7 @@ Puppet::Type.newtype(:dsc_xspusageapplication) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -211,7 +211,7 @@ Puppet::Type.newtype(:dsc_xspusageapplication) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
+++ b/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
@@ -82,7 +82,7 @@ Puppet::Type.newtype(:dsc_xsqlserverrssecureconnectionlevel) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xvhd) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -198,7 +198,7 @@ Puppet::Type.newtype(:dsc_xvhd) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -180,7 +180,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -198,7 +198,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -231,7 +231,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -345,7 +345,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -363,7 +363,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -93,7 +93,7 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -110,7 +110,7 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwaitfordisk.rb
+++ b/lib/puppet/type/dsc_xwaitfordisk.rb
@@ -64,7 +64,7 @@ Puppet::Type.newtype(:dsc_xwaitfordisk) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:dsc_xwaitfordisk) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_xwaitfordisk) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -95,7 +95,7 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwefsubscription.rb
+++ b/lib/puppet/type/dsc_xwefsubscription.rb
@@ -169,7 +169,7 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -187,7 +187,7 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -205,7 +205,7 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -184,7 +184,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -201,7 +201,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -218,7 +218,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -235,7 +235,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 
@@ -252,7 +252,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
       end
     end
     munge do |value|
-      value.to_i
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
     end
   end
 

--- a/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
@@ -8,6 +8,10 @@ module PuppetX
         raise ArgumentError.new "invalid value: #{value}"
       end
 
+      def self.munge_integer(value)
+        value.is_a?(Array) ? value.map { |v| v.to_i } : value.to_i
+      end
+
       def self.munge_embeddedinstance(mof_type, embeddedinstance_value)
         remapped_value = embeddedinstance_value.map do |key, value|
           if mof_type[key.downcase]

--- a/spec/unit/puppet/type/dsc_package_spec.rb
+++ b/spec/unit/puppet/type/dsc_package_spec.rb
@@ -202,12 +202,14 @@ describe Puppet::Type.type(:dsc_package) do
     expect{dsc_package[:dsc_returncode] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_returncode' do
-    expect{dsc_package[:dsc_returncode] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_returncode' do
+    dsc_package[:dsc_returncode] = [32, 64, 128]
+    expect(dsc_package[:dsc_returncode]).to eq([32, 64, 128])
   end
 
-  it 'should not accept uint for dsc_returncode' do
-    expect{dsc_package[:dsc_returncode] = 16}.to raise_error(Puppet::ResourceError)
+  it 'should accept uint for dsc_returncode' do
+    dsc_package[:dsc_returncode] = [32, 64, 128]
+    expect(dsc_package[:dsc_returncode]).to eq([32, 64, 128])
   end
 
   it 'should not accept array for dsc_logpath' do
@@ -282,8 +284,9 @@ describe Puppet::Type.type(:dsc_package) do
     expect{dsc_package[:dsc_size] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_size' do
-    expect{dsc_package[:dsc_size] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_size' do
+    dsc_package[:dsc_size] = 32
+    expect(dsc_package[:dsc_size]).to eq(32)
   end
 
   it 'should accept uint for dsc_size' do

--- a/spec/unit/puppet/type/dsc_windowsprocess_spec.rb
+++ b/spec/unit/puppet/type/dsc_windowsprocess_spec.rb
@@ -231,8 +231,9 @@ describe Puppet::Type.type(:dsc_windowsprocess) do
     expect{dsc_windowsprocess[:dsc_pagedmemorysize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_pagedmemorysize' do
-    expect{dsc_windowsprocess[:dsc_pagedmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_pagedmemorysize' do
+    dsc_windowsprocess[:dsc_pagedmemorysize] = 64
+    expect(dsc_windowsprocess[:dsc_pagedmemorysize]).to eq(64)
   end
 
   it 'should accept uint for dsc_pagedmemorysize' do
@@ -266,8 +267,9 @@ describe Puppet::Type.type(:dsc_windowsprocess) do
     expect{dsc_windowsprocess[:dsc_nonpagedmemorysize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_nonpagedmemorysize' do
-    expect{dsc_windowsprocess[:dsc_nonpagedmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_nonpagedmemorysize' do
+    dsc_windowsprocess[:dsc_nonpagedmemorysize] = 64
+    expect(dsc_windowsprocess[:dsc_nonpagedmemorysize]).to eq(64)
   end
 
   it 'should accept uint for dsc_nonpagedmemorysize' do
@@ -301,8 +303,9 @@ describe Puppet::Type.type(:dsc_windowsprocess) do
     expect{dsc_windowsprocess[:dsc_virtualmemorysize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_virtualmemorysize' do
-    expect{dsc_windowsprocess[:dsc_virtualmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_virtualmemorysize' do
+    dsc_windowsprocess[:dsc_virtualmemorysize] = 64
+    expect(dsc_windowsprocess[:dsc_virtualmemorysize]).to eq(64)
   end
 
   it 'should accept uint for dsc_virtualmemorysize' do

--- a/spec/unit/puppet/type/dsc_xadcscertificationauthority_spec.rb
+++ b/spec/unit/puppet/type/dsc_xadcscertificationauthority_spec.rb
@@ -379,8 +379,9 @@ describe Puppet::Type.type(:dsc_xadcscertificationauthority) do
     expect{dsc_xadcscertificationauthority[:dsc_keylength] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_keylength' do
-    expect{dsc_xadcscertificationauthority[:dsc_keylength] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_keylength' do
+    dsc_xadcscertificationauthority[:dsc_keylength] = 32
+    expect(dsc_xadcscertificationauthority[:dsc_keylength]).to eq(32)
   end
 
   it 'should accept uint for dsc_keylength' do
@@ -663,8 +664,9 @@ describe Puppet::Type.type(:dsc_xadcscertificationauthority) do
     expect{dsc_xadcscertificationauthority[:dsc_validityperiodunits] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_validityperiodunits' do
-    expect{dsc_xadcscertificationauthority[:dsc_validityperiodunits] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_validityperiodunits' do
+    dsc_xadcscertificationauthority[:dsc_validityperiodunits] = 32
+    expect(dsc_xadcscertificationauthority[:dsc_validityperiodunits]).to eq(32)
   end
 
   it 'should accept uint for dsc_validityperiodunits' do

--- a/spec/unit/puppet/type/dsc_xarchive_spec.rb
+++ b/spec/unit/puppet/type/dsc_xarchive_spec.rb
@@ -255,8 +255,9 @@ describe Puppet::Type.type(:dsc_xarchive) do
     expect{dsc_xarchive[:dsc_size] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_size' do
-    expect{dsc_xarchive[:dsc_size] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_size' do
+    dsc_xarchive[:dsc_size] = 64
+    expect(dsc_xarchive[:dsc_size]).to eq(64)
   end
 
   it 'should accept uint for dsc_size' do

--- a/spec/unit/puppet/type/dsc_xazurepackfqdn_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackfqdn_spec.rb
@@ -110,8 +110,9 @@ describe Puppet::Type.type(:dsc_xazurepackfqdn) do
     expect{dsc_xazurepackfqdn[:dsc_port] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_port' do
-    expect{dsc_xazurepackfqdn[:dsc_port] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_port' do
+    dsc_xazurepackfqdn[:dsc_port] = 16
+    expect(dsc_xazurepackfqdn[:dsc_port]).to eq(16)
   end
 
   it 'should accept uint for dsc_port' do

--- a/spec/unit/puppet/type/dsc_xazurepackidentityprovider_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackidentityprovider_spec.rb
@@ -90,8 +90,9 @@ describe Puppet::Type.type(:dsc_xazurepackidentityprovider) do
     expect{dsc_xazurepackidentityprovider[:dsc_port] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_port' do
-    expect{dsc_xazurepackidentityprovider[:dsc_port] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_port' do
+    dsc_xazurepackidentityprovider[:dsc_port] = 16
+    expect(dsc_xazurepackidentityprovider[:dsc_port]).to eq(16)
   end
 
   it 'should accept uint for dsc_port' do

--- a/spec/unit/puppet/type/dsc_xazurepackrelyingparty_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazurepackrelyingparty_spec.rb
@@ -90,8 +90,9 @@ describe Puppet::Type.type(:dsc_xazurepackrelyingparty) do
     expect{dsc_xazurepackrelyingparty[:dsc_port] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_port' do
-    expect{dsc_xazurepackrelyingparty[:dsc_port] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_port' do
+    dsc_xazurepackrelyingparty[:dsc_port] = 16
+    expect(dsc_xazurepackrelyingparty[:dsc_port]).to eq(16)
   end
 
   it 'should accept uint for dsc_port' do

--- a/spec/unit/puppet/type/dsc_xazuresqldatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xazuresqldatabase_spec.rb
@@ -57,8 +57,9 @@ describe Puppet::Type.type(:dsc_xazuresqldatabase) do
     expect{dsc_xazuresqldatabase[:dsc_maximumsizeingb] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_maximumsizeingb' do
-    expect{dsc_xazuresqldatabase[:dsc_maximumsizeingb] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_maximumsizeingb' do
+    dsc_xazuresqldatabase[:dsc_maximumsizeingb] = 32
+    expect(dsc_xazuresqldatabase[:dsc_maximumsizeingb]).to eq(32)
   end
 
   it 'should accept uint for dsc_maximumsizeingb' do

--- a/spec/unit/puppet/type/dsc_xdisk_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdisk_spec.rb
@@ -48,8 +48,9 @@ describe Puppet::Type.type(:dsc_xdisk) do
     expect{dsc_xdisk[:dsc_disknumber] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_disknumber' do
-    expect{dsc_xdisk[:dsc_disknumber] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_disknumber' do
+    dsc_xdisk[:dsc_disknumber] = 32
+    expect(dsc_xdisk[:dsc_disknumber]).to eq(32)
   end
 
   it 'should accept uint for dsc_disknumber' do
@@ -83,8 +84,9 @@ describe Puppet::Type.type(:dsc_xdisk) do
     expect{dsc_xdisk[:dsc_size] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_size' do
-    expect{dsc_xdisk[:dsc_size] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_size' do
+    dsc_xdisk[:dsc_size] = 64
+    expect(dsc_xdisk[:dsc_size]).to eq(64)
   end
 
   it 'should accept uint for dsc_size' do

--- a/spec/unit/puppet/type/dsc_xdscwebservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xdscwebservice_spec.rb
@@ -76,8 +76,9 @@ describe Puppet::Type.type(:dsc_xdscwebservice) do
     expect{dsc_xdscwebservice[:dsc_port] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_port' do
-    expect{dsc_xdscwebservice[:dsc_port] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_port' do
+    dsc_xdscwebservice[:dsc_port] = 32
+    expect(dsc_xdscwebservice[:dsc_port]).to eq(32)
   end
 
   it 'should accept uint for dsc_port' do

--- a/spec/unit/puppet/type/dsc_xexchautomountpoint_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchautomountpoint_spec.rb
@@ -105,8 +105,9 @@ describe Puppet::Type.type(:dsc_xexchautomountpoint) do
     expect{dsc_xexchautomountpoint[:dsc_sparevolumecount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sparevolumecount' do
-    expect{dsc_xexchautomountpoint[:dsc_sparevolumecount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sparevolumecount' do
+    dsc_xexchautomountpoint[:dsc_sparevolumecount] = 32
+    expect(dsc_xexchautomountpoint[:dsc_sparevolumecount]).to eq(32)
   end
 
   it 'should accept uint for dsc_sparevolumecount' do

--- a/spec/unit/puppet/type/dsc_xexchdatabaseavailabilitygroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchdatabaseavailabilitygroup_spec.rb
@@ -776,8 +776,9 @@ describe Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroup) do
     expect{dsc_xexchdatabaseavailabilitygroup[:dsc_replicationport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_replicationport' do
-    expect{dsc_xexchdatabaseavailabilitygroup[:dsc_replicationport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_replicationport' do
+    dsc_xexchdatabaseavailabilitygroup[:dsc_replicationport] = 16
+    expect(dsc_xexchdatabaseavailabilitygroup[:dsc_replicationport]).to eq(16)
   end
 
   it 'should accept uint for dsc_replicationport' do

--- a/spec/unit/puppet/type/dsc_xexchjetstress_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchjetstress_spec.rb
@@ -125,8 +125,9 @@ describe Puppet::Type.type(:dsc_xexchjetstress) do
     expect{dsc_xexchjetstress[:dsc_maxwaitminutes] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_maxwaitminutes' do
-    expect{dsc_xexchjetstress[:dsc_maxwaitminutes] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_maxwaitminutes' do
+    dsc_xexchjetstress[:dsc_maxwaitminutes] = 32
+    expect(dsc_xexchjetstress[:dsc_maxwaitminutes]).to eq(32)
   end
 
   it 'should accept uint for dsc_maxwaitminutes' do
@@ -160,8 +161,9 @@ describe Puppet::Type.type(:dsc_xexchjetstress) do
     expect{dsc_xexchjetstress[:dsc_minachievediops] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_minachievediops' do
-    expect{dsc_xexchjetstress[:dsc_minachievediops] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_minachievediops' do
+    dsc_xexchjetstress[:dsc_minachievediops] = 32
+    expect(dsc_xexchjetstress[:dsc_minachievediops]).to eq(32)
   end
 
   it 'should accept uint for dsc_minachievediops' do

--- a/spec/unit/puppet/type/dsc_xexchmailboxdatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchmailboxdatabase_spec.rb
@@ -94,8 +94,9 @@ describe Puppet::Type.type(:dsc_xexchmailboxdatabase) do
     expect{dsc_xexchmailboxdatabase[:dsc_databasecopycount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_databasecopycount' do
-    expect{dsc_xexchmailboxdatabase[:dsc_databasecopycount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_databasecopycount' do
+    dsc_xexchmailboxdatabase[:dsc_databasecopycount] = 32
+    expect(dsc_xexchmailboxdatabase[:dsc_databasecopycount]).to eq(32)
   end
 
   it 'should accept uint for dsc_databasecopycount' do

--- a/spec/unit/puppet/type/dsc_xexchmailboxdatabasecopy_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchmailboxdatabasecopy_spec.rb
@@ -153,8 +153,9 @@ describe Puppet::Type.type(:dsc_xexchmailboxdatabasecopy) do
     expect{dsc_xexchmailboxdatabasecopy[:dsc_activationpreference] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_activationpreference' do
-    expect{dsc_xexchmailboxdatabasecopy[:dsc_activationpreference] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_activationpreference' do
+    dsc_xexchmailboxdatabasecopy[:dsc_activationpreference] = 32
+    expect(dsc_xexchmailboxdatabasecopy[:dsc_activationpreference]).to eq(32)
   end
 
   it 'should accept uint for dsc_activationpreference' do

--- a/spec/unit/puppet/type/dsc_xexchwaitforadprep_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchwaitforadprep_spec.rb
@@ -272,8 +272,9 @@ describe Puppet::Type.type(:dsc_xexchwaitforadprep) do
     expect{dsc_xexchwaitforadprep[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retryintervalsec' do
-    expect{dsc_xexchwaitforadprep[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retryintervalsec' do
+    dsc_xexchwaitforadprep[:dsc_retryintervalsec] = 32
+    expect(dsc_xexchwaitforadprep[:dsc_retryintervalsec]).to eq(32)
   end
 
   it 'should accept uint for dsc_retryintervalsec' do
@@ -307,8 +308,9 @@ describe Puppet::Type.type(:dsc_xexchwaitforadprep) do
     expect{dsc_xexchwaitforadprep[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retrycount' do
-    expect{dsc_xexchwaitforadprep[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retrycount' do
+    dsc_xexchwaitforadprep[:dsc_retrycount] = 32
+    expect(dsc_xexchwaitforadprep[:dsc_retrycount]).to eq(32)
   end
 
   it 'should accept uint for dsc_retrycount' do

--- a/spec/unit/puppet/type/dsc_xexchwaitfordag_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchwaitfordag_spec.rb
@@ -85,8 +85,9 @@ describe Puppet::Type.type(:dsc_xexchwaitfordag) do
     expect{dsc_xexchwaitfordag[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retryintervalsec' do
-    expect{dsc_xexchwaitfordag[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retryintervalsec' do
+    dsc_xexchwaitfordag[:dsc_retryintervalsec] = 32
+    expect(dsc_xexchwaitfordag[:dsc_retryintervalsec]).to eq(32)
   end
 
   it 'should accept uint for dsc_retryintervalsec' do
@@ -120,8 +121,9 @@ describe Puppet::Type.type(:dsc_xexchwaitfordag) do
     expect{dsc_xexchwaitfordag[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retrycount' do
-    expect{dsc_xexchwaitfordag[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retrycount' do
+    dsc_xexchwaitfordag[:dsc_retrycount] = 32
+    expect(dsc_xexchwaitfordag[:dsc_retrycount]).to eq(32)
   end
 
   it 'should accept uint for dsc_retrycount' do

--- a/spec/unit/puppet/type/dsc_xexchwaitformailboxdatabase_spec.rb
+++ b/spec/unit/puppet/type/dsc_xexchwaitformailboxdatabase_spec.rb
@@ -102,8 +102,9 @@ describe Puppet::Type.type(:dsc_xexchwaitformailboxdatabase) do
     expect{dsc_xexchwaitformailboxdatabase[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retryintervalsec' do
-    expect{dsc_xexchwaitformailboxdatabase[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retryintervalsec' do
+    dsc_xexchwaitformailboxdatabase[:dsc_retryintervalsec] = 32
+    expect(dsc_xexchwaitformailboxdatabase[:dsc_retryintervalsec]).to eq(32)
   end
 
   it 'should accept uint for dsc_retryintervalsec' do
@@ -137,8 +138,9 @@ describe Puppet::Type.type(:dsc_xexchwaitformailboxdatabase) do
     expect{dsc_xexchwaitformailboxdatabase[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retrycount' do
-    expect{dsc_xexchwaitformailboxdatabase[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retrycount' do
+    dsc_xexchwaitformailboxdatabase[:dsc_retrycount] = 32
+    expect(dsc_xexchwaitformailboxdatabase[:dsc_retrycount]).to eq(32)
   end
 
   it 'should accept uint for dsc_retrycount' do

--- a/spec/unit/puppet/type/dsc_xipaddress_spec.rb
+++ b/spec/unit/puppet/type/dsc_xipaddress_spec.rb
@@ -75,8 +75,9 @@ describe Puppet::Type.type(:dsc_xipaddress) do
     expect{dsc_xipaddress[:dsc_subnetmask] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_subnetmask' do
-    expect{dsc_xipaddress[:dsc_subnetmask] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_subnetmask' do
+    dsc_xipaddress[:dsc_subnetmask] = 32
+    expect(dsc_xipaddress[:dsc_subnetmask]).to eq(32)
   end
 
   it 'should accept uint for dsc_subnetmask' do

--- a/spec/unit/puppet/type/dsc_xmppreference_spec.rb
+++ b/spec/unit/puppet/type/dsc_xmppreference_spec.rb
@@ -199,8 +199,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_quarantinepurgeitemsafterdelay] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_quarantinepurgeitemsafterdelay' do
-    expect{dsc_xmppreference[:dsc_quarantinepurgeitemsafterdelay] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_quarantinepurgeitemsafterdelay' do
+    dsc_xmppreference[:dsc_quarantinepurgeitemsafterdelay] = 32
+    expect(dsc_xmppreference[:dsc_quarantinepurgeitemsafterdelay]).to eq(32)
   end
 
   it 'should accept uint for dsc_quarantinepurgeitemsafterdelay' do
@@ -360,8 +361,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_reportingadditionalactiontimeout] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_reportingadditionalactiontimeout' do
-    expect{dsc_xmppreference[:dsc_reportingadditionalactiontimeout] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_reportingadditionalactiontimeout' do
+    dsc_xmppreference[:dsc_reportingadditionalactiontimeout] = 32
+    expect(dsc_xmppreference[:dsc_reportingadditionalactiontimeout]).to eq(32)
   end
 
   it 'should accept uint for dsc_reportingadditionalactiontimeout' do
@@ -395,8 +397,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_reportingnoncriticaltimeout] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_reportingnoncriticaltimeout' do
-    expect{dsc_xmppreference[:dsc_reportingnoncriticaltimeout] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_reportingnoncriticaltimeout' do
+    dsc_xmppreference[:dsc_reportingnoncriticaltimeout] = 32
+    expect(dsc_xmppreference[:dsc_reportingnoncriticaltimeout]).to eq(32)
   end
 
   it 'should accept uint for dsc_reportingnoncriticaltimeout' do
@@ -430,8 +433,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_reportingcriticalfailuretimeout] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_reportingcriticalfailuretimeout' do
-    expect{dsc_xmppreference[:dsc_reportingcriticalfailuretimeout] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_reportingcriticalfailuretimeout' do
+    dsc_xmppreference[:dsc_reportingcriticalfailuretimeout] = 32
+    expect(dsc_xmppreference[:dsc_reportingcriticalfailuretimeout]).to eq(32)
   end
 
   it 'should accept uint for dsc_reportingcriticalfailuretimeout' do
@@ -465,8 +469,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_scanavgcpuloadfactor] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_scanavgcpuloadfactor' do
-    expect{dsc_xmppreference[:dsc_scanavgcpuloadfactor] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_scanavgcpuloadfactor' do
+    dsc_xmppreference[:dsc_scanavgcpuloadfactor] = 32
+    expect(dsc_xmppreference[:dsc_scanavgcpuloadfactor]).to eq(32)
   end
 
   it 'should accept uint for dsc_scanavgcpuloadfactor' do
@@ -547,8 +552,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_scanpurgeitemsafterdelay] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_scanpurgeitemsafterdelay' do
-    expect{dsc_xmppreference[:dsc_scanpurgeitemsafterdelay] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_scanpurgeitemsafterdelay' do
+    dsc_xmppreference[:dsc_scanpurgeitemsafterdelay] = 32
+    expect(dsc_xmppreference[:dsc_scanpurgeitemsafterdelay]).to eq(32)
   end
 
   it 'should accept uint for dsc_scanpurgeitemsafterdelay' do
@@ -811,8 +817,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_signaturefirstaugraceperiod] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_signaturefirstaugraceperiod' do
-    expect{dsc_xmppreference[:dsc_signaturefirstaugraceperiod] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_signaturefirstaugraceperiod' do
+    dsc_xmppreference[:dsc_signaturefirstaugraceperiod] = 32
+    expect(dsc_xmppreference[:dsc_signaturefirstaugraceperiod]).to eq(32)
   end
 
   it 'should accept uint for dsc_signaturefirstaugraceperiod' do
@@ -846,8 +853,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_signatureaugraceperiod] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_signatureaugraceperiod' do
-    expect{dsc_xmppreference[:dsc_signatureaugraceperiod] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_signatureaugraceperiod' do
+    dsc_xmppreference[:dsc_signatureaugraceperiod] = 32
+    expect(dsc_xmppreference[:dsc_signatureaugraceperiod]).to eq(32)
   end
 
   it 'should accept uint for dsc_signatureaugraceperiod' do
@@ -1086,8 +1094,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_signatureupdatecatchupinterval] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_signatureupdatecatchupinterval' do
-    expect{dsc_xmppreference[:dsc_signatureupdatecatchupinterval] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_signatureupdatecatchupinterval' do
+    dsc_xmppreference[:dsc_signatureupdatecatchupinterval] = 32
+    expect(dsc_xmppreference[:dsc_signatureupdatecatchupinterval]).to eq(32)
   end
 
   it 'should accept uint for dsc_signatureupdatecatchupinterval' do
@@ -1121,8 +1130,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_signatureupdateinterval] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_signatureupdateinterval' do
-    expect{dsc_xmppreference[:dsc_signatureupdateinterval] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_signatureupdateinterval' do
+    dsc_xmppreference[:dsc_signatureupdateinterval] = 32
+    expect(dsc_xmppreference[:dsc_signatureupdateinterval]).to eq(32)
   end
 
   it 'should accept uint for dsc_signatureupdateinterval' do
@@ -2005,8 +2015,9 @@ describe Puppet::Type.type(:dsc_xmppreference) do
     expect{dsc_xmppreference[:dsc_threatiddefaultaction_ids] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_threatiddefaultaction_ids' do
-    expect{dsc_xmppreference[:dsc_threatiddefaultaction_ids] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_threatiddefaultaction_ids' do
+    dsc_xmppreference[:dsc_threatiddefaultaction_ids] = 64
+    expect(dsc_xmppreference[:dsc_threatiddefaultaction_ids]).to eq(64)
   end
 
   it 'should accept uint for dsc_threatiddefaultaction_ids' do

--- a/spec/unit/puppet/type/dsc_xpackage_spec.rb
+++ b/spec/unit/puppet/type/dsc_xpackage_spec.rb
@@ -222,12 +222,14 @@ describe Puppet::Type.type(:dsc_xpackage) do
     expect{dsc_xpackage[:dsc_returncode] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_returncode' do
-    expect{dsc_xpackage[:dsc_returncode] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_returncode' do
+    dsc_xpackage[:dsc_returncode] = [32, 64, 128]
+    expect(dsc_xpackage[:dsc_returncode]).to eq([32, 64, 128])
   end
 
-  it 'should not accept uint for dsc_returncode' do
-    expect{dsc_xpackage[:dsc_returncode] = 16}.to raise_error(Puppet::ResourceError)
+  it 'should accept uint for dsc_returncode' do
+    dsc_xpackage[:dsc_returncode] = [32, 64, 128]
+    expect(dsc_xpackage[:dsc_returncode]).to eq([32, 64, 128])
   end
 
   it 'should not accept array for dsc_logpath' do
@@ -302,8 +304,9 @@ describe Puppet::Type.type(:dsc_xpackage) do
     expect{dsc_xpackage[:dsc_size] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_size' do
-    expect{dsc_xpackage[:dsc_size] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_size' do
+    dsc_xpackage[:dsc_size] = 32
+    expect(dsc_xpackage[:dsc_size]).to eq(32)
   end
 
   it 'should accept uint for dsc_size' do

--- a/spec/unit/puppet/type/dsc_xrdremoteapp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xrdremoteapp_spec.rb
@@ -225,8 +225,9 @@ describe Puppet::Type.type(:dsc_xrdremoteapp) do
     expect{dsc_xrdremoteapp[:dsc_iconindex] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_iconindex' do
-    expect{dsc_xrdremoteapp[:dsc_iconindex] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_iconindex' do
+    dsc_xrdremoteapp[:dsc_iconindex] = 32
+    expect(dsc_xrdremoteapp[:dsc_iconindex]).to eq(32)
   end
 
   it 'should accept uint for dsc_iconindex' do

--- a/spec/unit/puppet/type/dsc_xrdsessioncollectionconfiguration_spec.rb
+++ b/spec/unit/puppet/type/dsc_xrdsessioncollectionconfiguration_spec.rb
@@ -63,8 +63,9 @@ describe Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration) do
     expect{dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_activesessionlimitmin' do
-    expect{dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_activesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin] = 32
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_activesessionlimitmin]).to eq(32)
   end
 
   it 'should accept uint for dsc_activesessionlimitmin' do
@@ -366,8 +367,9 @@ describe Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration) do
     expect{dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_disconnectedsessionlimitmin' do
-    expect{dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_disconnectedsessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin] = 32
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_disconnectedsessionlimitmin]).to eq(32)
   end
 
   it 'should accept uint for dsc_disconnectedsessionlimitmin' do
@@ -417,8 +419,9 @@ describe Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration) do
     expect{dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_idlesessionlimitmin' do
-    expect{dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_idlesessionlimitmin' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin] = 32
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_idlesessionlimitmin]).to eq(32)
   end
 
   it 'should accept uint for dsc_idlesessionlimitmin' do
@@ -452,8 +455,9 @@ describe Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration) do
     expect{dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_maxredirectedmonitors' do
-    expect{dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_maxredirectedmonitors' do
+    dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors] = 32
+    expect(dsc_xrdsessioncollectionconfiguration[:dsc_maxredirectedmonitors]).to eq(32)
   end
 
   it 'should accept uint for dsc_maxredirectedmonitors' do

--- a/spec/unit/puppet/type/dsc_xrobocopy_spec.rb
+++ b/spec/unit/puppet/type/dsc_xrobocopy_spec.rb
@@ -107,8 +107,9 @@ describe Puppet::Type.type(:dsc_xrobocopy) do
     expect{dsc_xrobocopy[:dsc_retry] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retry' do
-    expect{dsc_xrobocopy[:dsc_retry] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retry' do
+    dsc_xrobocopy[:dsc_retry] = 32
+    expect(dsc_xrobocopy[:dsc_retry]).to eq(32)
   end
 
   it 'should accept uint for dsc_retry' do
@@ -142,8 +143,9 @@ describe Puppet::Type.type(:dsc_xrobocopy) do
     expect{dsc_xrobocopy[:dsc_wait] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_wait' do
-    expect{dsc_xrobocopy[:dsc_wait] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_wait' do
+    dsc_xrobocopy[:dsc_wait] = 32
+    expect(dsc_xrobocopy[:dsc_wait]).to eq(32)
   end
 
   it 'should accept uint for dsc_wait' do

--- a/spec/unit/puppet/type/dsc_xscomconsolesetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomconsolesetup_spec.rb
@@ -159,8 +159,9 @@ describe Puppet::Type.type(:dsc_xscomconsolesetup) do
     expect{dsc_xscomconsolesetup[:dsc_usemicrosoftupdate] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_usemicrosoftupdate' do
-    expect{dsc_xscomconsolesetup[:dsc_usemicrosoftupdate] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_usemicrosoftupdate' do
+    dsc_xscomconsolesetup[:dsc_usemicrosoftupdate] = 1
+    expect(dsc_xscomconsolesetup[:dsc_usemicrosoftupdate]).to eq(1)
   end
 
   it 'should accept uint for dsc_usemicrosoftupdate' do
@@ -194,8 +195,9 @@ describe Puppet::Type.type(:dsc_xscomconsolesetup) do
     expect{dsc_xscomconsolesetup[:dsc_sendceipreports] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sendceipreports' do
-    expect{dsc_xscomconsolesetup[:dsc_sendceipreports] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sendceipreports' do
+    dsc_xscomconsolesetup[:dsc_sendceipreports] = 1
+    expect(dsc_xscomconsolesetup[:dsc_sendceipreports]).to eq(1)
   end
 
   it 'should accept uint for dsc_sendceipreports' do
@@ -279,8 +281,9 @@ describe Puppet::Type.type(:dsc_xscomconsolesetup) do
     expect{dsc_xscomconsolesetup[:dsc_sendodrreports] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sendodrreports' do
-    expect{dsc_xscomconsolesetup[:dsc_sendodrreports] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sendodrreports' do
+    dsc_xscomconsolesetup[:dsc_sendodrreports] = 1
+    expect(dsc_xscomconsolesetup[:dsc_sendodrreports]).to eq(1)
   end
 
   it 'should accept uint for dsc_sendodrreports' do

--- a/spec/unit/puppet/type/dsc_xscommanagementserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscommanagementserversetup_spec.rb
@@ -256,8 +256,9 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect{dsc_xscommanagementserversetup[:dsc_managementserviceport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_managementserviceport' do
-    expect{dsc_xscommanagementserversetup[:dsc_managementserviceport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_managementserviceport' do
+    dsc_xscommanagementserversetup[:dsc_managementserviceport] = 16
+    expect(dsc_xscommanagementserversetup[:dsc_managementserviceport]).to eq(16)
   end
 
   it 'should accept uint for dsc_managementserviceport' do
@@ -467,8 +468,9 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect{dsc_xscommanagementserversetup[:dsc_databasesize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_databasesize' do
-    expect{dsc_xscommanagementserversetup[:dsc_databasesize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_databasesize' do
+    dsc_xscommanagementserversetup[:dsc_databasesize] = 16
+    expect(dsc_xscommanagementserversetup[:dsc_databasesize]).to eq(16)
   end
 
   it 'should accept uint for dsc_databasesize' do
@@ -534,8 +536,9 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect{dsc_xscommanagementserversetup[:dsc_dwdatabasesize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_dwdatabasesize' do
-    expect{dsc_xscommanagementserversetup[:dsc_dwdatabasesize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_dwdatabasesize' do
+    dsc_xscommanagementserversetup[:dsc_dwdatabasesize] = 16
+    expect(dsc_xscommanagementserversetup[:dsc_dwdatabasesize]).to eq(16)
   end
 
   it 'should accept uint for dsc_dwdatabasesize' do
@@ -569,8 +572,9 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect{dsc_xscommanagementserversetup[:dsc_usemicrosoftupdate] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_usemicrosoftupdate' do
-    expect{dsc_xscommanagementserversetup[:dsc_usemicrosoftupdate] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_usemicrosoftupdate' do
+    dsc_xscommanagementserversetup[:dsc_usemicrosoftupdate] = 1
+    expect(dsc_xscommanagementserversetup[:dsc_usemicrosoftupdate]).to eq(1)
   end
 
   it 'should accept uint for dsc_usemicrosoftupdate' do
@@ -604,8 +608,9 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect{dsc_xscommanagementserversetup[:dsc_sendceipreports] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sendceipreports' do
-    expect{dsc_xscommanagementserversetup[:dsc_sendceipreports] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sendceipreports' do
+    dsc_xscommanagementserversetup[:dsc_sendceipreports] = 1
+    expect(dsc_xscommanagementserversetup[:dsc_sendceipreports]).to eq(1)
   end
 
   it 'should accept uint for dsc_sendceipreports' do
@@ -689,8 +694,9 @@ describe Puppet::Type.type(:dsc_xscommanagementserversetup) do
     expect{dsc_xscommanagementserversetup[:dsc_sendodrreports] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sendodrreports' do
-    expect{dsc_xscommanagementserversetup[:dsc_sendodrreports] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sendodrreports' do
+    dsc_xscommanagementserversetup[:dsc_sendodrreports] = 1
+    expect(dsc_xscommanagementserversetup[:dsc_sendodrreports]).to eq(1)
   end
 
   it 'should accept uint for dsc_sendodrreports' do

--- a/spec/unit/puppet/type/dsc_xscomreportingserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomreportingserversetup_spec.rb
@@ -231,8 +231,9 @@ describe Puppet::Type.type(:dsc_xscomreportingserversetup) do
     expect{dsc_xscomreportingserversetup[:dsc_usemicrosoftupdate] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_usemicrosoftupdate' do
-    expect{dsc_xscomreportingserversetup[:dsc_usemicrosoftupdate] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_usemicrosoftupdate' do
+    dsc_xscomreportingserversetup[:dsc_usemicrosoftupdate] = 1
+    expect(dsc_xscomreportingserversetup[:dsc_usemicrosoftupdate]).to eq(1)
   end
 
   it 'should accept uint for dsc_usemicrosoftupdate' do
@@ -266,8 +267,9 @@ describe Puppet::Type.type(:dsc_xscomreportingserversetup) do
     expect{dsc_xscomreportingserversetup[:dsc_sendceipreports] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sendceipreports' do
-    expect{dsc_xscomreportingserversetup[:dsc_sendceipreports] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sendceipreports' do
+    dsc_xscomreportingserversetup[:dsc_sendceipreports] = 1
+    expect(dsc_xscomreportingserversetup[:dsc_sendceipreports]).to eq(1)
   end
 
   it 'should accept uint for dsc_sendceipreports' do
@@ -351,8 +353,9 @@ describe Puppet::Type.type(:dsc_xscomreportingserversetup) do
     expect{dsc_xscomreportingserversetup[:dsc_sendodrreports] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sendodrreports' do
-    expect{dsc_xscomreportingserversetup[:dsc_sendodrreports] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sendodrreports' do
+    dsc_xscomreportingserversetup[:dsc_sendodrreports] = 1
+    expect(dsc_xscomreportingserversetup[:dsc_sendodrreports]).to eq(1)
   end
 
   it 'should accept uint for dsc_sendodrreports' do

--- a/spec/unit/puppet/type/dsc_xscomwebconsoleserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscomwebconsoleserversetup_spec.rb
@@ -282,8 +282,9 @@ describe Puppet::Type.type(:dsc_xscomwebconsoleserversetup) do
     expect{dsc_xscomwebconsoleserversetup[:dsc_usemicrosoftupdate] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_usemicrosoftupdate' do
-    expect{dsc_xscomwebconsoleserversetup[:dsc_usemicrosoftupdate] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_usemicrosoftupdate' do
+    dsc_xscomwebconsoleserversetup[:dsc_usemicrosoftupdate] = 1
+    expect(dsc_xscomwebconsoleserversetup[:dsc_usemicrosoftupdate]).to eq(1)
   end
 
   it 'should accept uint for dsc_usemicrosoftupdate' do
@@ -317,8 +318,9 @@ describe Puppet::Type.type(:dsc_xscomwebconsoleserversetup) do
     expect{dsc_xscomwebconsoleserversetup[:dsc_sendceipreports] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sendceipreports' do
-    expect{dsc_xscomwebconsoleserversetup[:dsc_sendceipreports] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sendceipreports' do
+    dsc_xscomwebconsoleserversetup[:dsc_sendceipreports] = 1
+    expect(dsc_xscomwebconsoleserversetup[:dsc_sendceipreports]).to eq(1)
   end
 
   it 'should accept uint for dsc_sendceipreports' do
@@ -402,8 +404,9 @@ describe Puppet::Type.type(:dsc_xscomwebconsoleserversetup) do
     expect{dsc_xscomwebconsoleserversetup[:dsc_sendodrreports] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sendodrreports' do
-    expect{dsc_xscomwebconsoleserversetup[:dsc_sendodrreports] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sendodrreports' do
+    dsc_xscomwebconsoleserversetup[:dsc_sendodrreports] = 1
+    expect(dsc_xscomwebconsoleserversetup[:dsc_sendodrreports]).to eq(1)
   end
 
   it 'should accept uint for dsc_sendodrreports' do

--- a/spec/unit/puppet/type/dsc_xscsmawebserviceserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscsmawebserviceserversetup_spec.rb
@@ -319,8 +319,9 @@ describe Puppet::Type.type(:dsc_xscsmawebserviceserversetup) do
     expect{dsc_xscsmawebserviceserversetup[:dsc_webserviceport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_webserviceport' do
-    expect{dsc_xscsmawebserviceserversetup[:dsc_webserviceport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_webserviceport' do
+    dsc_xscsmawebserviceserversetup[:dsc_webserviceport] = 16
+    expect(dsc_xscsmawebserviceserversetup[:dsc_webserviceport]).to eq(16)
   end
 
   it 'should accept uint for dsc_webserviceport' do

--- a/spec/unit/puppet/type/dsc_xscspfserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscspfserversetup_spec.rb
@@ -269,8 +269,9 @@ describe Puppet::Type.type(:dsc_xscspfserversetup) do
     expect{dsc_xscspfserversetup[:dsc_databaseportnumber] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_databaseportnumber' do
-    expect{dsc_xscspfserversetup[:dsc_databaseportnumber] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_databaseportnumber' do
+    dsc_xscspfserversetup[:dsc_databaseportnumber] = 16
+    expect(dsc_xscspfserversetup[:dsc_databaseportnumber]).to eq(16)
   end
 
   it 'should accept uint for dsc_databaseportnumber' do
@@ -320,8 +321,9 @@ describe Puppet::Type.type(:dsc_xscspfserversetup) do
     expect{dsc_xscspfserversetup[:dsc_websiteportnumber] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_websiteportnumber' do
-    expect{dsc_xscspfserversetup[:dsc_websiteportnumber] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_websiteportnumber' do
+    dsc_xscspfserversetup[:dsc_websiteportnumber] = 16
+    expect(dsc_xscspfserversetup[:dsc_websiteportnumber]).to eq(16)
   end
 
   it 'should accept uint for dsc_websiteportnumber' do

--- a/spec/unit/puppet/type/dsc_xscvmmconsolesetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscvmmconsolesetup_spec.rb
@@ -157,8 +157,9 @@ describe Puppet::Type.type(:dsc_xscvmmconsolesetup) do
     expect{dsc_xscvmmconsolesetup[:dsc_indigotcpport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_indigotcpport' do
-    expect{dsc_xscvmmconsolesetup[:dsc_indigotcpport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_indigotcpport' do
+    dsc_xscvmmconsolesetup[:dsc_indigotcpport] = 16
+    expect(dsc_xscvmmconsolesetup[:dsc_indigotcpport]).to eq(16)
   end
 
   it 'should accept uint for dsc_indigotcpport' do
@@ -192,8 +193,9 @@ describe Puppet::Type.type(:dsc_xscvmmconsolesetup) do
     expect{dsc_xscvmmconsolesetup[:dsc_muoptin] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_muoptin' do
-    expect{dsc_xscvmmconsolesetup[:dsc_muoptin] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_muoptin' do
+    dsc_xscvmmconsolesetup[:dsc_muoptin] = 1
+    expect(dsc_xscvmmconsolesetup[:dsc_muoptin]).to eq(1)
   end
 
   it 'should accept uint for dsc_muoptin' do

--- a/spec/unit/puppet/type/dsc_xscvmmmanagementserversetup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xscvmmmanagementserversetup_spec.rb
@@ -425,8 +425,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_indigotcpport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_indigotcpport' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_indigotcpport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_indigotcpport' do
+    dsc_xscvmmmanagementserversetup[:dsc_indigotcpport] = 16
+    expect(dsc_xscvmmmanagementserversetup[:dsc_indigotcpport]).to eq(16)
   end
 
   it 'should accept uint for dsc_indigotcpport' do
@@ -460,8 +461,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_indigohttpsport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_indigohttpsport' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_indigohttpsport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_indigohttpsport' do
+    dsc_xscvmmmanagementserversetup[:dsc_indigohttpsport] = 16
+    expect(dsc_xscvmmmanagementserversetup[:dsc_indigohttpsport]).to eq(16)
   end
 
   it 'should accept uint for dsc_indigohttpsport' do
@@ -495,8 +497,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_indigonettcpport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_indigonettcpport' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_indigonettcpport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_indigonettcpport' do
+    dsc_xscvmmmanagementserversetup[:dsc_indigonettcpport] = 16
+    expect(dsc_xscvmmmanagementserversetup[:dsc_indigonettcpport]).to eq(16)
   end
 
   it 'should accept uint for dsc_indigonettcpport' do
@@ -530,8 +533,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_indigohttpport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_indigohttpport' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_indigohttpport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_indigohttpport' do
+    dsc_xscvmmmanagementserversetup[:dsc_indigohttpport] = 16
+    expect(dsc_xscvmmmanagementserversetup[:dsc_indigohttpport]).to eq(16)
   end
 
   it 'should accept uint for dsc_indigohttpport' do
@@ -565,8 +569,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_wsmantcpport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_wsmantcpport' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_wsmantcpport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_wsmantcpport' do
+    dsc_xscvmmmanagementserversetup[:dsc_wsmantcpport] = 16
+    expect(dsc_xscvmmmanagementserversetup[:dsc_wsmantcpport]).to eq(16)
   end
 
   it 'should accept uint for dsc_wsmantcpport' do
@@ -600,8 +605,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_bitstcpport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_bitstcpport' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_bitstcpport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_bitstcpport' do
+    dsc_xscvmmmanagementserversetup[:dsc_bitstcpport] = 16
+    expect(dsc_xscvmmmanagementserversetup[:dsc_bitstcpport]).to eq(16)
   end
 
   it 'should accept uint for dsc_bitstcpport' do
@@ -747,8 +753,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_retainsqldatabase] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retainsqldatabase' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_retainsqldatabase] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retainsqldatabase' do
+    dsc_xscvmmmanagementserversetup[:dsc_retainsqldatabase] = 1
+    expect(dsc_xscvmmmanagementserversetup[:dsc_retainsqldatabase]).to eq(1)
   end
 
   it 'should accept uint for dsc_retainsqldatabase' do
@@ -782,8 +789,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_forcehavmmuninstall] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_forcehavmmuninstall' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_forcehavmmuninstall] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_forcehavmmuninstall' do
+    dsc_xscvmmmanagementserversetup[:dsc_forcehavmmuninstall] = 1
+    expect(dsc_xscvmmmanagementserversetup[:dsc_forcehavmmuninstall]).to eq(1)
   end
 
   it 'should accept uint for dsc_forcehavmmuninstall' do
@@ -817,8 +825,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_sqmoptin] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_sqmoptin' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_sqmoptin] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_sqmoptin' do
+    dsc_xscvmmmanagementserversetup[:dsc_sqmoptin] = 1
+    expect(dsc_xscvmmmanagementserversetup[:dsc_sqmoptin]).to eq(1)
   end
 
   it 'should accept uint for dsc_sqmoptin' do
@@ -852,8 +861,9 @@ describe Puppet::Type.type(:dsc_xscvmmmanagementserversetup) do
     expect{dsc_xscvmmmanagementserversetup[:dsc_muoptin] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_muoptin' do
-    expect{dsc_xscvmmmanagementserversetup[:dsc_muoptin] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_muoptin' do
+    dsc_xscvmmmanagementserversetup[:dsc_muoptin] = 1
+    expect(dsc_xscvmmmanagementserversetup[:dsc_muoptin]).to eq(1)
   end
 
   it 'should accept uint for dsc_muoptin' do

--- a/spec/unit/puppet/type/dsc_xservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xservice_spec.rb
@@ -301,8 +301,9 @@ describe Puppet::Type.type(:dsc_xservice) do
     expect{dsc_xservice[:dsc_startuptimeout] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_startuptimeout' do
-    expect{dsc_xservice[:dsc_startuptimeout] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_startuptimeout' do
+    dsc_xservice[:dsc_startuptimeout] = 32
+    expect(dsc_xservice[:dsc_startuptimeout]).to eq(32)
   end
 
   it 'should accept uint for dsc_startuptimeout' do

--- a/spec/unit/puppet/type/dsc_xsmbshare_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsmbshare_spec.rb
@@ -112,8 +112,9 @@ describe Puppet::Type.type(:dsc_xsmbshare) do
     expect{dsc_xsmbshare[:dsc_concurrentuserlimit] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_concurrentuserlimit' do
-    expect{dsc_xsmbshare[:dsc_concurrentuserlimit] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_concurrentuserlimit' do
+    dsc_xsmbshare[:dsc_concurrentuserlimit] = 32
+    expect(dsc_xsmbshare[:dsc_concurrentuserlimit]).to eq(32)
   end
 
   it 'should accept uint for dsc_concurrentuserlimit' do

--- a/spec/unit/puppet/type/dsc_xspcreatefarm_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspcreatefarm_spec.rb
@@ -153,8 +153,9 @@ describe Puppet::Type.type(:dsc_xspcreatefarm) do
     expect{dsc_xspcreatefarm[:dsc_centraladministrationport] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_centraladministrationport' do
-    expect{dsc_xspcreatefarm[:dsc_centraladministrationport] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_centraladministrationport' do
+    dsc_xspcreatefarm[:dsc_centraladministrationport] = 32
+    expect(dsc_xspcreatefarm[:dsc_centraladministrationport]).to eq(32)
   end
 
   it 'should accept uint for dsc_centraladministrationport' do

--- a/spec/unit/puppet/type/dsc_xspdiagnosticloggingsettings_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspdiagnosticloggingsettings_spec.rb
@@ -63,8 +63,9 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_logspaceingb] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_logspaceingb' do
-    expect{dsc_xspdiagnosticloggingsettings[:dsc_logspaceingb] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_logspaceingb' do
+    dsc_xspdiagnosticloggingsettings[:dsc_logspaceingb] = 32
+    expect(dsc_xspdiagnosticloggingsettings[:dsc_logspaceingb]).to eq(32)
   end
 
   it 'should accept uint for dsc_logspaceingb' do
@@ -192,8 +193,9 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_daystokeeplogs] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_daystokeeplogs' do
-    expect{dsc_xspdiagnosticloggingsettings[:dsc_daystokeeplogs] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_daystokeeplogs' do
+    dsc_xspdiagnosticloggingsettings[:dsc_daystokeeplogs] = 32
+    expect(dsc_xspdiagnosticloggingsettings[:dsc_daystokeeplogs]).to eq(32)
   end
 
   it 'should accept uint for dsc_daystokeeplogs' do
@@ -415,8 +417,9 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionnotifyinterval] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_eventlogfloodprotectionnotifyinterval' do
-    expect{dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionnotifyinterval] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_eventlogfloodprotectionnotifyinterval' do
+    dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionnotifyinterval] = 32
+    expect(dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionnotifyinterval]).to eq(32)
   end
 
   it 'should accept uint for dsc_eventlogfloodprotectionnotifyinterval' do
@@ -450,8 +453,9 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionquietperiod] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_eventlogfloodprotectionquietperiod' do
-    expect{dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionquietperiod] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_eventlogfloodprotectionquietperiod' do
+    dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionquietperiod] = 32
+    expect(dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionquietperiod]).to eq(32)
   end
 
   it 'should accept uint for dsc_eventlogfloodprotectionquietperiod' do
@@ -485,8 +489,9 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionthreshold] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_eventlogfloodprotectionthreshold' do
-    expect{dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionthreshold] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_eventlogfloodprotectionthreshold' do
+    dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionthreshold] = 32
+    expect(dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectionthreshold]).to eq(32)
   end
 
   it 'should accept uint for dsc_eventlogfloodprotectionthreshold' do
@@ -520,8 +525,9 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectiontriggerperiod] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_eventlogfloodprotectiontriggerperiod' do
-    expect{dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectiontriggerperiod] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_eventlogfloodprotectiontriggerperiod' do
+    dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectiontriggerperiod] = 32
+    expect(dsc_xspdiagnosticloggingsettings[:dsc_eventlogfloodprotectiontriggerperiod]).to eq(32)
   end
 
   it 'should accept uint for dsc_eventlogfloodprotectiontriggerperiod' do
@@ -555,8 +561,9 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_logcutinterval] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_logcutinterval' do
-    expect{dsc_xspdiagnosticloggingsettings[:dsc_logcutinterval] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_logcutinterval' do
+    dsc_xspdiagnosticloggingsettings[:dsc_logcutinterval] = 32
+    expect(dsc_xspdiagnosticloggingsettings[:dsc_logcutinterval]).to eq(32)
   end
 
   it 'should accept uint for dsc_logcutinterval' do
@@ -637,8 +644,9 @@ describe Puppet::Type.type(:dsc_xspdiagnosticloggingsettings) do
     expect{dsc_xspdiagnosticloggingsettings[:dsc_scripterrorreportingdelay] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_scripterrorreportingdelay' do
-    expect{dsc_xspdiagnosticloggingsettings[:dsc_scripterrorreportingdelay] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_scripterrorreportingdelay' do
+    dsc_xspdiagnosticloggingsettings[:dsc_scripterrorreportingdelay] = 32
+    expect(dsc_xspdiagnosticloggingsettings[:dsc_scripterrorreportingdelay]).to eq(32)
   end
 
   it 'should accept uint for dsc_scripterrorreportingdelay' do

--- a/spec/unit/puppet/type/dsc_xspdistributedcacheservice_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspdistributedcacheservice_spec.rb
@@ -104,8 +104,9 @@ describe Puppet::Type.type(:dsc_xspdistributedcacheservice) do
     expect{dsc_xspdistributedcacheservice[:dsc_cachesizeinmb] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_cachesizeinmb' do
-    expect{dsc_xspdistributedcacheservice[:dsc_cachesizeinmb] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_cachesizeinmb' do
+    dsc_xspdistributedcacheservice[:dsc_cachesizeinmb] = 32
+    expect(dsc_xspdistributedcacheservice[:dsc_cachesizeinmb]).to eq(32)
   end
 
   it 'should accept uint for dsc_cachesizeinmb' do

--- a/spec/unit/puppet/type/dsc_xspmanagedaccount_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspmanagedaccount_spec.rb
@@ -90,8 +90,9 @@ describe Puppet::Type.type(:dsc_xspmanagedaccount) do
     expect{dsc_xspmanagedaccount[:dsc_emailnotification] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_emailnotification' do
-    expect{dsc_xspmanagedaccount[:dsc_emailnotification] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_emailnotification' do
+    dsc_xspmanagedaccount[:dsc_emailnotification] = 32
+    expect(dsc_xspmanagedaccount[:dsc_emailnotification]).to eq(32)
   end
 
   it 'should accept uint for dsc_emailnotification' do
@@ -125,8 +126,9 @@ describe Puppet::Type.type(:dsc_xspmanagedaccount) do
     expect{dsc_xspmanagedaccount[:dsc_preexpiredays] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_preexpiredays' do
-    expect{dsc_xspmanagedaccount[:dsc_preexpiredays] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_preexpiredays' do
+    dsc_xspmanagedaccount[:dsc_preexpiredays] = 32
+    expect(dsc_xspmanagedaccount[:dsc_preexpiredays]).to eq(32)
   end
 
   it 'should accept uint for dsc_preexpiredays' do

--- a/spec/unit/puppet/type/dsc_xspsecurestoreserviceapp_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspsecurestoreserviceapp_spec.rb
@@ -120,8 +120,9 @@ describe Puppet::Type.type(:dsc_xspsecurestoreserviceapp) do
     expect{dsc_xspsecurestoreserviceapp[:dsc_auditlogmaxsize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_auditlogmaxsize' do
-    expect{dsc_xspsecurestoreserviceapp[:dsc_auditlogmaxsize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_auditlogmaxsize' do
+    dsc_xspsecurestoreserviceapp[:dsc_auditlogmaxsize] = 32
+    expect(dsc_xspsecurestoreserviceapp[:dsc_auditlogmaxsize]).to eq(32)
   end
 
   it 'should accept uint for dsc_auditlogmaxsize' do

--- a/spec/unit/puppet/type/dsc_xspsite_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspsite_spec.rb
@@ -74,8 +74,9 @@ describe Puppet::Type.type(:dsc_xspsite) do
     expect{dsc_xspsite[:dsc_compatibilitylevel] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_compatibilitylevel' do
-    expect{dsc_xspsite[:dsc_compatibilitylevel] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_compatibilitylevel' do
+    dsc_xspsite[:dsc_compatibilitylevel] = 32
+    expect(dsc_xspsite[:dsc_compatibilitylevel]).to eq(32)
   end
 
   it 'should accept uint for dsc_compatibilitylevel' do
@@ -157,8 +158,9 @@ describe Puppet::Type.type(:dsc_xspsite) do
     expect{dsc_xspsite[:dsc_language] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_language' do
-    expect{dsc_xspsite[:dsc_language] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_language' do
+    dsc_xspsite[:dsc_language] = 32
+    expect(dsc_xspsite[:dsc_language]).to eq(32)
   end
 
   it 'should accept uint for dsc_language' do

--- a/spec/unit/puppet/type/dsc_xspusageapplication_spec.rb
+++ b/spec/unit/puppet/type/dsc_xspusageapplication_spec.rb
@@ -155,8 +155,9 @@ describe Puppet::Type.type(:dsc_xspusageapplication) do
     expect{dsc_xspusageapplication[:dsc_usagelogcuttime] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_usagelogcuttime' do
-    expect{dsc_xspusageapplication[:dsc_usagelogcuttime] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_usagelogcuttime' do
+    dsc_xspusageapplication[:dsc_usagelogcuttime] = 32
+    expect(dsc_xspusageapplication[:dsc_usagelogcuttime]).to eq(32)
   end
 
   it 'should accept uint for dsc_usagelogcuttime' do
@@ -206,8 +207,9 @@ describe Puppet::Type.type(:dsc_xspusageapplication) do
     expect{dsc_xspusageapplication[:dsc_usagelogmaxfilesizekb] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_usagelogmaxfilesizekb' do
-    expect{dsc_xspusageapplication[:dsc_usagelogmaxfilesizekb] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_usagelogmaxfilesizekb' do
+    dsc_xspusageapplication[:dsc_usagelogmaxfilesizekb] = 32
+    expect(dsc_xspusageapplication[:dsc_usagelogmaxfilesizekb]).to eq(32)
   end
 
   it 'should accept uint for dsc_usagelogmaxfilesizekb' do
@@ -241,8 +243,9 @@ describe Puppet::Type.type(:dsc_xspusageapplication) do
     expect{dsc_xspusageapplication[:dsc_usagelogmaxspacegb] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_usagelogmaxspacegb' do
-    expect{dsc_xspusageapplication[:dsc_usagelogmaxspacegb] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_usagelogmaxspacegb' do
+    dsc_xspusageapplication[:dsc_usagelogmaxspacegb] = 32
+    expect(dsc_xspusageapplication[:dsc_usagelogmaxspacegb]).to eq(32)
   end
 
   it 'should accept uint for dsc_usagelogmaxspacegb' do

--- a/spec/unit/puppet/type/dsc_xsqlhaendpoint_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlhaendpoint_spec.rb
@@ -91,8 +91,9 @@ describe Puppet::Type.type(:dsc_xsqlhaendpoint) do
     expect{dsc_xsqlhaendpoint[:dsc_portnumber] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_portnumber' do
-    expect{dsc_xsqlhaendpoint[:dsc_portnumber] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_portnumber' do
+    dsc_xsqlhaendpoint[:dsc_portnumber] = 32
+    expect(dsc_xsqlhaendpoint[:dsc_portnumber]).to eq(32)
   end
 
   it 'should accept uint for dsc_portnumber' do

--- a/spec/unit/puppet/type/dsc_xsqlserverrssecureconnectionlevel_spec.rb
+++ b/spec/unit/puppet/type/dsc_xsqlserverrssecureconnectionlevel_spec.rb
@@ -57,8 +57,9 @@ describe Puppet::Type.type(:dsc_xsqlserverrssecureconnectionlevel) do
     expect{dsc_xsqlserverrssecureconnectionlevel[:dsc_secureconnectionlevel] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_secureconnectionlevel' do
-    expect{dsc_xsqlserverrssecureconnectionlevel[:dsc_secureconnectionlevel] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_secureconnectionlevel' do
+    dsc_xsqlserverrssecureconnectionlevel[:dsc_secureconnectionlevel] = 16
+    expect(dsc_xsqlserverrssecureconnectionlevel[:dsc_secureconnectionlevel]).to eq(16)
   end
 
   it 'should accept uint for dsc_secureconnectionlevel' do

--- a/spec/unit/puppet/type/dsc_xvhd_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvhd_spec.rb
@@ -107,8 +107,9 @@ describe Puppet::Type.type(:dsc_xvhd) do
     expect{dsc_xvhd[:dsc_maximumsizebytes] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_maximumsizebytes' do
-    expect{dsc_xvhd[:dsc_maximumsizebytes] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_maximumsizebytes' do
+    dsc_xvhd[:dsc_maximumsizebytes] = 64
+    expect(dsc_xvhd[:dsc_maximumsizebytes]).to eq(64)
   end
 
   it 'should accept uint for dsc_maximumsizebytes' do
@@ -264,8 +265,9 @@ describe Puppet::Type.type(:dsc_xvhd) do
     expect{dsc_xvhd[:dsc_filesizebytes] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_filesizebytes' do
-    expect{dsc_xvhd[:dsc_filesizebytes] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_filesizebytes' do
+    dsc_xvhd[:dsc_filesizebytes] = 64
+    expect(dsc_xvhd[:dsc_filesizebytes]).to eq(64)
   end
 
   it 'should accept uint for dsc_filesizebytes' do

--- a/spec/unit/puppet/type/dsc_xvmhyperv_spec.rb
+++ b/spec/unit/puppet/type/dsc_xvmhyperv_spec.rb
@@ -169,8 +169,9 @@ describe Puppet::Type.type(:dsc_xvmhyperv) do
     expect{dsc_xvmhyperv[:dsc_generation] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_generation' do
-    expect{dsc_xvmhyperv[:dsc_generation] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_generation' do
+    dsc_xvmhyperv[:dsc_generation] = 32
+    expect(dsc_xvmhyperv[:dsc_generation]).to eq(32)
   end
 
   it 'should accept uint for dsc_generation' do
@@ -204,8 +205,9 @@ describe Puppet::Type.type(:dsc_xvmhyperv) do
     expect{dsc_xvmhyperv[:dsc_startupmemory] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_startupmemory' do
-    expect{dsc_xvmhyperv[:dsc_startupmemory] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_startupmemory' do
+    dsc_xvmhyperv[:dsc_startupmemory] = 64
+    expect(dsc_xvmhyperv[:dsc_startupmemory]).to eq(64)
   end
 
   it 'should accept uint for dsc_startupmemory' do
@@ -239,8 +241,9 @@ describe Puppet::Type.type(:dsc_xvmhyperv) do
     expect{dsc_xvmhyperv[:dsc_minimummemory] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_minimummemory' do
-    expect{dsc_xvmhyperv[:dsc_minimummemory] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_minimummemory' do
+    dsc_xvmhyperv[:dsc_minimummemory] = 64
+    expect(dsc_xvmhyperv[:dsc_minimummemory]).to eq(64)
   end
 
   it 'should accept uint for dsc_minimummemory' do
@@ -274,8 +277,9 @@ describe Puppet::Type.type(:dsc_xvmhyperv) do
     expect{dsc_xvmhyperv[:dsc_maximummemory] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_maximummemory' do
-    expect{dsc_xvmhyperv[:dsc_maximummemory] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_maximummemory' do
+    dsc_xvmhyperv[:dsc_maximummemory] = 64
+    expect(dsc_xvmhyperv[:dsc_maximummemory]).to eq(64)
   end
 
   it 'should accept uint for dsc_maximummemory' do
@@ -325,8 +329,9 @@ describe Puppet::Type.type(:dsc_xvmhyperv) do
     expect{dsc_xvmhyperv[:dsc_processorcount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_processorcount' do
-    expect{dsc_xvmhyperv[:dsc_processorcount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_processorcount' do
+    dsc_xvmhyperv[:dsc_processorcount] = 32
+    expect(dsc_xvmhyperv[:dsc_processorcount]).to eq(32)
   end
 
   it 'should accept uint for dsc_processorcount' do
@@ -552,8 +557,9 @@ describe Puppet::Type.type(:dsc_xvmhyperv) do
     expect{dsc_xvmhyperv[:dsc_cpuusage] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_cpuusage' do
-    expect{dsc_xvmhyperv[:dsc_cpuusage] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_cpuusage' do
+    dsc_xvmhyperv[:dsc_cpuusage] = 32
+    expect(dsc_xvmhyperv[:dsc_cpuusage]).to eq(32)
   end
 
   it 'should accept uint for dsc_cpuusage' do
@@ -587,8 +593,9 @@ describe Puppet::Type.type(:dsc_xvmhyperv) do
     expect{dsc_xvmhyperv[:dsc_memoryassigned] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_memoryassigned' do
-    expect{dsc_xvmhyperv[:dsc_memoryassigned] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_memoryassigned' do
+    dsc_xvmhyperv[:dsc_memoryassigned] = 64
+    expect(dsc_xvmhyperv[:dsc_memoryassigned]).to eq(64)
   end
 
   it 'should accept uint for dsc_memoryassigned' do

--- a/spec/unit/puppet/type/dsc_xwaitforaddomain_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitforaddomain_spec.rb
@@ -68,8 +68,9 @@ describe Puppet::Type.type(:dsc_xwaitforaddomain) do
     expect{dsc_xwaitforaddomain[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retryintervalsec' do
-    expect{dsc_xwaitforaddomain[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retryintervalsec' do
+    dsc_xwaitforaddomain[:dsc_retryintervalsec] = 64
+    expect(dsc_xwaitforaddomain[:dsc_retryintervalsec]).to eq(64)
   end
 
   it 'should accept uint for dsc_retryintervalsec' do
@@ -103,8 +104,9 @@ describe Puppet::Type.type(:dsc_xwaitforaddomain) do
     expect{dsc_xwaitforaddomain[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retrycount' do
-    expect{dsc_xwaitforaddomain[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retrycount' do
+    dsc_xwaitforaddomain[:dsc_retrycount] = 32
+    expect(dsc_xwaitforaddomain[:dsc_retrycount]).to eq(32)
   end
 
   it 'should accept uint for dsc_retrycount' do

--- a/spec/unit/puppet/type/dsc_xwaitforcluster_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitforcluster_spec.rb
@@ -47,8 +47,9 @@ describe Puppet::Type.type(:dsc_xwaitforcluster) do
     expect{dsc_xwaitforcluster[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retryintervalsec' do
-    expect{dsc_xwaitforcluster[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retryintervalsec' do
+    dsc_xwaitforcluster[:dsc_retryintervalsec] = 64
+    expect(dsc_xwaitforcluster[:dsc_retryintervalsec]).to eq(64)
   end
 
   it 'should accept uint for dsc_retryintervalsec' do
@@ -82,8 +83,9 @@ describe Puppet::Type.type(:dsc_xwaitforcluster) do
     expect{dsc_xwaitforcluster[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retrycount' do
-    expect{dsc_xwaitforcluster[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retrycount' do
+    dsc_xwaitforcluster[:dsc_retrycount] = 32
+    expect(dsc_xwaitforcluster[:dsc_retrycount]).to eq(32)
   end
 
   it 'should accept uint for dsc_retrycount' do

--- a/spec/unit/puppet/type/dsc_xwaitfordisk_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitfordisk_spec.rb
@@ -31,8 +31,9 @@ describe Puppet::Type.type(:dsc_xwaitfordisk) do
     expect{dsc_xwaitfordisk[:dsc_disknumber] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_disknumber' do
-    expect{dsc_xwaitfordisk[:dsc_disknumber] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_disknumber' do
+    dsc_xwaitfordisk[:dsc_disknumber] = 32
+    expect(dsc_xwaitfordisk[:dsc_disknumber]).to eq(32)
   end
 
   it 'should accept uint for dsc_disknumber' do
@@ -66,8 +67,9 @@ describe Puppet::Type.type(:dsc_xwaitfordisk) do
     expect{dsc_xwaitfordisk[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retryintervalsec' do
-    expect{dsc_xwaitfordisk[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retryintervalsec' do
+    dsc_xwaitfordisk[:dsc_retryintervalsec] = 64
+    expect(dsc_xwaitfordisk[:dsc_retryintervalsec]).to eq(64)
   end
 
   it 'should accept uint for dsc_retryintervalsec' do
@@ -101,8 +103,9 @@ describe Puppet::Type.type(:dsc_xwaitfordisk) do
     expect{dsc_xwaitfordisk[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retrycount' do
-    expect{dsc_xwaitfordisk[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retrycount' do
+    dsc_xwaitfordisk[:dsc_retrycount] = 32
+    expect(dsc_xwaitfordisk[:dsc_retrycount]).to eq(32)
   end
 
   it 'should accept uint for dsc_retrycount' do

--- a/spec/unit/puppet/type/dsc_xwaitforsqlhagroup_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwaitforsqlhagroup_spec.rb
@@ -67,8 +67,9 @@ describe Puppet::Type.type(:dsc_xwaitforsqlhagroup) do
     expect{dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retryintervalsec' do
-    expect{dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retryintervalsec' do
+    dsc_xwaitforsqlhagroup[:dsc_retryintervalsec] = 64
+    expect(dsc_xwaitforsqlhagroup[:dsc_retryintervalsec]).to eq(64)
   end
 
   it 'should accept uint for dsc_retryintervalsec' do
@@ -102,8 +103,9 @@ describe Puppet::Type.type(:dsc_xwaitforsqlhagroup) do
     expect{dsc_xwaitforsqlhagroup[:dsc_retrycount] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_retrycount' do
-    expect{dsc_xwaitforsqlhagroup[:dsc_retrycount] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_retrycount' do
+    dsc_xwaitforsqlhagroup[:dsc_retrycount] = 32
+    expect(dsc_xwaitforsqlhagroup[:dsc_retrycount]).to eq(32)
   end
 
   it 'should accept uint for dsc_retrycount' do

--- a/spec/unit/puppet/type/dsc_xwefsubscription_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwefsubscription_spec.rb
@@ -315,8 +315,9 @@ describe Puppet::Type.type(:dsc_xwefsubscription) do
     expect{dsc_xwefsubscription[:dsc_maxlatencytime] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_maxlatencytime' do
-    expect{dsc_xwefsubscription[:dsc_maxlatencytime] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_maxlatencytime' do
+    dsc_xwefsubscription[:dsc_maxlatencytime] = 64
+    expect(dsc_xwefsubscription[:dsc_maxlatencytime]).to eq(64)
   end
 
   it 'should accept uint for dsc_maxlatencytime' do
@@ -350,8 +351,9 @@ describe Puppet::Type.type(:dsc_xwefsubscription) do
     expect{dsc_xwefsubscription[:dsc_heartbeatinterval] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_heartbeatinterval' do
-    expect{dsc_xwefsubscription[:dsc_heartbeatinterval] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_heartbeatinterval' do
+    dsc_xwefsubscription[:dsc_heartbeatinterval] = 64
+    expect(dsc_xwefsubscription[:dsc_heartbeatinterval]).to eq(64)
   end
 
   it 'should accept uint for dsc_heartbeatinterval' do

--- a/spec/unit/puppet/type/dsc_xwindowsprocess_spec.rb
+++ b/spec/unit/puppet/type/dsc_xwindowsprocess_spec.rb
@@ -231,8 +231,9 @@ describe Puppet::Type.type(:dsc_xwindowsprocess) do
     expect{dsc_xwindowsprocess[:dsc_pagedmemorysize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_pagedmemorysize' do
-    expect{dsc_xwindowsprocess[:dsc_pagedmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_pagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_pagedmemorysize] = 64
+    expect(dsc_xwindowsprocess[:dsc_pagedmemorysize]).to eq(64)
   end
 
   it 'should accept uint for dsc_pagedmemorysize' do
@@ -266,8 +267,9 @@ describe Puppet::Type.type(:dsc_xwindowsprocess) do
     expect{dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_nonpagedmemorysize' do
-    expect{dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_nonpagedmemorysize' do
+    dsc_xwindowsprocess[:dsc_nonpagedmemorysize] = 64
+    expect(dsc_xwindowsprocess[:dsc_nonpagedmemorysize]).to eq(64)
   end
 
   it 'should accept uint for dsc_nonpagedmemorysize' do
@@ -301,8 +303,9 @@ describe Puppet::Type.type(:dsc_xwindowsprocess) do
     expect{dsc_xwindowsprocess[:dsc_virtualmemorysize] = true}.to raise_error(Puppet::ResourceError)
   end
 
-  it 'should not accept int for dsc_virtualmemorysize' do
-    expect{dsc_xwindowsprocess[:dsc_virtualmemorysize] = -16}.to raise_error(Puppet::ResourceError)
+  it 'should accept int for dsc_virtualmemorysize' do
+    dsc_xwindowsprocess[:dsc_virtualmemorysize] = 64
+    expect(dsc_xwindowsprocess[:dsc_virtualmemorysize]).to eq(64)
   end
 
   it 'should accept uint for dsc_virtualmemorysize' do


### PR DESCRIPTION
Some DSC Resource parameters accept uint arrays. Account for this in the
type generation by detecting the unit array and adding correct
validation and spec generation

Note this relies on PR #119 being merged first in order to build the types correctly.