### PR TITLE
(maint) Pin mime-types version to allow Ruby 1.9

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -17,6 +17,8 @@ Gemfile:
       - gem: mocha
         version: '~>0.10.5'
       - gem: puppet-blacksmith
+      - gem: mime-types
+        version: '~>2.99'
     ':system_tests':
       - gem: beaker
       - gem: master_manipulator

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development do
   gem 'puppet_facts',                        :require => false
   gem 'mocha', '~>0.10.5',                   :require => false
   gem 'puppet-blacksmith',                   :require => false
+  gem 'mime-types', '~>2.99',                :require => false
 end
 
 group :system_tests do


### PR DESCRIPTION
puppet-blacksmith depends on mime-types gem, which just released
a new version that requires Ruby 2. We require building the module
with 1.9.3 so pin the version to 2.99 which will allow using Ruby
less than 2.0.