### PR TITLE
(MODULES-2870) Update Test Pre-suites

### DIFF
--- a/tests/acceptance/pre-suite/02_dsc_module_install.rb
+++ b/tests/acceptance/pre-suite/02_dsc_module_install.rb
@@ -15,6 +15,7 @@ agents.each do |agent|
   step 'Install DSC Module Dependencies'
   on(agent, puppet('module install puppetlabs-stdlib'))
   on(agent, puppet('module install puppetlabs-powershell'))
+  on(agent, puppet('module install puppetlabs-reboot'))
 
   step 'Install DSC Module'
   local[:target_module_path] = agent['distmoduledir']

--- a/tests/integration/pre-suite/01_dsc_module_install.rb
+++ b/tests/integration/pre-suite/01_dsc_module_install.rb
@@ -3,6 +3,7 @@ test_name 'FM-2626 - C68506 - Plug-in Sync Module from Master with Prerequisites
 step 'Install DSC Module Dependencies'
 on(master, puppet('module install puppetlabs-stdlib'))
 on(master, puppet('module install puppetlabs-powershell'))
+on(master, puppet('module install puppetlabs-reboot'))
 
 step 'Install DSC Module'
 proj_root = File.expand_path(File.join(File.dirname(__FILE__), '../../../'))


### PR DESCRIPTION
The pre-suites for the tests needs to add the "reboot" module as a dependency.
acceptance test
[skip ci]