### PR TITLE
(MODULES-2579) Handle Signed Integers

### DIFF
--- a/build/dsc/property.rb
+++ b/build/dsc/property.rb
@@ -99,11 +99,11 @@ module Dsc
     end
 
     def int?
-      ["int16","int32","int64","sint16","sint32","sint64"].include?(type)
+      ["int8","int16","int32","int64","sint8","sint16","sint32","sint64"].include?(type)
     end
 
     def int_array?
-      ["int16[]","int32[]","int64[]"].include?(type)
+      ["int8[]","int16[]","int32[]","int64[]","sint8[]","sint16[]","sint32[]","sint64[]"].include?(type)
     end
 
     def string?

--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -173,7 +173,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
       end
 <%    when property.bool? -%>
 <%    when property.int? -%>
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
 <%    when property.uint? -%>

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -226,7 +226,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -243,7 +243,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet/type/dsc_xblautobitlocker.rb
+++ b/lib/puppet/type/dsc_xblautobitlocker.rb
@@ -76,7 +76,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
@@ -88,7 +88,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -165,7 +165,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -211,7 +211,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
@@ -228,7 +228,7 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet/type/dsc_xexchreceiveconnector.rb
+++ b/lib/puppet/type/dsc_xexchreceiveconnector.rb
@@ -449,7 +449,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -480,7 +480,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -511,7 +511,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -528,7 +528,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -573,7 +573,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet/type/dsc_xexchwaitforadprep.rb
+++ b/lib/puppet/type/dsc_xexchwaitforadprep.rb
@@ -91,7 +91,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
     def mof_is_embedded?; false end
     desc "Specifies that the Active Directory schema should have been prepared using Exchange 2013 'setup /PrepareSchema', and should be at the specified version"
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -109,7 +109,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
     def mof_is_embedded?; false end
     desc "Specifies that the Exchange Organization should have been prepared using Exchange 2013 'setup /PrepareAD', and should be at the specified version"
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -127,7 +127,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
     def mof_is_embedded?; false end
     desc "Specifies that the domain containing the target Exchange 2013 server was prepared using setup /PrepareAD, /PrepareDomain, or /PrepareAllDomains, and should be at the specified version"
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet/type/dsc_xwefsubscription.rb
+++ b/lib/puppet/type/dsc_xwefsubscription.rb
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
     def mof_is_embedded?; false end
     desc "The number of events that can occur on the source before they are submitted to the collector, default 1"
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -230,7 +230,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end
@@ -247,7 +247,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
     def mof_type; 'sint32' end
     def mof_is_embedded?; false end
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -75,7 +75,7 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
     def mof_is_embedded?; false end
     desc "sizethat the event log file is allowed to be When the file reaches this maximum size it is considered full"
     validate do |value|
-      unless value.kind_of?(Numeric) || value.to_i.to_s == value || value.to_i >= 0
+      unless value.kind_of?(Numeric) || value.to_i.to_s == value
           fail("Invalid value #{value}. Should be a signed Integer")
       end
     end

--- a/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
@@ -72,9 +72,10 @@ module PuppetX
           munge_boolean(value.to_s)
         when "uint8","uint16","uint32","uint64",
           "uint8[]","uint16[]","uint32[]","uint64[]",
-          "int16","int32","int64",
-          "sint16","sint32","sint64",
-          "int16[]","int32[]","int64[]"
+          "int8","int16","int32","int64",
+          "int8[]","int16[]","int32[]","int64[]",
+          "sint8","sint16","sint32","sint64",
+          "sint8[]","sint16[]","sint32[]","sint64[]"
 
           width = mof_type[:type].gsub(/[^\d]/, '').to_i
 


### PR DESCRIPTION
- [x] Fix signed integer validation
- [x] Add sint8[], sint16[], sint32[], and sint64[] to the parameter code generation
- [x] Add sint8[], sint16[], sint32[], and sint64[] to the validation helpers

*Note*: PR #118 fixes generating correct validation methods for integer array (uint32[]..etc) parameters. This PR doesn't try to fix that since it's already done.