### PR TITLE
(MODULES-2689) Update Tests to Use "MODULE_VERSION" Env Var

### DIFF
--- a/tests/acceptance/pre-suite/02_dsc_module_install.rb
+++ b/tests/acceptance/pre-suite/02_dsc_module_install.rb
@@ -4,9 +4,12 @@ confine(:to, :platform => 'windows')
 
 # Init
 proj_root = File.expand_path(File.join(File.dirname(__FILE__), '../../../'))
-puts(proj_root)
+
 staging = { :module_name => 'puppetlabs-dsc' }
 local = { :module_name => 'dsc', :source => proj_root }
+
+# Check to see if module version is specified.
+staging[:version] = ENV['MODULE_VERSION'] if ENV['MODULE_VERSION']
 
 agents.each do |agent|
   step 'Install DSC Module Dependencies'

--- a/tests/integration/pre-suite/01_dsc_module_install.rb
+++ b/tests/integration/pre-suite/01_dsc_module_install.rb
@@ -1,8 +1,5 @@
 test_name 'FM-2626 - C68506 - Plug-in Sync Module from Master with Prerequisites Satisfied on Agent'
 
-# step 'Install Module via PMT'
-# stub_forge_on(master, options[:forge_host] || 'api-module-staging.puppetlabs.com')
-
 step 'Install DSC Module Dependencies'
 on(master, puppet('module install puppetlabs-stdlib'))
 on(master, puppet('module install puppetlabs-powershell'))
@@ -11,6 +8,9 @@ step 'Install DSC Module'
 proj_root = File.expand_path(File.join(File.dirname(__FILE__), '../../../'))
 staging = { :module_name => 'puppetlabs-dsc' }
 local = { :module_name => 'dsc', :source => proj_root, :target_module_path => master['distmoduledir'] }
+
+# Check to see if module version is specified.
+staging[:version] = ENV['MODULE_VERSION'] if ENV['MODULE_VERSION']
 
 # in CI install from staging forge, otherwise from local
 install_dev_puppet_module_on(master, options[:forge_host] ? staging : local)

--- a/tests/test_run_scripts/acceptance_tests.sh
+++ b/tests/test_run_scripts/acceptance_tests.sh
@@ -13,8 +13,8 @@ if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64a'
   ARGS[1]='1.2.2'
   ARGS[2]='forge'
-elif [ $# -ne 3 ]; then
-  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE>'
+elif [[ $# -lt 3 || $# -gt 4 ]]; then
+  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE> <MODULE_VERSION>'
   exit 1
 else
   ARGS=("$@")
@@ -33,9 +33,20 @@ elif [ ${ARGS[2]} == 'local' ]; then
   echo 'Testing Module Using Local Code'
 else
   echo 'You must specify "forge" or "local" for test type!'
-  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE>'
+  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE> <MODULE_VERSION>'
   exit 1
 fi
+
+# Determine if a module version was specified.
+if [ -n "${ARGS[3]}" ]; then
+  echo "Using Module Version: ${ARGS[3]}"
+  export MODULE_VERSION=${ARGS[3]}
+elif [[ $# -eq 3 && ${ARGS[2]} == 'forge' ]]; then
+  echo 'WARNING: Running Acceptance Tests from Forge without Module Version!'
+fi
+
+# Sleep so the user has time to read script messages.
+sleep 2
 
 export BEAKER_PUPPET_AGENT_VERSION=${ARGS[1]}
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net

--- a/tests/test_run_scripts/integration_tests.sh
+++ b/tests/test_run_scripts/integration_tests.sh
@@ -12,8 +12,8 @@ if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64mda'
   ARGS[1]='http://neptune.puppetlabs.lan/2015.2/preview'
   ARGS[2]='forge'
-elif [ $# -ne 3 ]; then
-  echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR> <LOCAL_OR_FORGE>'
+elif [[ $# -lt 3 || $# -gt 4 ]]; then
+  echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR> <LOCAL_OR_FORGE> <MODULE_VERSION>'
   exit 1
 else
   ARGS=("$@")
@@ -32,9 +32,20 @@ elif [ ${ARGS[2]} == 'local' ]; then
   echo 'Testing Module Using Local Code'
 else
   echo 'You must specify "forge" or "local" for test type!'
-  echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE>'
+  echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR> <LOCAL_OR_FORGE> <MODULE_VERSION>'
   exit 1
 fi
+
+# Determine if a module version was specified.
+if [ -n "${ARGS[3]}" ]; then
+  echo "Using Module Version: ${ARGS[3]}"
+  export MODULE_VERSION=${ARGS[3]}
+elif [[ $# -eq 3 && ${ARGS[2]} == 'forge' ]]; then
+  echo 'WARNING: Running Integration Tests from Forge without Module Version!'
+fi
+
+# Sleep so the user has time to read script messages.
+sleep 2
 
 export pe_dist_dir=${ARGS[1]}
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net


### PR DESCRIPTION
The integration and acceptance tests will attempt to always use the latest
module from the staging Forge currently. However, this will not always pickup
the latests pre-released version of the module if final releases exist. The
"MODULE_VERSION" environment variable is set by CI when pre-releases of a
module are published to the staging Forge.