### PR TITLE
(MODULES-2244) Remove WaitFor DSC Resources from Upstream

### DIFF
--- a/build/dsc.rake
+++ b/build/dsc.rake
@@ -110,8 +110,8 @@ eod
     task :build, [:module_path] do |t, args|
       module_path = args[:module_path] || default_dsc_module_path
       m = Dsc::Manager.new
-      wait_for_resources = Dir["#{module_path}/**/*WaitFor*"]
-      fail "WaitFor* resources found - aborting type building!\n\n#{wait_for_resources}\n" if !wait_for_resources.empty?
+      wait_for_resources = Dir["#{module_path}/**/MSFT_WaitFor*"]
+      fail "MSFT_WaitFor* resources found - aborting type building! Please remove the following MSFT_WaitFor* DSC Resources and run the build again.\n\n#{wait_for_resources}\n" if !wait_for_resources.empty?
       m.target_module_path = module_path
       msgs = m.build_dsc_types
       msgs.each{|m| puts "#{m}"}


### PR DESCRIPTION
Update rake task to remove any WaitFor DSC Resources downloaded from the
upstream DSCResources repo