### PR TITLE
(MODULES-2641) Invoke-DscResource triggers reboot

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
     powershell: "puppetlabs/powershell"
+    reboot: "puppetlabs/reboot"
   symlinks:
     "dsc": "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ dsc_windowsfeature {'IIS':
 
 All DSC Resource names and parameters have to be in lowercase, e.g: `dsc_windowsfeature` or `dsc_name`.
 
+### Handling Reboots with DSC
+
+You will need to add the following `reboot` resource to your manifest. It must have the name `dsc_reboot` for the `dsc` module to find and use it.
+
+~~~puppet
+reboot { 'dsc_reboot' :
+    message => 'DSC has requested a reboot',
+    when => 'pending'
+}
+~~~
+
 ### Installing Packages with DSC
 
 You can install MSIs or EXEs with DSC using the Puppet type `dsc_package` which maps to the `Package` DSC Resource.

--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -237,6 +237,10 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
   end
 
 <%  end %>
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -57,8 +57,12 @@ EOT
     output = powershell(powershell_args, script_content)
     Puppet.debug "Create Dsc Resource returned: #{output}"
     data = JSON.parse(output)
+
     fail(data['errormessage']) if !data['errormessage'].empty?
-    true
+
+    notify_reboot_pending if data['rebootrequired'] == true
+
+    data
   end
 
   def destroy
@@ -67,8 +71,30 @@ EOT
     output = powershell(powershell_args, script_content)
     Puppet.debug "Destroy Dsc Resource returned: #{output}"
     data = JSON.parse(output)
+
     fail(data['errormessage']) if !data['errormessage'].empty?
-    true
+
+    notify_reboot_pending if data['rebootrequired'] == true
+
+    data
+  end
+
+  def notify_reboot_pending
+    Puppet.info "A reboot is required to progress further. Notifying Puppet."
+
+    reboot_resource = resource.catalog.resource(:reboot, 'dsc_reboot')
+    unless reboot_resource
+      Puppet.warning "No reboot resource found in the graph that has 'dsc_reboot' as its name. Cannot signal reboot to Puppet."
+      return
+    end
+
+    if reboot_resource.provider.respond_to?(:reboot_required)
+      # internal API used to let reboot resource knows a reboot is pending
+      reboot_resource.provider.reboot_required = true
+    else
+      Puppet.warning "Reboot module must be updated, since resource does not have :reboot_required method implemented. Cannot signal reboot to Puppet."
+      return
+    end
   end
 
   def format_dsc_value(dsc_value)

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -157,6 +157,10 @@ Puppet::Type.newtype(:dsc_archive) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_archive).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -105,6 +105,10 @@ Puppet::Type.newtype(:dsc_environment) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_environment).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -266,6 +266,10 @@ Puppet::Type.newtype(:dsc_file) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_file).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -159,6 +159,10 @@ Puppet::Type.newtype(:dsc_group) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_group).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -52,6 +52,10 @@ Puppet::Type.newtype(:dsc_log) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_log).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -265,6 +265,10 @@ Puppet::Type.newtype(:dsc_package) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_package).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -159,6 +159,10 @@ Puppet::Type.newtype(:dsc_registry) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_registry).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -119,6 +119,10 @@ Puppet::Type.newtype(:dsc_script) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_script).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -222,6 +222,10 @@ Puppet::Type.newtype(:dsc_service) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_service).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -184,6 +184,10 @@ Puppet::Type.newtype(:dsc_user) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_user).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -151,6 +151,10 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_windowsfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_windowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_windowsoptionalfeature.rb
@@ -205,6 +205,10 @@ Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_windowsoptionalfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -257,6 +257,10 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_windowsprocess).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xadcscertificationauthority.rb
+++ b/lib/puppet/type/dsc_xadcscertificationauthority.rb
@@ -393,6 +393,10 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xadcscertificationauthority).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xadcswebenrollment.rb
+++ b/lib/puppet/type/dsc_xadcswebenrollment.rb
@@ -106,6 +106,10 @@ Puppet::Type.newtype(:dsc_xadcswebenrollment) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xadcswebenrollment).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -178,6 +178,10 @@ Puppet::Type.newtype(:dsc_xaddomain) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xaddomain).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -132,6 +132,10 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xaddomaincontroller).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -144,6 +144,10 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xaddomaintrust).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xadrecyclebin.rb
+++ b/lib/puppet/type/dsc_xadrecyclebin.rb
@@ -101,6 +101,10 @@ Puppet::Type.newtype(:dsc_xadrecyclebin) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xadrecyclebin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -124,6 +124,10 @@ Puppet::Type.newtype(:dsc_xaduser) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xaduser).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -188,6 +188,10 @@ Puppet::Type.newtype(:dsc_xarchive) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xarchive).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -120,6 +120,10 @@ Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazureaffinitygroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurepackadmin.rb
+++ b/lib/puppet/type/dsc_xazurepackadmin.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xazurepackadmin) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurepackadmin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
+++ b/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
@@ -136,6 +136,10 @@ Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurepackdatabasesetting).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurepackfqdn.rb
+++ b/lib/puppet/type/dsc_xazurepackfqdn.rb
@@ -137,6 +137,10 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurepackfqdn).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurepackidentityprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackidentityprovider.rb
@@ -137,6 +137,10 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurepackidentityprovider).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurepackrelyingparty.rb
+++ b/lib/puppet/type/dsc_xazurepackrelyingparty.rb
@@ -137,6 +137,10 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurepackrelyingparty).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurepackresourceprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackresourceprovider.rb
@@ -608,6 +608,10 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurepackresourceprovider).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurepacksetup.rb
+++ b/lib/puppet/type/dsc_xazurepacksetup.rb
@@ -201,6 +201,10 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurepacksetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurepackupdate.rb
+++ b/lib/puppet/type/dsc_xazurepackupdate.rb
@@ -104,6 +104,10 @@ Puppet::Type.newtype(:dsc_xazurepackupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurepackupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -197,6 +197,10 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurequickvm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -120,6 +120,10 @@ Puppet::Type.newtype(:dsc_xazureservice) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazureservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -184,6 +184,10 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazuresqldatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -152,6 +152,10 @@ Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazuresqldatabaseserverfirewallrule).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -135,6 +135,10 @@ Puppet::Type.newtype(:dsc_xazurestorageaccount) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurestorageaccount).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -90,6 +90,10 @@ Puppet::Type.newtype(:dsc_xazuresubscription) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazuresubscription).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -228,6 +228,10 @@ Puppet::Type.newtype(:dsc_xazurevm) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurevm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -150,6 +150,10 @@ Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurevmdscconfiguration).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xazurevmdscextension.rb
+++ b/lib/puppet/type/dsc_xazurevmdscextension.rb
@@ -282,6 +282,10 @@ Puppet::Type.newtype(:dsc_xazurevmdscextension) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xazurevmdscextension).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xblautobitlocker.rb
+++ b/lib/puppet/type/dsc_xblautobitlocker.rb
@@ -365,6 +365,10 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xblautobitlocker).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xblbitlocker.rb
+++ b/lib/puppet/type/dsc_xblbitlocker.rb
@@ -360,6 +360,10 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xblbitlocker).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xbltpm.rb
+++ b/lib/puppet/type/dsc_xbltpm.rb
@@ -103,6 +103,10 @@ Puppet::Type.newtype(:dsc_xbltpm) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xbltpm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xcertreq.rb
+++ b/lib/puppet/type/dsc_xcertreq.rb
@@ -117,6 +117,10 @@ Puppet::Type.newtype(:dsc_xcertreq) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xcertreq).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -86,6 +86,10 @@ Puppet::Type.newtype(:dsc_xcluster) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xcluster).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -117,6 +117,10 @@ Puppet::Type.newtype(:dsc_xcomputer) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xcomputer).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xcredssp.rb
+++ b/lib/puppet/type/dsc_xcredssp.rb
@@ -96,6 +96,10 @@ Puppet::Type.newtype(:dsc_xcredssp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xcredssp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -184,6 +184,10 @@ Puppet::Type.newtype(:dsc_xdatabase) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdatabaselogin.rb
+++ b/lib/puppet/type/dsc_xdatabaselogin.rb
@@ -139,6 +139,10 @@ Puppet::Type.newtype(:dsc_xdatabaselogin) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdatabaselogin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdatabaseserver.rb
+++ b/lib/puppet/type/dsc_xdatabaseserver.rb
@@ -58,6 +58,10 @@ Puppet::Type.newtype(:dsc_xdatabaseserver) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdatabaseserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -137,6 +137,10 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdbpackage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
+++ b/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
@@ -90,6 +90,10 @@ Puppet::Type.newtype(:dsc_xdefaultgatewayaddress) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdefaultgatewayaddress).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -144,6 +144,10 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdhcpserveroption).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -140,6 +140,10 @@ Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdhcpserverreservation).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -188,6 +188,10 @@ Puppet::Type.newtype(:dsc_xdhcpserverscope) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdhcpserverscope).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdisk.rb
+++ b/lib/puppet/type/dsc_xdisk.rb
@@ -106,6 +106,10 @@ Puppet::Type.newtype(:dsc_xdisk) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdisk).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdismfeature.rb
+++ b/lib/puppet/type/dsc_xdismfeature.rb
@@ -90,6 +90,10 @@ Puppet::Type.newtype(:dsc_xdismfeature) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdismfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdnsarecord.rb
+++ b/lib/puppet/type/dsc_xdnsarecord.rb
@@ -87,6 +87,10 @@ Puppet::Type.newtype(:dsc_xdnsarecord) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdnsarecord).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -93,6 +93,10 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdnsserveraddress).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -108,6 +108,10 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdnsserversecondaryzone).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -91,6 +91,10 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdnsserverzonetransfer).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -233,6 +233,10 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xdscwebservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
@@ -283,6 +283,10 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchactivesyncvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchantimalwarescanning.rb
+++ b/lib/puppet/type/dsc_xexchantimalwarescanning.rb
@@ -88,6 +88,10 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchantimalwarescanning).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
@@ -166,6 +166,10 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchautodiscovervirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchautomountpoint.rb
+++ b/lib/puppet/type/dsc_xexchautomountpoint.rb
@@ -234,6 +234,10 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchautomountpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchclientaccessserver.rb
+++ b/lib/puppet/type/dsc_xexchclientaccessserver.rb
@@ -119,6 +119,10 @@ Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchclientaccessserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
@@ -418,6 +418,10 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
@@ -117,6 +117,10 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroupmember).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
@@ -171,6 +171,10 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroupnetwork).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
@@ -230,6 +230,10 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchecpvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexcheventloglevel.rb
+++ b/lib/puppet/type/dsc_xexcheventloglevel.rb
@@ -89,6 +89,10 @@ Puppet::Type.newtype(:dsc_xexcheventloglevel) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexcheventloglevel).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchexchangecertificate.rb
+++ b/lib/puppet/type/dsc_xexchexchangecertificate.rb
@@ -171,6 +171,10 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchexchangecertificate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchexchangeserver.rb
+++ b/lib/puppet/type/dsc_xexchexchangeserver.rb
@@ -178,6 +178,10 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchexchangeserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchimapsettings.rb
+++ b/lib/puppet/type/dsc_xexchimapsettings.rb
@@ -153,6 +153,10 @@ Puppet::Type.newtype(:dsc_xexchimapsettings) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchimapsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchinstall.rb
+++ b/lib/puppet/type/dsc_xexchinstall.rb
@@ -88,6 +88,10 @@ Puppet::Type.newtype(:dsc_xexchinstall) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchinstall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchjetstress.rb
+++ b/lib/puppet/type/dsc_xexchjetstress.rb
@@ -124,6 +124,10 @@ Puppet::Type.newtype(:dsc_xexchjetstress) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchjetstress).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchjetstresscleanup.rb
+++ b/lib/puppet/type/dsc_xexchjetstresscleanup.rb
@@ -153,6 +153,10 @@ Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchjetstresscleanup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchmailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabase.rb
@@ -507,6 +507,10 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchmailboxdatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
@@ -196,6 +196,10 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchmailboxdatabasecopy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchmailboxserver.rb
+++ b/lib/puppet/type/dsc_xexchmailboxserver.rb
@@ -120,6 +120,10 @@ Puppet::Type.newtype(:dsc_xexchmailboxserver) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchmailboxserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchmaintenancemode.rb
+++ b/lib/puppet/type/dsc_xexchmaintenancemode.rb
@@ -152,6 +152,10 @@ Puppet::Type.newtype(:dsc_xexchmaintenancemode) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchmaintenancemode).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
@@ -150,6 +150,10 @@ Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchmapivirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
@@ -270,6 +270,10 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchoabvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchoutlookanywhere.rb
+++ b/lib/puppet/type/dsc_xexchoutlookanywhere.rb
@@ -288,6 +288,10 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchoutlookanywhere).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
@@ -342,6 +342,10 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchowavirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchpopsettings.rb
+++ b/lib/puppet/type/dsc_xexchpopsettings.rb
@@ -153,6 +153,10 @@ Puppet::Type.newtype(:dsc_xexchpopsettings) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchpopsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
@@ -196,6 +196,10 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchpowershellvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchreceiveconnector.rb
+++ b/lib/puppet/type/dsc_xexchreceiveconnector.rb
@@ -890,6 +890,10 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchreceiveconnector).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchtransportservice.rb
+++ b/lib/puppet/type/dsc_xexchtransportservice.rb
@@ -1429,6 +1429,10 @@ Puppet::Type.newtype(:dsc_xexchtransportservice) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchtransportservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchumcallroutersettings.rb
+++ b/lib/puppet/type/dsc_xexchumcallroutersettings.rb
@@ -104,6 +104,10 @@ Puppet::Type.newtype(:dsc_xexchumcallroutersettings) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchumcallroutersettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchumservice.rb
+++ b/lib/puppet/type/dsc_xexchumservice.rb
@@ -104,6 +104,10 @@ Puppet::Type.newtype(:dsc_xexchumservice) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchumservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchwaitforadprep.rb
+++ b/lib/puppet/type/dsc_xexchwaitforadprep.rb
@@ -179,6 +179,10 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchwaitforadprep).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchwaitfordag.rb
+++ b/lib/puppet/type/dsc_xexchwaitfordag.rb
@@ -122,6 +122,10 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchwaitfordag).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
@@ -137,6 +137,10 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchwaitformailboxdatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
@@ -243,6 +243,10 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xexchwebservicesvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -273,6 +273,10 @@ Puppet::Type.newtype(:dsc_xfirewall) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xfirewall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -160,6 +160,10 @@ Puppet::Type.newtype(:dsc_xgroup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xgroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xhotfix.rb
+++ b/lib/puppet/type/dsc_xhotfix.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xhotfix) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xhotfix).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xiisfeaturedelegation.rb
+++ b/lib/puppet/type/dsc_xiisfeaturedelegation.rb
@@ -75,6 +75,10 @@ Puppet::Type.newtype(:dsc_xiisfeaturedelegation) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xiisfeaturedelegation).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xiishandler.rb
+++ b/lib/puppet/type/dsc_xiishandler.rb
@@ -75,6 +75,10 @@ Puppet::Type.newtype(:dsc_xiishandler) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xiishandler).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xiismimetypemapping.rb
+++ b/lib/puppet/type/dsc_xiismimetypemapping.rb
@@ -92,6 +92,10 @@ Puppet::Type.newtype(:dsc_xiismimetypemapping) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xiismimetypemapping).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -172,6 +172,10 @@ Puppet::Type.newtype(:dsc_xiismodule) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xiismodule).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
+++ b/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
@@ -90,6 +90,10 @@ Puppet::Type.newtype(:dsc_xinternetexplorerhomepage) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xinternetexplorerhomepage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -108,6 +108,10 @@ Puppet::Type.newtype(:dsc_xipaddress) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xipaddress).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -142,6 +142,10 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xjeaendpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -126,6 +126,10 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xjeatoolkit).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xmicrosoftupdate.rb
+++ b/lib/puppet/type/dsc_xmicrosoftupdate.rb
@@ -60,6 +60,10 @@ Puppet::Type.newtype(:dsc_xmicrosoftupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xmicrosoftupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xmountimage.rb
+++ b/lib/puppet/type/dsc_xmountimage.rb
@@ -105,6 +105,10 @@ Puppet::Type.newtype(:dsc_xmountimage) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xmountimage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xmppreference.rb
+++ b/lib/puppet/type/dsc_xmppreference.rb
@@ -951,6 +951,10 @@ Puppet::Type.newtype(:dsc_xmppreference) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xmppreference).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -91,6 +91,10 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xmysqldatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -126,6 +126,10 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xmysqlgrant).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -91,6 +91,10 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xmysqlserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -107,6 +107,10 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xmysqluser).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -423,6 +423,10 @@ Puppet::Type.newtype(:dsc_xpackage) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xpackage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xpendingreboot.rb
+++ b/lib/puppet/type/dsc_xpendingreboot.rb
@@ -135,6 +135,10 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xpendingreboot).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
+++ b/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
@@ -58,6 +58,10 @@ Puppet::Type.newtype(:dsc_xpowershellexecutionpolicy) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xpowershellexecutionpolicy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -139,6 +139,10 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xpsendpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xrdremoteapp.rb
+++ b/lib/puppet/type/dsc_xrdremoteapp.rb
@@ -230,6 +230,10 @@ Puppet::Type.newtype(:dsc_xrdremoteapp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xrdremoteapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -102,6 +102,10 @@ Puppet::Type.newtype(:dsc_xrdsessioncollection) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xrdsessioncollection).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -343,6 +343,10 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -89,6 +89,10 @@ Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xrdsessiondeployment).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -78,6 +78,10 @@ Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xremotedesktopadmin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -136,6 +136,10 @@ Puppet::Type.newtype(:dsc_xremotefile) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xremotefile).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xrobocopy.rb
+++ b/lib/puppet/type/dsc_xrobocopy.rb
@@ -232,6 +232,10 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xrobocopy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscdpmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscdpmconsolesetup.rb
@@ -106,6 +106,10 @@ Puppet::Type.newtype(:dsc_xscdpmconsolesetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscdpmconsolesetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
@@ -106,6 +106,10 @@ Puppet::Type.newtype(:dsc_xscdpmdatabaseserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscdpmdatabaseserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscdpmserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmserversetup.rb
@@ -258,6 +258,10 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscdpmserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscomadmin.rb
+++ b/lib/puppet/type/dsc_xscomadmin.rb
@@ -108,6 +108,10 @@ Puppet::Type.newtype(:dsc_xscomadmin) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscomadmin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscomconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscomconsolesetup.rb
@@ -193,6 +193,10 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscomconsolesetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscomconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscomconsoleupdate.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xscomconsoleupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscomconsoleupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscommanagementpack.rb
+++ b/lib/puppet/type/dsc_xscommanagementpack.rb
@@ -146,6 +146,10 @@ Puppet::Type.newtype(:dsc_xscommanagementpack) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscommanagementpack).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscommanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscommanagementserversetup.rb
@@ -477,6 +477,10 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscommanagementserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscommanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscommanagementserverupdate.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xscommanagementserverupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscommanagementserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscomreportingserversetup.rb
+++ b/lib/puppet/type/dsc_xscomreportingserversetup.rb
@@ -254,6 +254,10 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscomreportingserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
@@ -257,6 +257,10 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscomwebconsoleserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserverupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscomwebconsoleserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscsmapowershellsetup.rb
+++ b/lib/puppet/type/dsc_xscsmapowershellsetup.rb
@@ -106,6 +106,10 @@ Puppet::Type.newtype(:dsc_xscsmapowershellsetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscsmapowershellsetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
@@ -257,6 +257,10 @@ Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscsmarunbookworkerserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
@@ -384,6 +384,10 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscsmawebserviceserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscspfserver.rb
+++ b/lib/puppet/type/dsc_xscspfserver.rb
@@ -109,6 +109,10 @@ Puppet::Type.newtype(:dsc_xscspfserver) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscspfserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscspfserversetup.rb
+++ b/lib/puppet/type/dsc_xscspfserversetup.rb
@@ -417,6 +417,10 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscspfserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscspfserverupdate.rb
+++ b/lib/puppet/type/dsc_xscspfserverupdate.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xscspfserverupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscspfserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscspfsetting.rb
+++ b/lib/puppet/type/dsc_xscspfsetting.rb
@@ -141,6 +141,10 @@ Puppet::Type.newtype(:dsc_xscspfsetting) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscspfsetting).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscspfstamp.rb
+++ b/lib/puppet/type/dsc_xscspfstamp.rb
@@ -109,6 +109,10 @@ Puppet::Type.newtype(:dsc_xscspfstamp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscspfstamp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscsrserversetup.rb
+++ b/lib/puppet/type/dsc_xscsrserversetup.rb
@@ -277,6 +277,10 @@ Puppet::Type.newtype(:dsc_xscsrserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscsrserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscsrserverupdate.rb
+++ b/lib/puppet/type/dsc_xscsrserverupdate.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xscsrserverupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscsrserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscvmmadmin.rb
+++ b/lib/puppet/type/dsc_xscvmmadmin.rb
@@ -108,6 +108,10 @@ Puppet::Type.newtype(:dsc_xscvmmadmin) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscvmmadmin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscvmmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscvmmconsolesetup.rb
@@ -157,6 +157,10 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscvmmconsolesetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xscvmmconsoleupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscvmmconsoleupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
@@ -574,6 +574,10 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscvmmmanagementserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserverupdate) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xscvmmmanagementserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -241,6 +241,10 @@ Puppet::Type.newtype(:dsc_xservice) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -289,6 +289,10 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsmbshare).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspbcsserviceapp.rb
+++ b/lib/puppet/type/dsc_xspbcsserviceapp.rb
@@ -116,6 +116,10 @@ Puppet::Type.newtype(:dsc_xspbcsserviceapp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspbcsserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspcacheaccounts.rb
+++ b/lib/puppet/type/dsc_xspcacheaccounts.rb
@@ -101,6 +101,10 @@ Puppet::Type.newtype(:dsc_xspcacheaccounts) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspcacheaccounts).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspcreatefarm.rb
+++ b/lib/puppet/type/dsc_xspcreatefarm.rb
@@ -170,6 +170,10 @@ Puppet::Type.newtype(:dsc_xspcreatefarm) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspcreatefarm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspdiagnosticloggingsettings.rb
+++ b/lib/puppet/type/dsc_xspdiagnosticloggingsettings.rb
@@ -359,6 +359,10 @@ Puppet::Type.newtype(:dsc_xspdiagnosticloggingsettings) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspdiagnosticloggingsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspdistributedcacheservice.rb
+++ b/lib/puppet/type/dsc_xspdistributedcacheservice.rb
@@ -140,6 +140,10 @@ Puppet::Type.newtype(:dsc_xspdistributedcacheservice) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspdistributedcacheservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspfeature.rb
+++ b/lib/puppet/type/dsc_xspfeature.rb
@@ -126,6 +126,10 @@ Puppet::Type.newtype(:dsc_xspfeature) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspinstall.rb
+++ b/lib/puppet/type/dsc_xspinstall.rb
@@ -90,6 +90,10 @@ Puppet::Type.newtype(:dsc_xspinstall) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspinstall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspinstallprereqs.rb
+++ b/lib/puppet/type/dsc_xspinstallprereqs.rb
@@ -286,6 +286,10 @@ Puppet::Type.newtype(:dsc_xspinstallprereqs) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspinstallprereqs).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspjoinfarm.rb
+++ b/lib/puppet/type/dsc_xspjoinfarm.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xspjoinfarm) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspjoinfarm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspmanagedaccount.rb
+++ b/lib/puppet/type/dsc_xspmanagedaccount.rb
@@ -138,6 +138,10 @@ Puppet::Type.newtype(:dsc_xspmanagedaccount) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspmanagedaccount).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspmanagedmetadataserviceapp.rb
+++ b/lib/puppet/type/dsc_xspmanagedmetadataserviceapp.rb
@@ -116,6 +116,10 @@ Puppet::Type.newtype(:dsc_xspmanagedmetadataserviceapp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspmanagedmetadataserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspmanagedpath.rb
+++ b/lib/puppet/type/dsc_xspmanagedpath.rb
@@ -120,6 +120,10 @@ Puppet::Type.newtype(:dsc_xspmanagedpath) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspmanagedpath).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspsearchserviceapp.rb
+++ b/lib/puppet/type/dsc_xspsearchserviceapp.rb
@@ -116,6 +116,10 @@ Puppet::Type.newtype(:dsc_xspsearchserviceapp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspsearchserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspsecurestoreserviceapp.rb
+++ b/lib/puppet/type/dsc_xspsecurestoreserviceapp.rb
@@ -243,6 +243,10 @@ Puppet::Type.newtype(:dsc_xspsecurestoreserviceapp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspsecurestoreserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspserviceapppool.rb
+++ b/lib/puppet/type/dsc_xspserviceapppool.rb
@@ -86,6 +86,10 @@ Puppet::Type.newtype(:dsc_xspserviceapppool) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspserviceapppool).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspserviceinstance.rb
+++ b/lib/puppet/type/dsc_xspserviceinstance.rb
@@ -91,6 +91,10 @@ Puppet::Type.newtype(:dsc_xspserviceinstance) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspserviceinstance).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspsite.rb
+++ b/lib/puppet/type/dsc_xspsite.rb
@@ -257,6 +257,10 @@ Puppet::Type.newtype(:dsc_xspsite) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspsite).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspstateserviceapp.rb
+++ b/lib/puppet/type/dsc_xspstateserviceapp.rb
@@ -117,6 +117,10 @@ Puppet::Type.newtype(:dsc_xspstateserviceapp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspstateserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspusageapplication.rb
+++ b/lib/puppet/type/dsc_xspusageapplication.rb
@@ -215,6 +215,10 @@ Puppet::Type.newtype(:dsc_xspusageapplication) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspusageapplication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspuserprofileserviceapp.rb
+++ b/lib/puppet/type/dsc_xspuserprofileserviceapp.rb
@@ -207,6 +207,10 @@ Puppet::Type.newtype(:dsc_xspuserprofileserviceapp) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspuserprofileserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspuserprofilesyncservice.rb
+++ b/lib/puppet/type/dsc_xspuserprofilesyncservice.rb
@@ -107,6 +107,10 @@ Puppet::Type.newtype(:dsc_xspuserprofilesyncservice) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspuserprofilesyncservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xspwebapplication.rb
+++ b/lib/puppet/type/dsc_xspwebapplication.rb
@@ -225,6 +225,10 @@ Puppet::Type.newtype(:dsc_xspwebapplication) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xspwebapplication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -105,6 +105,10 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlhaendpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -165,6 +165,10 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlhagroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -87,6 +87,10 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlhaservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlserverfailoverclustersetup.rb
+++ b/lib/puppet/type/dsc_xsqlserverfailoverclustersetup.rb
@@ -717,6 +717,10 @@ Puppet::Type.newtype(:dsc_xsqlserverfailoverclustersetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlserverfailoverclustersetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlserverfirewall.rb
+++ b/lib/puppet/type/dsc_xsqlserverfirewall.rb
@@ -202,6 +202,10 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlserverfirewall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -178,6 +178,10 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlserverinstall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlserverrsconfig.rb
+++ b/lib/puppet/type/dsc_xsqlserverrsconfig.rb
@@ -117,6 +117,10 @@ Puppet::Type.newtype(:dsc_xsqlserverrsconfig) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlserverrsconfig).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
+++ b/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
@@ -91,6 +91,10 @@ Puppet::Type.newtype(:dsc_xsqlserverrssecureconnectionlevel) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlserverrssecureconnectionlevel).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsqlserversetup.rb
+++ b/lib/puppet/type/dsc_xsqlserversetup.rb
@@ -699,6 +699,10 @@ Puppet::Type.newtype(:dsc_xsqlserversetup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsqlserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsystemrestore.rb
+++ b/lib/puppet/type/dsc_xsystemrestore.rb
@@ -78,6 +78,10 @@ Puppet::Type.newtype(:dsc_xsystemrestore) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsystemrestore).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xsystemrestorepoint.rb
+++ b/lib/puppet/type/dsc_xsystemrestorepoint.rb
@@ -93,6 +93,10 @@ Puppet::Type.newtype(:dsc_xsystemrestorepoint) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xsystemrestorepoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xtimezone.rb
+++ b/lib/puppet/type/dsc_xtimezone.rb
@@ -73,6 +73,10 @@ Puppet::Type.newtype(:dsc_xtimezone) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xtimezone).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -207,6 +207,10 @@ Puppet::Type.newtype(:dsc_xvhd) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xvhd).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -124,6 +124,10 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xvhdfile).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -420,6 +420,10 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xvmhyperv).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -156,6 +156,10 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xvmswitch).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -107,6 +107,10 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwaitforaddomain).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -91,6 +91,10 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwaitforcluster).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwaitfordisk.rb
+++ b/lib/puppet/type/dsc_xwaitfordisk.rb
@@ -94,6 +94,10 @@ Puppet::Type.newtype(:dsc_xwaitfordisk) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwaitfordisk).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -153,6 +153,10 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwaitforsqlhagroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -122,6 +122,10 @@ Puppet::Type.newtype(:dsc_xwebapplication) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwebapplication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -93,6 +93,10 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwebapppool).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwebapppooldefaults.rb
+++ b/lib/puppet/type/dsc_xwebapppooldefaults.rb
@@ -94,6 +94,10 @@ Puppet::Type.newtype(:dsc_xwebapppooldefaults) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwebapppooldefaults).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -143,6 +143,10 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwebconfigkeyvalue).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwebpackagedeploy.rb
+++ b/lib/puppet/type/dsc_xwebpackagedeploy.rb
@@ -90,6 +90,10 @@ Puppet::Type.newtype(:dsc_xwebpackagedeploy) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwebpackagedeploy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -207,6 +207,10 @@ Puppet::Type.newtype(:dsc_xwebsite) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwebsite).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwebsitedefaults.rb
+++ b/lib/puppet/type/dsc_xwebsitedefaults.rb
@@ -139,6 +139,10 @@ Puppet::Type.newtype(:dsc_xwebsitedefaults) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwebsitedefaults).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -124,6 +124,10 @@ Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwebvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwefcollector.rb
+++ b/lib/puppet/type/dsc_xwefcollector.rb
@@ -75,6 +75,10 @@ Puppet::Type.newtype(:dsc_xwefcollector) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwefcollector).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwefsubscription.rb
+++ b/lib/puppet/type/dsc_xwefsubscription.rb
@@ -381,6 +381,10 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwefsubscription).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -206,6 +206,10 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwindowsoptionalfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -258,6 +258,10 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwindowsprocess).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -137,6 +137,10 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwineventlog).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
   end
 
 
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
 end
 
 Puppet::Type.type(:dsc_xwordpresssite).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do

--- a/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
@@ -130,6 +130,35 @@ module PuppetX
           end
         end
       end
+
+      def self.should_add_reboot_relationship(resource, reboot_resource, pending_relationships)
+        return false if !reboot_resource
+
+        # edge exists in graph from previous resource, so don't add
+        return false if resource.catalog.relationship_graph.edge?(resource, reboot_resource) ||
+          # newly formed edges not yet in catalog include the edge, so don't add
+          pending_relationships.any? { |e| e.source == resource && e.target == reboot_resource }
+
+        true
+      end
+
+      # if an edge already exists from Reboot[dsc_reboot] to this resource
+      # Puppet will recognize the cyclic dependency automatically and fail with:
+      # Error: Failed to apply catalog: Found 1 dependency cycle:
+      # (Dsc_file[foo] => Reboot[dsc_reboot] => Dsc_file[foo])
+      def self.ensure_reboot_relationship(resource, pending_relationships)
+        reboot_resource = resource.catalog.resource(:reboot, 'dsc_reboot')
+
+        # do nothing if no Reboot[dsc_reboot] or already an edge from resource to it
+        if should_add_reboot_relationship(resource, reboot_resource, pending_relationships)
+          # otherwise build resource[name] => Reboot[dsc_reboot]
+          edge = Puppet::Relationship.new(resource, reboot_resource,
+              { :callback => :refresh, :event => :ALL_EVENTS })
+          pending_relationships << edge
+        end
+
+        pending_relationships
+      end
     end
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -44,6 +44,10 @@
     {
       "name": "puppetlabs-powershell",
       "version_requirement": ">= 1.0.1 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs-reboot",
+      "version_requirement": ">= 1.2.1 < 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
  When a DSC resource indicates that a reboot is required via its
  RebootRequired property, notify the Puppet resource reboot named
  dsc_reboot if it exists, so that a reboot may be executed on demand.

 - Typically, edges in the graphs between each DSC resource and the
   Puppet DSC resources could be created through Puppet's autotnotify
   helper.  However, this wasn't added until Puppet 4 and this module
   supports Puppet 3.8, so a different approach is required.

 - Override the builddepends method of each DSC type, so that a Puppet
   relationship dsc_type['name'] => reboot['dsc_reboot'] may be
   created, when the dsc_reboot instance exists in the catalog.  This
   allows refresh events to be propagated to the dsc_reboot instance
   when the DSC PowerShell provider calls create.

 - To ensure that reboots only happen when Invoke-DscResource returns
   RebootRequired, set an attribute on the Windows reboot provider
   called reboot_required.  The dsc_reboot instance must be configured
   to only reboot when 'pending', which will now check this internal
   state in addition to the other checks it normally performs, like
   checking registry settings - pending file renames, computer rename,
   Windows Update, etc.

fixup with prior commit - regenerate types as well