### PR TITLE
(maint) Update Dependencies to use / separator

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,15 +37,15 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_requirement": ">= 2.3.0 < 5.0.0"
     },
     {
-      "name": "puppetlabs-powershell",
+      "name": "puppetlabs/powershell",
       "version_requirement": ">= 1.0.1 < 2.0.0"
     },
     {
-      "name": "puppetlabs-reboot",
+      "name": "puppetlabs/reboot",
       "version_requirement": ">= 1.2.1 < 2.0.0"
     }
   ]


### PR DESCRIPTION
In older versions of Puppet, there is a bug where a dependency is not
realized as installed when using "-" e.g. "puppetlabs-reboot" versus
"puppetlabs/reboot". Update to using "/" to guarantee compatibility
with older versions of Puppet.