### PR TITLE
(MODULES-2512) Cannot ensure absent on Service DSC Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,39 @@ information, see about_Execution_Policies at http://go.microsoft.com/fwlink/?Lin
 
 - The `dsc_log` resource may not appear to work. The ["Log" resource](https://technet.microsoft.com/en-us/library/Dn282117.aspx) writes events to the 'Microsoft-Windows-Desired State Configuration/Analytic' event log, which is [disabled by default](https://technet.microsoft.com/en-us/library/Cc749492.aspx).
 
-- You may have issues attempting to use `dsc_ensure => absent` on `dsc_service`. See [MODULES-2512](https://tickets.puppetlabs.com/browse/MODULES-2512) for details.
+- You may have issues attempting to use `dsc_ensure => absent` with `dsc_service` with services that are not running. 
+
+When setting resources to absent, it is common to specify a minimal statement like so:
+
+~~~
+dsc_service{'disable_foo':
+  dsc_ensure => absent,
+  dsc_name => 'foo'
+}
+~~~
+
+Due to the way the Service DSC Resource sets its defaults, the above minimal statement will report the service as already absent erroneously if the service is currently not running. In order to work around this, you must specify that `State => 'Stopped'` as well as `Ensure => absent'`. The following example will work:
+
+~~~
+dsc_service{'disable_foo':
+  dsc_ensure => absent,
+  dsc_name => 'foo',
+  dsc_state => 'stopped'
+}
+~~~
+
+[MODULES-2512](https://tickets.puppetlabs.com/browse/MODULES-2512) has more details.
+
+ - You may have issues attempting to use `dsc_ensure => absent` with `dsc_xservice` with services that are already not present. To work around this problem, always specify the path to the executable for the service when specifying `absent`. [MODULES-2512](https://tickets.puppetlabs.com/browse/MODULES-2512) has more details. The following example works:
+ 
+~~~
+dsc_xservice{'disable_foo':
+  dsc_ensure => absent,
+  dsc_name => 'foo',
+  dsc_path => 'c:\\Program Files\\Foo\\bin\\foo.exe'
+}
+~~~
+
 
 - When installing the module on Windows you may run into an issue regarding long file names (LFN) due to the long paths of the generated schema files. If you install your module on a Linux master and then use plugin sync you will likely not see this issue. If you are attempting to install the module on a Windows machine using `puppet module install puppetlabs-dsc` you may run into an error that looks similar to the following:
 


### PR DESCRIPTION
If a user specifies a service as absent, when it is not running, it will
not be removed. This is because the dsc resource returns false when testing for
existence instead of true even though service exists because of the
following code `return ($State -eq "Stopped" -and $svc.Status -eq
"Stopped") -or ($svc.Status -eq "Running" -and $State -eq "Running")`
Since $state is a paramter and is defautled to 'Running', if the service
is stopped this will always return false instead of true.

If a user specifies a service as absent when the service is already not
present, it will error. This happens because we invert absent to present
to determine if resource exists. t\This causes the error because testing
for present requires a Path, but not when testing it is Absent. Since we
dont provide the path there is nothing to pass to Present, so it throws
an error during the testing phase.

This updates the readme to inform the user of workarounds to these
issues.