### PR TITLE
(WIP)(MODULES-2785) Fix Broken Teardown 

### DIFF
--- a/tests/acceptance/pre-suite/00_install_certs.rb
+++ b/tests/acceptance/pre-suite/00_install_certs.rb
@@ -1,4 +1,3 @@
-#require 'pry-debugger'
 test_name "Install CA Certs"
 confine(:to, :platform => 'windows')
 

--- a/tests/acceptance/pre-suite/00_install_certs.rb
+++ b/tests/acceptance/pre-suite/00_install_certs.rb
@@ -1,5 +1,8 @@
+#require 'pry-debugger'
 test_name "Install CA Certs"
 confine(:to, :platform => 'windows')
+
+temp_dir_name = 'windows\temp'
 
 GEOTRUST_GLOBAL_CA = <<-EOM
 -----BEGIN CERTIFICATE-----
@@ -76,18 +79,16 @@ A4GBAFjOKer89961zgK5F7WF0bnj4JXMJTENAKaSbn+2kmOeUJXRmm/kEd5jhW6Y
 EOM
 
 hosts.each do |host|
+  # The 'root' is considered to be "C:\" on BitVise templates.
   step "Installing Geotrust CA cert"
-  create_remote_file(host, "geotrustglobal.pem", GEOTRUST_GLOBAL_CA)
-  on host, "chmod 644 geotrustglobal.pem"
-  on host, "cmd /c certutil -v -addstore Root `cygpath -w geotrustglobal.pem`"
+  create_remote_file(host, "#{temp_dir_name}/geotrustglobal.pem".gsub(/\\/,'/'), GEOTRUST_GLOBAL_CA)
+  on(host, "cmd /c certutil -v -addstore Root c:\\#{temp_dir_name}\\geotrustglobal.pem")
 
   step "Installing Usertrust Network CA cert"
-  create_remote_file(host, "usertrust-network.pem", USERTRUST_NETWORK_CA)
-  on host, "chmod 644 usertrust-network.pem"
-  on host, "cmd /c certutil -v -addstore Root `cygpath -w usertrust-network.pem`"
+  create_remote_file(host, "#{temp_dir_name}/usertrust-network.pem".gsub(/\\/,'/'), USERTRUST_NETWORK_CA)
+  on(host, "cmd /c certutil -v -addstore Root c:\\#{temp_dir_name}\\usertrust-network.pem")
 
   step "Installing Equifax CA cert"
-  create_remote_file(host, "equifax.pem", EQUIFAX_CA)
-  on host, "chmod 644 equifax.pem"
-  on host, "cmd /c certutil -v -addstore Root `cygpath -w equifax.pem`"
+  create_remote_file(host, "#{temp_dir_name}/equifax.pem".gsub(/\\/,'/'), EQUIFAX_CA)
+  on(host, "cmd /c certutil -v -addstore Root c:\\#{temp_dir_name}\\equifax.pem")
 end

--- a/tests/acceptance/pre-suite/02_dsc_module_install.rb
+++ b/tests/acceptance/pre-suite/02_dsc_module_install.rb
@@ -14,7 +14,8 @@ agents.each do |agent|
   on(agent, puppet('module install puppetlabs-powershell'))
 
   step 'Install DSC Module'
-  local[:target_module_path] = agent['distmoduledir']
+  local[:target_module_path] = agent['distmoduledir'][2,agent['distmoduledir'].length]
+
   # in CI install from staging forge, otherwise from local
   install_dev_puppet_module_on(agent, options[:forge_host] ? staging : local)
 end

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
@@ -7,6 +7,8 @@ confine(:to, :platform => 'windows')
 test_dir_name = 'test'
 
 # In-line Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 test_dir_path = "C:/#{test_dir_name}"
 test_file_path = "#{test_dir_path}/test.txt"
 test_file_contents = 'catcat'
@@ -27,7 +29,15 @@ MANIFEST
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'Directory',
+    :Force           => '$true',
+    :DestinationPath => test_dir_path
+  )
 end
 
 # Tests
@@ -40,9 +50,9 @@ agents.each do |agent|
   step 'Verify Results'
   assert_dsc_resource(
     agent,
-    'File',
-    'PSDesiredStateConfiguration',
+    dsc_type,
+    dsc_module,
     :DestinationPath => test_file_path,
-    :Contents => test_file_contents
+    :Contents        => test_file_contents
   )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
@@ -7,6 +7,8 @@ confine(:to, :platform => 'windows')
 test_dir_name = 'test'
 
 # In-line Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 test_dir_path = "C:/#{test_dir_name}"
 test_file_path = "#{test_dir_path}/test.txt"
 test_file_contents = 'catcat'
@@ -27,7 +29,15 @@ MANIFEST
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'Directory',
+    :Force           => '$true',
+    :DestinationPath => test_dir_path
+  )
 end
 
 # Tests
@@ -40,9 +50,9 @@ agents.each do |agent|
   step 'Verify Results'
   assert_dsc_resource(
     agent,
-    'File',
-    'PSDesiredStateConfiguration',
+    dsc_type,
+    dsc_module,
     :DestinationPath => test_file_path,
-    :Contents => test_file_contents
+    :Contents        => test_file_contents
   )
 end

--- a/tests/acceptance/tests/basic_dsc_resources/file/dir_valid_unicode_path.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/dir_valid_unicode_path.rb
@@ -7,7 +7,7 @@ confine(:to, :platform => 'windows')
 # Init
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 test_manifest_name = 'test_manifest.pp'
-test_dir_name = "\u1134\u1169\u1185\u1173\u112D\u1117\u1114\u1135\u114E"
+test_manifest_path = "C:\\#{test_manifest_name}"
 
 # ERB Manifest
 dsc_type = 'file'
@@ -15,7 +15,7 @@ dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
   :dsc_type            => 'Directory',
-  :dsc_destinationpath => "C:\\#{test_dir_name}"
+  :dsc_destinationpath => "C:\\\u1134\u1169\u1185\u1173\u112D\u1117\u1114\u1135\u114E"
 }
 
 dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
@@ -24,21 +24,43 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
-  on(agents, "rm -rf /cygdrive/c/#{test_manifest_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => dsc_props[:dsc_type],
+    :DestinationPath => dsc_props[:dsc_destinationpath]
+  )
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'File',
+    :DestinationPath => test_manifest_path
+  )
 end
 
 # Setup
-create_remote_file(agents, "/cygdrive/c/#{test_manifest_name}", dsc_manifest)
+create_remote_file(agents, "/#{test_manifest_name}", dsc_manifest)
 
 # Tests
 agents.each do |agent|
   step 'Apply Manifest'
-  on(agent, puppet("apply C:\\\\#{test_manifest_name}"), :acceptable_exit_codes => [0,2]) do |result|
+  on(agent, puppet("apply #{test_manifest_path}"), :acceptable_exit_codes => [0,2]) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
-  # Expected to fail because of MODULES-2310
   step 'Verify Results'
-  on(agent, "test -d /cygdrive/c/#{test_dir_name}", :acceptable_exit_codes => 1)
+  expect_failure('Expected to fail because of MODULES-2310') do
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:dsc_ensure],
+      :Type            => dsc_props[:dsc_type],
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
+  end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_contents.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_contents.rb
@@ -7,46 +7,62 @@ confine(:to, :platform => 'windows')
 # Init
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 test_manifest_name = 'test_manifest.pp'
-test_file_name = 'test.file'
-test_file_contents = "\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158\u3140\u3145\u3176\u3145"
+test_manifest_path = "C:\\#{test_manifest_name}"
 
 # ERB Manifest
 dsc_type = 'file'
 dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
-  :dsc_destinationpath => "C:\\#{test_file_name}"
+  :dsc_type            => 'File',
+  :dsc_contents        => "\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158\u3140\u3145\u3176\u3145",
+  :dsc_destinationpath => "C:\\test.file"
 }
 
 dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
-# Verify
-test_file_md5_sum_regex = /6ba9d431f246339d2e659e71c6d1eb6a  \/cygdrive\/c\/#{test_file_name}/
-
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_file_name}")
-  on(agents, "rm -rf /cygdrive/c/#{test_manifest_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => dsc_props[:dsc_type],
+    :DestinationPath => dsc_props[:dsc_destinationpath]
+  )
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'File',
+    :DestinationPath => test_manifest_path
+  )
 end
 
 # Setup
-create_remote_file(agents, "/cygdrive/c/#{test_manifest_name}", dsc_manifest)
+create_remote_file(agents, "/#{test_manifest_name}", dsc_manifest)
 
 # Tests
 agents.each do |agent|
   step 'Apply Manifest'
-  on(agent, puppet("apply C:\\\\#{test_manifest_name}"), :acceptable_exit_codes => [0,2]) do |result|
-    expect_failure('Expected to fail because of MODULES-2310') do
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
+  on(agent, puppet("apply #{test_manifest_path}"), :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify Results'
-  on(agent, "md5sum /cygdrive/c/#{test_file_name}", :acceptable_exit_codes => 1) do |result|
-    expect_failure('Expected to fail because of MODULES-2310') do
-      assert_match(test_file_md5_sum_regex, result.stdout, 'Expected file content is invalid!')
-    end
+  expect_failure('Expected to fail because of MODULES-2310') do
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:dsc_ensure],
+      :Type            => dsc_props[:dsc_type],
+      :Contents        => dsc_props[:dsc_contents],
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_path.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_path.rb
@@ -7,14 +7,16 @@ confine(:to, :platform => 'windows')
 # Init
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 test_manifest_name = 'test_manifest.pp'
-test_file_name = "\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158\u3140\u3145\u3176\u3145"
+test_manifest_path = "C:\\#{test_manifest_name}"
 
 # ERB Manifest
 dsc_type = 'file'
 dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
-  :dsc_destinationpath => "C:\\#{test_file_name}"
+  :dsc_type            => 'File',
+  :dsc_contents        => 'Not cool',
+  :dsc_destinationpath => "C:\\\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158\u3140\u3145\u3176\u3145"
 }
 
 dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
@@ -23,22 +25,44 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_file_name}")
-  on(agents, "rm -rf /cygdrive/c/#{test_manifest_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => dsc_props[:dsc_type],
+    :DestinationPath => dsc_props[:dsc_destinationpath]
+  )
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'File',
+    :DestinationPath => test_manifest_path
+  )
 end
 
 # Setup
-create_remote_file(agents, "/cygdrive/c/#{test_manifest_name}", dsc_manifest)
+create_remote_file(agents, "/#{test_manifest_name}", dsc_manifest)
 
 # Tests
 agents.each do |agent|
   step 'Apply Manifest'
-  on(agent, puppet("apply C:\\\\#{test_manifest_name}"), :acceptable_exit_codes => [0,2]) do |result|
-    expect_failure('Expected to fail because of MODULES-2310') do
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
+  on(agent, puppet("apply #{test_manifest_path}"), :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify Results'
-  on(agent, "test -f /cygdrive/c/#{test_file_name}", :acceptable_exit_codes => 1)
+  expect_failure('Expected to fail because of MODULES-2310') do
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:dsc_ensure],
+      :Type            => dsc_props[:dsc_type],
+      :Contents        => dsc_props[:dsc_contents],
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
+  end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_source.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/file/file_valid_unicode_source.rb
@@ -7,6 +7,7 @@ confine(:to, :platform => 'windows')
 # Init
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 test_manifest_name = 'test_manifest.pp'
+test_manifest_path = "C:\\#{test_manifest_name}"
 test_file_name = 'test.file'
 source_file_name = "\u3172\u3142\u3144\u3149\u3151\u3167\u3169\u3159\u3158\u3140\u3145\u3176\u3145"
 
@@ -15,7 +16,8 @@ dsc_type = 'file'
 dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure          => 'Present',
-  :dsc_destinationpath => "C:\\#{test_file_name}",
+  :dsc_type            => 'File',
+  :dsc_destinationpath => 'C:/test.file',
   :dsc_sourcepath      => "C:\\#{source_file_name}"
 }
 
@@ -25,31 +27,64 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_file_name}")
-  on(agents, "rm -rf /cygdrive/c/#{source_file_name}")
-  on(agents, "rm -rf /cygdrive/c/#{test_manifest_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => dsc_props[:dsc_type],
+    :DestinationPath => dsc_props[:dsc_destinationpath]
+  )
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => dsc_props[:dsc_type],
+    :DestinationPath => dsc_props[:dsc_sourcepath]
+  )
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'File',
+    :DestinationPath => test_manifest_path
+  )
 end
 
 # Verify
 source_file_contents = 'Valid data!'
 
 # Setup
-create_remote_file(agents, "/cygdrive/c/#{test_manifest_name}", dsc_manifest)
-create_remote_file(agents, "/cygdrive/c/#{source_file_name}", source_file_contents)
+create_remote_file(agents, "/#{test_manifest_name}", dsc_manifest)
+set_dsc_resource(
+  agents,
+  dsc_type,
+  dsc_module,
+  :Ensure          => 'Present',
+  :Type            => dsc_props[:dsc_type],
+  :Contents        => source_file_contents,
+  :DestinationPath => dsc_props[:dsc_sourcepath]
+)
 
 # Tests
 agents.each do |agent|
   step 'Apply Manifest'
-  on(agent, puppet("apply C:\\\\#{test_manifest_name}"), :acceptable_exit_codes => [0,2]) do |result|
-    expect_failure('Expected to fail because of MODULES-2310') do
-      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-    end
+  on(agent, puppet("apply #{test_manifest_path}"), :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 
   step 'Verify Results'
-  on(agent, "cat /cygdrive/c/#{test_file_name}", :acceptable_exit_codes => 1) do |result|
-    expect_failure('Expected to fail because of MODULES-2310') do
-      assert_match(/\A#{source_file_contents}\z/, result.stdout, 'File content is invalid!')
-    end
+  expect_failure('Expected to fail because of MODULES-2310') do
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:dsc_ensure],
+      :Type            => dsc_props[:dsc_type],
+      :Contents        => source_file_contents,
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/group/group_unicode_groupname.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/group/group_unicode_groupname.rb
@@ -7,6 +7,7 @@ confine(:to, :platform => 'windows')
 # Init
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 test_manifest_name = 'test_manifest.pp'
+test_manifest_path = "C:\\#{test_manifest_name}"
 
 # ERB Manifest
 dsc_type = 'group'
@@ -29,16 +30,23 @@ teardown do
     :Ensure    => 'Absent',
     :GroupName  => dsc_props[:dsc_groupname]
   )
-  on(agents, "rm -rf /cygdrive/c/#{test_manifest_name}")
+  set_dsc_resource(
+    agents,
+    'File',
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'File',
+    :DestinationPath => test_manifest_path
+  )
 end
 
 # Setup
-create_remote_file(agents, "/cygdrive/c/#{test_manifest_name}", dsc_manifest)
+create_remote_file(agents, "/#{test_manifest_name}", dsc_manifest)
 
 # Tests
 agents.each do |agent|
   step 'Apply Manifest'
-  on(agent, puppet("apply C:\\\\#{test_manifest_name}"), :acceptable_exit_codes => [0,2]) do |result|
+  on(agent, puppet("apply #{test_manifest_path}"), :acceptable_exit_codes => [0,2]) do |result|
     assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
   end
 

--- a/tests/acceptance/tests/basic_dsc_resources/package/negative/package_failed_install.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/package/negative/package_failed_install.rb
@@ -26,7 +26,7 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "cmd /c \"#{install_path}\\uninstall.exe /S\"")
+  on(agents, powershell("Start-Process \"#{install_path}\\uninstall.exe /S\" -Wait"))
 
   set_dsc_resource(
     agents,

--- a/tests/acceptance/tests/basic_dsc_resources/package/package_valid_args.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/package/package_valid_args.rb
@@ -26,7 +26,7 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "cmd /c \"#{install_path}\\Uninstall.exe /S\"")
+  on(agents, powershell("Start-Process \"#{install_path}\\Uninstall.exe /S\" -Wait"))
 
   set_dsc_resource(
     agents,

--- a/tests/acceptance/tests/basic_dsc_resources/package/package_valid_returncode.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/package/package_valid_returncode.rb
@@ -27,7 +27,7 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(bin
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "cmd /c \"#{install_path}\\uninstall.exe /S\"", :acceptable_exit_codes => 1)
+  on(agents, powershell("Start-Process \"#{install_path}\\uninstall.exe /S\" -Wait"), :acceptable_exit_codes => 1)
 
   set_dsc_resource(
     agents,

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -3,11 +3,8 @@ test_name 'FM-2624 - C68533 - Apply DSC Resource Manifest with Mix of Passing an
 
 confine(:to, :platform => 'windows')
 
-# Init
-test_dir_name = 'test'
-
 # In-line Manifest
-test_dir_good = "C:/#{test_dir_name}"
+test_dir_good = 'C:/test'
 test_dir_bad = "Q:/not/here"
 
 dsc_manifest = <<-MANIFEST
@@ -29,7 +26,15 @@ error_msg = /Error: The system cannot find the path specified. The related file\
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  set_dsc_resource(
+    agents,
+    'File',
+    'PSDesiredStateConfiguration',
+    :Ensure          => 'Absent',
+    :Type            => 'Directory',
+    :Force           => '$true',
+    :DestinationPath => test_dir_good
+  )
 end
 
 # Tests

--- a/tests/acceptance/tests/basic_dsc_resources/windowsprocess/process_valid_args.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/windowsprocess/process_valid_args.rb
@@ -6,7 +6,7 @@ confine(:to, :platform => 'windows')
 
 # Init
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
-output_file_name = 'ping.out'
+output_file_path = 'C:\ping.out'
 
 # ERB Manifest
 dsc_type = 'windowsprocess'
@@ -14,7 +14,7 @@ dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_path      => 'C:\Windows\System32\cmd.exe',
-  :dsc_arguments => "/c ping.exe -n 1 -4 localhost > C:\\#{output_file_name}",
+  :dsc_arguments => "/c ping.exe -n 1 -4 localhost > #{output_file_path}",
 }
 
 dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
@@ -28,7 +28,7 @@ teardown do
     'file',
     dsc_module,
     :Ensure          => 'Absent',
-    :DestinationPath => "C:\\#{output_file_name}"
+    :DestinationPath => output_file_path
   )
 end
 
@@ -43,7 +43,7 @@ agents.each do |agent|
   end
 
   step 'Verify Results'
-  on(agent, "cat /cygdrive/c/#{output_file_name}") do |result|
+  on(agent, powershell("Get-Content #{output_file_path}")) do |result|
     assert_match(output_file_regex, result.stdout, 'Expected contents not detected!')
   end
 end

--- a/tests/acceptance/tests/basic_functionality/allow_lcm_modes.rb
+++ b/tests/acceptance/tests/basic_functionality/allow_lcm_modes.rb
@@ -41,6 +41,6 @@ agents.each do |agent|
     'File',
     'PSDesiredStateConfiguration',
     :DestinationPath => 'C:\test.file',
-    :Contents => 'Cats go meow!'
+    :Contents        => 'Cats go meow!'
   )
 end

--- a/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
+++ b/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
@@ -9,6 +9,8 @@ test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 test_dir_path = "C:\\#{test_dir_name}"
 test_file_path = "#{test_dir_path}\\test.txt"
 test_file_contents = 'catcat'
@@ -19,7 +21,15 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'Directory',
+    :Force           => '$true',
+    :DestinationPath => test_dir_path
+  )
 end
 
 # Tests
@@ -32,9 +42,9 @@ agents.each do |agent|
   step 'Verify Results'
   assert_dsc_resource(
     agent,
-    'File',
-    'PSDesiredStateConfiguration',
+    dsc_type,
+    dsc_module,
     :DestinationPath => test_file_path.gsub("\\", '/'),
-    :Contents => test_file_contents
+    :Contents        => test_file_contents
   )
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
@@ -5,11 +5,12 @@ test_name 'FM-2623 - C68534 - Apply DSC Resource Manifest via "puppet apply" wit
 confine(:to, :platform => 'windows')
 
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
-test_dir_path = "C:/#{test_dir_name}"
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+test_dir_path = 'C:/test'
 test_file_path = "#{test_dir_path}/test.txt"
 test_file_contents = 'catcat'
 
@@ -22,7 +23,15 @@ debug_msg = /Debug:.*Dsc_file\[tmp_file\]: The container Class\[Main\] will prop
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'Directory',
+    :Force           => '$true',
+    :DestinationPath => test_dir_path
+  )
 end
 
 # Tests
@@ -36,9 +45,9 @@ agents.each do |agent|
   step 'Verify that No Changes were Made'
   assert_dsc_resource(
     agent,
-    'File',
-    'PSDesiredStateConfiguration',
+    dsc_type,
+    dsc_module,
     :DestinationPath => test_file_path,
-    :Contents => test_file_contents
+    :Contents        => test_file_contents
   )
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
@@ -5,11 +5,12 @@ test_name 'FM-2625 - C68511 - Apply DSC Resource Manifest via "puppet apply"'
 confine(:to, :platform => 'windows')
 
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
-test_dir_path = "C:/#{test_dir_name}"
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+test_dir_path = 'C:/test'
 test_file_path = "#{test_dir_path}/test.txt"
 test_file_contents = 'catcat'
 
@@ -19,7 +20,15 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 # Teardown
 teardown do
   step 'Remove Test Artifacts'
-  on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+  set_dsc_resource(
+    agents,
+    dsc_type,
+    dsc_module,
+    :Ensure          => 'Absent',
+    :Type            => 'Directory',
+    :Force           => '$true',
+    :DestinationPath => test_dir_path
+  )
 end
 
 # Tests
@@ -32,9 +41,9 @@ agents.each do |agent|
   step 'Verify Results'
   assert_dsc_resource(
     agent,
-    'File',
-    'PSDesiredStateConfiguration',
+    dsc_type,
+    dsc_module,
     :DestinationPath => test_file_path,
-    :Contents => test_file_contents
+    :Contents        => test_file_contents
   )
 end

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
@@ -5,11 +5,10 @@ test_name 'FM-2623 - C68509 - Apply DSC Resource Manifest in "noop" Mode Using "
 confine(:to, :platform => 'windows')
 
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
-test_dir_path = "C:/#{test_dir_name}"
+test_dir_path = 'C:/test'
 test_file_path = "#{test_dir_path}/test.txt"
 test_file_contents = 'catcat'
 
@@ -30,7 +29,7 @@ agents.each do |agent|
       'File',
       'PSDesiredStateConfiguration',
       :DestinationPath => test_file_path,
-      :Contents => test_file_contents
+      :Contents        => test_file_contents
     )
   end
 end

--- a/tests/configs/windows-2008r2-64a
+++ b/tests/configs/windows-2008r2-64a
@@ -3,8 +3,9 @@ HOSTS:
     roles:
       - agent
     platform: windows-2008r2-x86_64
-    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-wmf5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-wmf5-bv-x86_64
     hypervisor: vcloud
+    is_cygwin: false
 CONFIG:
   masterless: true
   nfs_server: none

--- a/tests/configs/windows-2008r2-64mda
+++ b/tests/configs/windows-2008r2-64mda
@@ -12,8 +12,9 @@ HOSTS:
     roles:
       - agent
     platform: windows-2008r2-x86_64
-    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-wmf5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-wmf5-bv-x86_64
     hypervisor: vcloud
+    is_cygwin: false
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/tests/configs/windows-2012r2-64a
+++ b/tests/configs/windows-2012r2-64a
@@ -3,8 +3,9 @@ HOSTS:
     roles:
       - agent
     platform: windows-2012r2-x86_64
-    template: Delivery/Quality Assurance/Templates/vCloud/win-2012r2-wmf5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2012r2-wmf5-bv-x86_64
     hypervisor: vcloud
+    is_cygwin: false
 CONFIG:
   masterless: true
   nfs_server: none

--- a/tests/configs/windows-2012r2-64mda
+++ b/tests/configs/windows-2012r2-64mda
@@ -12,8 +12,9 @@ HOSTS:
     roles:
       - agent
     platform: windows-2012r2-x86_64
-    template: Delivery/Quality Assurance/Templates/vCloud/win-2012r2-wmf5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2012r2-wmf5-bv-x86_64
     hypervisor: vcloud
+    is_cygwin: false
 CONFIG:
   nfs_server: none
   consoleport: 443

--- a/tests/integration/pre-suite/02_configure_lcm.rb
+++ b/tests/integration/pre-suite/02_configure_lcm.rb
@@ -1,3 +1,4 @@
+require 'master_manipulator'
 test_name 'FM-2626 - C70297 - Configure LCM for "Disabled" Refresh Mode'
 
 #Init

--- a/tests/integration/tests/basic_functionality/negative/dsc_on_linux.rb
+++ b/tests/integration/tests/basic_functionality/negative/dsc_on_linux.rb
@@ -27,7 +27,7 @@ inject_site_pp(master, get_site_pp_path(master), site_pp)
 confine_block(:except, :platform => 'windows') do
   agents.each do |agent|
     step 'Run Puppet Agent'
-    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => 4) do |result|
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [4,6]) do |result|
       assert_match(error_msg, result.stderr, 'Expected error was not detected!')
     end
   end

--- a/tests/integration/tests/basic_functionality/puppet_agent_debug_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_debug_dsc_manifest.rb
@@ -4,11 +4,12 @@ require 'dsc_utils'
 test_name 'FM-2623 - C68535 - Apply DSC Resource Manifest via "puppet agent" with Debug Enabled'
 
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
-test_dir_path = "C:/#{test_dir_name}"
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+test_dir_path = 'C:/test'
 test_file_path = "#{test_dir_path}/test.txt"
 test_file_contents = 'catcat'
 
@@ -22,7 +23,15 @@ debug_msg = /Debug:.*Dsc_file\[tmp_file\]: The container Node\[default\] will pr
 teardown do
   confine_block(:to, :platform => 'windows') do
     step 'Remove Test Artifacts'
-    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      dsc_module,
+      :Ensure          => 'Absent',
+      :Type            => 'Directory',
+      :Force           => '$true',
+      :DestinationPath => test_dir_path
+    )
   end
 end
 
@@ -43,10 +52,10 @@ confine_block(:to, :platform => 'windows') do
     step 'Verify that No Changes were Made'
     assert_dsc_resource(
       agent,
-      'File',
-      'PSDesiredStateConfiguration',
+      dsc_type,
+      dsc_module,
       :DestinationPath => test_file_path,
-      :Contents => test_file_contents
+      :Contents        => test_file_contents
     )
   end
 end

--- a/tests/integration/tests/basic_functionality/puppet_agent_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_dsc_manifest.rb
@@ -4,11 +4,12 @@ require 'dsc_utils'
 test_name 'FM-2798 - C68512 - Apply DSC Resource Manifest via "puppet agent"'
 
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
-test_dir_path = "C:/#{test_dir_name}"
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+test_dir_path = 'C:/test'
 test_file_path = "#{test_dir_path}/test.txt"
 test_file_contents = 'catcat'
 
@@ -19,7 +20,15 @@ dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 teardown do
   confine_block(:to, :platform => 'windows') do
     step 'Remove Test Artifacts'
-    on(agents, "rm -rf /cygdrive/c/#{test_dir_name}")
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      dsc_module,
+      :Ensure          => 'Absent',
+      :Type            => 'Directory',
+      :Force           => '$true',
+      :DestinationPath => test_dir_path
+    )
   end
 end
 
@@ -39,10 +48,10 @@ confine_block(:to, :platform => 'windows') do
     step 'Verify Results'
     assert_dsc_resource(
       agent,
-      'File',
-      'PSDesiredStateConfiguration',
+      dsc_type,
+      dsc_module,
       :DestinationPath => test_file_path,
-      :Contents => test_file_contents
+      :Contents        => test_file_contents
     )
   end
 end

--- a/tests/integration/tests/basic_functionality/puppet_agent_noop_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_noop_dsc_manifest.rb
@@ -4,11 +4,10 @@ require 'dsc_utils'
 test_name 'FM-2623 - C68510 - Apply DSC Resource Manifest in "noop" Mode Using "puppet agent"'
 
 # Init
-test_dir_name = 'test'
 local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 
 # ERB Manifest
-test_dir_path = "C:/#{test_dir_name}"
+test_dir_path = 'C:/test'
 test_file_path = "#{test_dir_path}/test.txt"
 test_file_contents = 'catcat'
 
@@ -35,7 +34,7 @@ confine_block(:to, :platform => 'windows') do
         'File',
         'PSDesiredStateConfiguration',
         :DestinationPath => test_file_path,
-        :Contents => test_file_contents
+        :Contents        => test_file_contents
       )
     end
   end

--- a/tests/integration/tests/user_scenarios/create_mysql_database_server.rb
+++ b/tests/integration/tests/user_scenarios/create_mysql_database_server.rb
@@ -5,6 +5,8 @@ require 'master_manipulator'
 test_name 'MODULES-2538 - C89507 - Apply DSC Manifest for Creating a MySql Database Server'
 
 # Init
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
 mysql_msi_file = 'mysql-installer.msi'
 sqlserver_dl_url = 'http://int-resources.ops.puppetlabs.net/QA_resources/microsoft_sql/mysql-installer-community-5.6.17.0.msi'
 sqlserver_dl_path = "C:\\#{mysql_msi_file}"
@@ -27,8 +29,13 @@ teardown do
         :Ensure => 'Absent',
         :ServiceName => mysql_instance,
     )
-    on(agents, "rm -rf /cygdrive/c/#{mysql_msi_file}")
-    on(agents, "rm -rf /cygdrive/c/temp.ps1")
+    set_dsc_resource(
+      agents,
+      'File',
+      'PSDesiredStateConfiguration',
+      :Ensure          => 'Absent',
+      :DestinationPath => "C:/#{mysql_msi_file}"
+    )
   end
 end
 

--- a/tests/lib/dsc_utils.rb
+++ b/tests/lib/dsc_utils.rb
@@ -166,7 +166,7 @@ def set_dsc_resource(hosts, dsc_resource_type, dsc_module, dsc_properties)
   assert_dsc_resource(hosts, dsc_resource_type, dsc_module, dsc_properties)
 end
 
-# Set a DSC resource on a host machine.
+# Set a DSC resource with credential on a host machine.
 #
 # ==== Attributes
 #
@@ -216,7 +216,13 @@ SCRIPT
   exec_ps_script(hosts, ps_command)
 
   # Verify State
-  assert_dsc_resource(hosts, dsc_resource_type, dsc_module, dsc_properties)
+  assert_dsc_cred_resource(hosts,
+                           user,
+                           password,
+                           dsc_resource_type,
+                           dsc_module,
+                           dsc_cred_param,
+                           dsc_properties)
 end
 
 module Beaker
@@ -259,7 +265,7 @@ module Beaker
         end
       end
 
-      # Verify that the PowerShell script.
+      # Verify the expected state of a DSC resource with credential on a given host.
       #
       # ==== Attributes
       #

--- a/tests/manifests/user_scenarios/kitchen_sink.pp.erb
+++ b/tests/manifests/user_scenarios/kitchen_sink.pp.erb
@@ -51,7 +51,6 @@ dsc_package { 'install_7zip':
   dsc_productid => '',
   dsc_arguments => "/S /D=${seven_zip_install_path}"
 }
-->
 dsc_environment { 'add_env_var':
   dsc_ensure => 'Present',
   dsc_name   => $env_var_name,

--- a/tests/manifests/user_scenarios/kitchen_sink.pp.erb
+++ b/tests/manifests/user_scenarios/kitchen_sink.pp.erb
@@ -51,6 +51,7 @@ dsc_package { 'install_7zip':
   dsc_productid => '',
   dsc_arguments => "/S /D=${seven_zip_install_path}"
 }
+->
 dsc_environment { 'add_env_var':
   dsc_ensure => 'Present',
   dsc_name   => $env_var_name,

--- a/tests/test_run_scripts/integration_tests.sh
+++ b/tests/test_run_scripts/integration_tests.sh
@@ -10,7 +10,7 @@ declare -a ARGS
 # Argument Parsing
 if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64mda'
-  ARGS[1]='http://neptune.puppetlabs.lan/2015.2/preview'
+  ARGS[1]='http://neptune.puppetlabs.lan/2015.2/ci-ready'
   ARGS[2]='forge'
 elif [ $# -ne 3 ]; then
   echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR> <LOCAL_OR_FORGE>'

--- a/tests/test_run_scripts/integration_tests.sh
+++ b/tests/test_run_scripts/integration_tests.sh
@@ -10,7 +10,7 @@ declare -a ARGS
 # Argument Parsing
 if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64mda'
-  ARGS[1]='http://neptune.puppetlabs.lan/2015.2/ci-ready'
+  ARGS[1]='http://neptune.puppetlabs.lan/2015.2/preview'
   ARGS[2]='forge'
 elif [ $# -ne 3 ]; then
   echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR> <LOCAL_OR_FORGE>'


### PR DESCRIPTION
The "dsc_utils.rb" contained a bug that prevented a clean teardown of artifacts
for the "create_mysql_database_server.rb" integration test. I also took the
opportunity to adjust some doc strings for methods.

DO NOT MERGE!!

This PR needs #121 merged first.

acceptance test
[skip-ci]