### PR TITLE
(MODULES-2784) Update PE Build Repo

### DIFF
--- a/tests/test_run_scripts/integration_tests.sh
+++ b/tests/test_run_scripts/integration_tests.sh
@@ -10,7 +10,7 @@ declare -a ARGS
 # Argument Parsing
 if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64mda'
-  ARGS[1]='http://neptune.puppetlabs.lan/2015.2/preview'
+  ARGS[1]='http://pe-releases.puppetlabs.lan/2015.2.2/'
   ARGS[2]='forge'
 elif [[ $# -lt 3 || $# -gt 4 ]]; then
   echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR> <LOCAL_OR_FORGE> <MODULE_VERSION>'


### PR DESCRIPTION
The build repository for PE 2015.2 specified in the test run script is out
of date. This update will set the default to use the officially released
build.
acceptance test
[skip-ci]