### PR TITLE
(MODULES-2826) Fix Integration Pre-suite

### DIFF
--- a/tests/integration/pre-suite/02_configure_lcm.rb
+++ b/tests/integration/pre-suite/02_configure_lcm.rb
@@ -1,3 +1,4 @@
+require 'master_manipulator'
 test_name 'FM-2626 - C70297 - Configure LCM for "Disabled" Refresh Mode'
 
 #Init


### PR DESCRIPTION
Add the "master_manipulator" reference to the integration pre-suite. This
change prevents a Beaker failure when using a subset of the pre-suite for
debugging purposes.

acceptance test
[skip ci]