### PR TITLE
(MODULES-2771) Ping master_manipulator Version

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -20,7 +20,7 @@ Gemfile:
     ':system_tests':
       - gem: beaker
       - gem: master_manipulator
-        version: '~> 1.1'
+        version: '1.1.2'
     ':build':
       - gem: 'librarian-repo'
         git: 'https://github.com/msutter/librarian-repo.git'


### PR DESCRIPTION
The QA-2147 bug causes the DSC pipeline to break on PE 3.8.x. To work around
this issue temporarily we need to pin the version to known working release.
This fix should allow the acceptance tests to pass in the CI pipeline.
[skip-ci]