### PR TITLE
(maint) Move PowerShell provider methods to class

### DIFF
--- a/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
@@ -31,7 +31,7 @@ $invokeParams = @{
   Name          = '<%= resource.dscmeta_resource_friendly_name %>'
   Method        = '<%= dsc_invoke_method %>'
   Property      = @{
-<% dsc_parameters.each do |p| -%>
+<% provider.dsc_parameters.each do |p| -%>
     <%- name = p.name.to_s.gsub(/^dsc_/,'')
     if name == 'ensure' && dsc_invoke_method == 'test'
       value = "\'#{resource.parameters[:ensure].default.to_s}\'"

--- a/spec/unit/puppet/provider/powershell_spec.rb
+++ b/spec/unit/puppet/provider/powershell_spec.rb
@@ -20,19 +20,19 @@ describe Puppet::Type.type(:dsc_file).provider(:powershell) do
   describe "when quotes are present" do
 
     it "should handle single quotes" do
-      expect(subject.format_dsc_value("The 'Cats' go 'meow'!")).to match(/'The ''Cats'' go ''meow''!'/)
+      expect(subject.class.format_dsc_value("The 'Cats' go 'meow'!")).to match(/'The ''Cats'' go ''meow''!'/)
     end
 
     it "should handle double single quotes" do
-      expect(subject.format_dsc_value("The ''Cats'' go 'meow'!")).to match(/'The ''''Cats'''' go ''meow''!'/)
+      expect(subject.class.format_dsc_value("The ''Cats'' go 'meow'!")).to match(/'The ''''Cats'''' go ''meow''!'/)
     end
 
     it "should handle double quotes" do
-      expect(subject.format_dsc_value("The 'Cats' go \"meow\"!")).to match(/'The ''Cats'' go "meow"!'/)
+      expect(subject.class.format_dsc_value("The 'Cats' go \"meow\"!")).to match(/'The ''Cats'' go "meow"!'/)
     end
 
     it "should handle dollar signs" do
-      expect(subject.format_dsc_value("This should show \$foo variable")).to match(/'This should show \$foo variable'/)
+      expect(subject.class.format_dsc_value("This should show \$foo variable")).to match(/'This should show \$foo variable'/)
     end
   end
 end


### PR DESCRIPTION
 - Previously, PowerShell provider methods were all instance methods,
   but this isn't strictly necessary.  Move methods for generating the
   Invoke-DscResource script to the providers class, so that they may
   later be called by self.instances / self.prefetch when adding 'get'
   support.