### PR TITLE
(MODULES-2829) Update Puppet Agent Version for Tests

### DIFF
--- a/tests/acceptance/pre-suite/01_puppet_agent_install.rb
+++ b/tests/acceptance/pre-suite/01_puppet_agent_install.rb
@@ -3,7 +3,7 @@ test_name 'Install Puppet Agent'
 confine(:to, :platform => 'windows')
 
 #Init
-puppet_agent_version = ENV['BEAKER_PUPPET_AGENT_VERSION'] || '1.2.7'
+puppet_agent_version = ENV['BEAKER_PUPPET_AGENT_VERSION'] || '1.3.2'
 
 step 'Install Puppet Agent'
 install_puppet_agent_on(agents, :version => puppet_agent_version)

--- a/tests/test_run_scripts/acceptance_tests.sh
+++ b/tests/test_run_scripts/acceptance_tests.sh
@@ -11,8 +11,8 @@ declare -a ARGS
 # Argument Parsing
 if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64a'
-  ARGS[1]='1.2.7'
-  ARGS[2]='forge'
+  ARGS[1]='1.3.2'
+  ARGS[2]='local'
 elif [[ $# -lt 3 || $# -gt 4 ]]; then
   echo 'USAGE acceptance_tests.sh <CONFIG> <PUPPET_AGENT_VER> <LOCAL_OR_FORGE> <MODULE_VERSION>'
   exit 1

--- a/tests/test_run_scripts/integration_tests.sh
+++ b/tests/test_run_scripts/integration_tests.sh
@@ -10,7 +10,7 @@ declare -a ARGS
 # Argument Parsing
 if [ $# -eq 0 ]; then
   ARGS[0]='windows-2012r2-64mda'
-  ARGS[1]='http://pe-releases.puppetlabs.lan/2015.2.2/'
+  ARGS[1]='http://pe-releases.puppetlabs.lan/2015.2.3/'
   ARGS[2]='forge'
 elif [[ $# -lt 3 || $# -gt 4 ]]; then
   echo 'USAGE integration_tests.sh <CONFIG> <PE_DIST_DIR> <LOCAL_OR_FORGE> <MODULE_VERSION>'


### PR DESCRIPTION
Update the version of Puppet Agent used for acceptance and integraction tests.
Also, I updated the integration test script to use the latest z release of PE.

acceptance test
[skip ci]