### PR TITLE
(MODULES-2800) Resource name Property Typo

### DIFF
--- a/build/dsc/resource.rb
+++ b/build/dsc/resource.rb
@@ -27,7 +27,7 @@ module Dsc
     end
 
     def name
-      @ame ||= @resource_cim_class.name
+      @name ||= @resource_cim_class.name
     end
 
     def instance_name


### PR DESCRIPTION
The backing variable to the Name property was missing the n