### PR TITLE
(MODULES-2709) Reuse PowerShell instance for DSC

### DIFF
--- a/lib/facter/uses_win32console.rb
+++ b/lib/facter/uses_win32console.rb
@@ -1,0 +1,8 @@
+Facter.add(:uses_win32console) do
+  setcode do
+    if Puppet::Util::Platform.windows?
+      defined?(Win32::Console) &&
+        Win32::Console.class == Class
+    end
+  end
+end

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -1,5 +1,8 @@
 require 'pathname'
 require 'json'
+if Puppet::Util::Platform.windows?
+  require_relative '../../../puppet_x/puppetlabs/powershell_manager'
+end
 
 Puppet::Type.type(:base_dsc).provide(:powershell) do
   confine :operatingsystem => :windows
@@ -34,7 +37,11 @@ EOT
 
 
   def self.powershell_args
-    ['-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command']
+    ['-NoProfile', '-NonInteractive', '-Sta', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command', '-']
+  end
+
+  def ps_manager
+    PuppetX::Dsc::PowerShellManager.instance("#{command(:powershell)} #{self.class.powershell_args.join(' ')}")
   end
 
   def exists?
@@ -42,7 +49,7 @@ EOT
     Puppet.debug "PowerShell Version: #{version}"
     script_content = ps_script_content('test')
     Puppet.debug "\n" + script_content
-    output = powershell(self.class.powershell_args, script_content)
+    output = ps_manager.execute(script_content)[:stdout]
     Puppet.debug "Dsc Resource returned: #{output}"
     data = JSON.parse(output)
     fail(data['errormessage']) if !data['errormessage'].empty?
@@ -56,7 +63,7 @@ EOT
   def create
     script_content = ps_script_content('set')
     Puppet.debug "\n" + script_content
-    output = powershell(self.class.powershell_args, script_content)
+    output = ps_manager.execute(script_content)[:stdout]
     Puppet.debug "Create Dsc Resource returned: #{output}"
     data = JSON.parse(output)
 
@@ -70,7 +77,7 @@ EOT
   def destroy
     script_content = ps_script_content('set')
     Puppet.debug "\n" + script_content
-    output = powershell(self.class.powershell_args, script_content)
+    output = ps_manager.execute(script_content)[:stdout]
     Puppet.debug "Destroy Dsc Resource returned: #{output}"
     data = JSON.parse(output)
 

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -22,7 +22,7 @@ module PuppetX
         at_exit { exit }
       end
 
-      def execute(powershell_code)
+      def execute(powershell_code, timeout_ms = 300 * 1000)
         output_ready_event_name =  "Global\\#{SecureRandom.uuid}"
         output_ready_event = self.class.create_event(output_ready_event_name)
 
@@ -40,7 +40,7 @@ module PuppetX
 
         CODE
 
-        out = exec_read_result(code, output_ready_event)
+        out = exec_read_result(code, output_ready_event, timeout_ms)
 
         { :stdout => out }
       ensure
@@ -163,9 +163,9 @@ module PuppetX
         raise Puppet::Util::Windows::Error.new(msg)
       end
 
-      def exec_read_result(powershell_code, output_ready_event)
+      def exec_read_result(powershell_code, output_ready_event, timeout_ms = 300 * 1000)
         write_stdin(powershell_code)
-        read_stdout(output_ready_event)
+        read_stdout(output_ready_event, timeout_ms)
       end
 
       ffi_convention :stdcall

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -1,0 +1,184 @@
+require 'securerandom'
+require 'open3'
+require 'ffi'
+
+module PuppetX
+  module Dsc
+    class PowerShellManager
+      extend Puppet::Util::Windows::String
+      extend FFI::Library
+
+      @@instances = {}
+
+      def self.instance(cmd)
+        @@instances[:cmd] ||= PowerShellManager.new(cmd)
+      end
+
+      def initialize(cmd)
+        @stdin, @stdout, @ps_process = Open3.popen2(cmd)
+
+        Puppet.debug "#{Time.now} #{cmd} is running as pid: #{@ps_process[:pid]}"
+
+        at_exit { exit }
+      end
+
+      def execute(powershell_code)
+        output_ready_event_name =  "Global\\#{SecureRandom.uuid}"
+        output_ready_event = self.class.create_event(output_ready_event_name)
+
+        # always need a trailing newline to ensure PowerShell parses code
+        code = <<-CODE
+        $event = [Threading.EventWaitHandle]::OpenExisting("#{output_ready_event_name}")
+
+        $Error.Clear()
+        $LASTEXITCODE = 0
+
+        #{powershell_code}
+
+        [Void]$event.Set()
+        [Void]$event.Dispose()
+
+        CODE
+
+        out = exec_read_result(code, output_ready_event)
+
+        { :stdout => out }
+      ensure
+        FFI::WIN32.CloseHandle(output_ready_event) if output_ready_event
+      end
+
+      def exit
+        Puppet.debug "PowerShellManager exiting..."
+        @stdin.puts "\nexit\n"
+        @stdin.close
+        @stdout.close
+
+        exit_msg = "PowerShell process did not terminate in reasonable time"
+        begin
+          Timeout.timeout(3) do
+            Puppet.debug "Awaiting PowerShell process termination..."
+            @exit_status = @ps_process.value
+          end
+        rescue Timeout::Error
+        end
+
+        exit_msg = "PowerShell process exited: #{@exit_status}" if @exit_status
+        Puppet.debug(exit_msg)
+        if @ps_process.alive?
+          Puppet.debug("Forcefully terminating PowerShell process.")
+          Process.kill('KILL', @ps_process[:pid])
+        end
+      end
+
+      private
+
+      def self.is_readable?(stream, timeout = 0.5)
+        read_ready = IO.select([stream], [], [], timeout)
+        read_ready && stream == read_ready[0][0]
+      end
+
+      def self.create_event(name, manual_reset = false, initial_state = false)
+        handle = FFI::Pointer::NULL_HANDLE
+
+        FFI::Pointer.from_string_to_wide_string(name) do |name_ptr|
+          handle = CreateEventW(FFI::Pointer::NULL,
+            manual_reset ? 1 : FFI::WIN32_FALSE,
+            initial_state ? 1 : FFI::WIN32_FALSE,
+            name_ptr)
+
+          if handle == FFI::Pointer::NULL_HANDLE
+            msg = "Failed to create new event #{name}"
+            raise Puppet::Util::Windows::Error.new(msg)
+          end
+        end
+
+        handle
+      end
+
+      WAIT_ABANDONED = 0x00000080
+      WAIT_OBJECT_0 = 0x00000000
+      WAIT_TIMEOUT = 0x00000102
+      WAIT_FAILED = 0xFFFFFFFF
+
+      def self.wait_on(wait_object, timeout_ms = 50)
+        wait_result = Puppet::Util::Windows::Process::WaitForSingleObject(
+          wait_object, timeout_ms)
+
+        case wait_result
+        when WAIT_OBJECT_0
+          Puppet.debug "Wait object signaled"
+        when WAIT_TIMEOUT
+          Puppet.debug "Waited #{timeout_ms} milliseconds..."
+        # only applicable to mutexes - should never happen here
+        when WAIT_ABANDONED
+          msg = 'Catastrophic failure: wait object in inconsistent state'
+          raise Puppet::Util::Windows::Error.new(msg)
+        when WAIT_FAILED
+          msg = 'Catastrophic failure: waiting on object to be signaled'
+          raise Puppet::Util::Windows::Error.new(msg)
+        end
+
+        wait_result
+      end
+
+      def write_stdin(input)
+        @stdin.puts(input)
+      rescue => e
+        msg = "Error writing STDIN / reading STDOUT: #{e}"
+        raise Puppet::Util::Windows::Error.new(msg)
+      end
+
+      def drain_stdout
+        output = []
+        while self.class.is_readable?(@stdout, 0.1) do
+          l = @stdout.gets
+          Puppet.debug "#{Time.now} STDOUT> #{l}"
+          output << l
+        end
+        output
+      end
+
+      def read_stdout(output_ready_event, timeout_ms = 20 * 1000, wait_interval_ms = 50)
+        output = []
+        waited = 0
+
+        # drain the pipe while waiting for the event signal
+        while WAIT_TIMEOUT == self.class.wait_on(output_ready_event, wait_interval_ms)
+          output << drain_stdout
+          waited += wait_interval_ms
+          if (waited > timeout_ms)
+            msg = "Catastrophic failure: wait object timeout #{timeout_ms} exceeded"
+            raise Puppet::Util::Windows::Error.new(msg, WAIT_TIMEOUT)
+          end
+        end
+
+        Puppet.debug "Waited #{waited} total milliseconds."
+
+        # once signaled, ensure everything has been drained
+        output << drain_stdout
+
+        output.join('')
+      rescue => e
+        msg = "Error reading STDOUT: #{e}"
+        raise Puppet::Util::Windows::Error.new(msg)
+      end
+
+      def exec_read_result(powershell_code, output_ready_event)
+        write_stdin(powershell_code)
+        read_stdout(output_ready_event)
+      end
+
+      ffi_convention :stdcall
+
+      # https://msdn.microsoft.com/en-us/library/windows/desktop/ms682396(v=vs.85).aspx
+      # HANDLE WINAPI CreateEvent(
+      #   _In_opt_ LPSECURITY_ATTRIBUTES lpEventAttributes,
+      #   _In_     BOOL                  bManualReset,
+      #   _In_     BOOL                  bInitialState,
+      #   _In_opt_ LPCTSTR               lpName
+      # );
+      ffi_lib :kernel32
+      attach_function_private :CreateEventW, [:pointer, :win32_bool, :win32_bool, :lpcwstr], :handle
+    end
+  end
+end

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -63,6 +63,17 @@ $bytes_in_k = (1024 * 64) + 1
       msg = /Catastrophic failure\: wait object timeout #{timeout_ms} exceeded/
       expect { manager.execute('sleep 1', timeout_ms)[:stdout] }.to raise_error(Puppet::Util::Windows::Error, msg)
     end
+
+    it "should not deadlock and return a valid JSON response given invalid unparseable PowerShell code" do
+      result = manager.execute(<<-CODE
+        {
+
+        CODE
+        )
+
+      response = JSON.parse(result[:stdout])
+      expect(response["errormessage"]).not_to be_empty
+    end
   end
 
 end

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -8,7 +8,8 @@ module PuppetX
   end
 end
 
-describe PuppetX::Dsc::PowerShellManager, :if => Puppet::Util::Platform.windows? do
+describe PuppetX::Dsc::PowerShellManager,
+  :if => Puppet::Util::Platform.windows? && !Facter.value(:uses_win32console) do
 
   let (:manager) {
     powershell = Puppet::Type.type(:base_dsc).defaultprovider.command(:powershell)

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet_x/puppetlabs/powershell_manager' if Puppet::Util::Platform.windows?
+
+module PuppetX
+  module Dsc
+    class PowerShellManager; end
+  end
+end
+
+describe PuppetX::Dsc::PowerShellManager, :if => Puppet::Util::Platform.windows? do
+
+  let (:manager) {
+    powershell = Puppet::Type.type(:base_dsc).defaultprovider.command(:powershell)
+    powershell_args = Puppet::Type.type(:base_dsc).defaultprovider.powershell_args
+    PuppetX::Dsc::PowerShellManager.instance("#{powershell} #{powershell_args.join(' ')}")
+  }
+
+  describe "when provided powershell commands" do
+    it "should return simple output" do
+      result = manager.execute('write-output foo')[:stdout]
+      expect(result).to eq("foo\n")
+    end
+
+    it "should execute cmdlets" do
+      result = manager.execute('ls')[:stdout]
+      expect(result).not_to eq(nil)
+    end
+
+    it "should execute cmdlets with pipes" do
+      result = manager.execute('Get-Process | ? { $_.PID -ne $PID }')[:stdout]
+      expect(result).not_to eq(nil)
+    end
+
+    it "should execute multi-line" do
+      result = manager.execute(<<-CODE
+$foo = ls
+$count = $foo.count
+$count
+      CODE
+      )[:stdout]
+      expect(result).not_to eq(nil)
+    end
+  end
+
+end


### PR DESCRIPTION
 - Currently, each time a resource modification is made, the PowerShell
   provider opens up new powershell.exe instance(s), makes a single
   Invoke-DscResource call, then terminates.

   This is a particularly expensive endeavor, since each resource
   requires a minimum of one powershell.exe instance for the sake of
   using Test to examine if the DSC resource is in the desired state. If
   a resource needs to be added / removed / modified via the Set method
   of Invoke-DscResource, then an additional instance is required.

   With the working set and slow startup times of powershell.exe this
   is a particularly expensive cost to pay per run.

 - Add a new PowerShellManager class that supports reuse of an initially
   created powershell.exe instance.  Modify the PowerShell provider to
   use this helper class instead of running powershell.exe on demand.

   In simple tests, this significantly (by a factor or 2x or more)
   reduces the runtime of a manifest.

 - The PowerShellManager class uses popen2 since the PowerShell template
   currently handles capturing Invoke-DscResource errors and propagating
   them through the JSON that is returned to Ruby.  Therefore, ignore
   stderr stream.  In other exploratory work, there was difficulty in
   getting stderr to be read from properly - in such instances, the
   IO.select call over stderr determined that the stream was readable,
   but the subsequent call to stderr.gets would block, and deadlock. Its
   presumed that this is a problem specifically with Ruby on Windows, or
   with capturing stderr from powershell.exe - but the exact cause has
   not yet been determined.