### PR TITLE
(MODULES-2919) DSC - Intermittent failure of Windows Process Tests

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/windowsprocess/process_valid_args.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/windowsprocess/process_valid_args.rb
@@ -14,7 +14,7 @@ dsc_module = 'PSDesiredStateConfiguration'
 dsc_props = {
   :dsc_ensure    => 'Present',
   :dsc_path      => 'C:\Windows\System32\cmd.exe',
-  :dsc_arguments => "/c ping.exe -n 1 -4 localhost > C:\\#{output_file_name}",
+  :dsc_arguments => "/c ping.exe -n 2 -4 localhost > C:\\#{output_file_name}",
 }
 
 dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')


### PR DESCRIPTION
Modified the command used to during the test and increased the execution time
from as-fast-as-possible to just over 1 second.  This will help stop false CI
failures caused by test hosts under heavy load