### PR TITLE
(MODULES-2965) Add Tests for "ensure" VS. "dsc_ensure"

### DIFF
--- a/tests/integration/tests/ensure_behavior/ensure_absent.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_absent.rb
@@ -1,0 +1,77 @@
+require 'erb'
+require 'master_manipulator'
+require 'dsc_utils'
+test_name 'MODULES-2965 - C96624 - Apply DSC Manifest with "ensure" Set to "absent"'
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+dsc_props = {
+  :ensure              => 'present',
+  :dsc_destinationpath => 'C:\test.file',
+  :dsc_contents        => 'Oh the humanity!',
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      dsc_module,
+      :Ensure          => 'Absent',
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
+  end
+end
+
+# Setup
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Create File'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+  end
+end
+
+# New manifest to remove value.
+dsc_props[:ensure] = 'absent'
+dsc_remove_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_remove_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Remove File'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    expect_failure('Expected to fail because of MODULES-2966') do
+      assert_dsc_resource(
+        agent,
+        dsc_type,
+        dsc_module,
+        :Ensure          => dsc_props[:ensure],
+        :DestinationPath => dsc_props[:dsc_destinationpath],
+        :Contents        => dsc_props[:dsc_contents],
+      )
+    end
+  end
+end

--- a/tests/integration/tests/ensure_behavior/ensure_absent_and_dsc_ensure_present.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_absent_and_dsc_ensure_present.rb
@@ -1,0 +1,59 @@
+require 'erb'
+require 'master_manipulator'
+require 'dsc_utils'
+test_name 'MODULES-2965 - C96627 - Apply DSC Manifest with "ensure" Set to "absent" and "dsc_ensure" Set to "present"'
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+dsc_props = {
+  :ensure              => 'absent',
+  :dsc_ensure          => 'present',
+  :dsc_destinationpath => 'C:\test.file',
+  :dsc_contents        => 'Enough already!',
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      dsc_module,
+      :Ensure          => 'Absent',
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
+  end
+end
+
+# Setup
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Run Puppet Agent'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify that the File is Present. (dsc_ensure takes precedence)'
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:dsc_ensure],
+      :DestinationPath => dsc_props[:dsc_destinationpath],
+      :Contents        => dsc_props[:dsc_contents],
+    )
+  end
+end

--- a/tests/integration/tests/ensure_behavior/ensure_and_dsc_ensure_absent.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_and_dsc_ensure_absent.rb
@@ -1,0 +1,76 @@
+require 'erb'
+require 'master_manipulator'
+require 'dsc_utils'
+test_name 'MODULES-2965 - C96629 - Apply DSC Manifest with "ensure" and "dsc_ensure" Set to "absent"'
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+dsc_props = {
+  :dsc_ensure          => 'present',
+  :dsc_destinationpath => 'C:\test.file',
+  :dsc_contents        => 'Ensure the absence.',
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      dsc_module,
+      :Ensure          => 'Absent',
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
+  end
+end
+
+# Setup
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Create File'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+  end
+end
+
+# New manifest to remove value.
+dsc_props[:ensure] = 'absent'
+dsc_props[:dsc_ensure] = 'absent'
+dsc_remove_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_remove_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Remove File'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:dsc_ensure],
+      :DestinationPath => dsc_props[:dsc_destinationpath],
+      :Contents        => dsc_props[:dsc_contents],
+    )
+  end
+end

--- a/tests/integration/tests/ensure_behavior/ensure_and_dsc_ensure_present.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_and_dsc_ensure_present.rb
@@ -1,0 +1,59 @@
+require 'erb'
+require 'master_manipulator'
+require 'dsc_utils'
+test_name 'MODULES-2965 - C96625 - Apply DSC Manifest with "ensure" and "dsc_ensure" Set to "present"'
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+dsc_props = {
+  :ensure              => 'present',
+  :dsc_ensure          => 'present',
+  :dsc_destinationpath => 'C:\test.file',
+  :dsc_contents        => 'Ensure the ensurance.',
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      dsc_module,
+      :Ensure          => 'Absent',
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
+  end
+end
+
+# Setup
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Run Puppet Agent'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:dsc_ensure],
+      :DestinationPath => dsc_props[:dsc_destinationpath],
+      :Contents        => dsc_props[:dsc_contents],
+    )
+  end
+end

--- a/tests/integration/tests/ensure_behavior/ensure_present.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_present.rb
@@ -1,0 +1,58 @@
+require 'erb'
+require 'master_manipulator'
+require 'dsc_utils'
+test_name 'MODULES-2965 - C96623 - Apply DSC Manifest with "ensure" Set to "present"'
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+dsc_props = {
+  :ensure              => 'present',
+  :dsc_destinationpath => 'C:\test.file',
+  :dsc_contents        => 'Cats go boo!',
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      dsc_module,
+      :Ensure          => 'Absent',
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
+  end
+end
+
+# Setup
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Run Puppet Agent'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:ensure],
+      :DestinationPath => dsc_props[:dsc_destinationpath],
+      :Contents        => dsc_props[:dsc_contents],
+    )
+  end
+end

--- a/tests/integration/tests/ensure_behavior/ensure_present_and_dsc_ensure_absent.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_present_and_dsc_ensure_absent.rb
@@ -1,0 +1,76 @@
+require 'erb'
+require 'master_manipulator'
+require 'dsc_utils'
+test_name 'MODULES-2965 - C96626 - Apply DSC Manifest with "ensure" Set to "present" and "dsc_ensure" Set to "absent"'
+
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
+# ERB Manifest
+dsc_type = 'file'
+dsc_module = 'PSDesiredStateConfiguration'
+dsc_props = {
+  :dsc_ensure          => 'present',
+  :dsc_destinationpath => 'C:\test.file',
+  :dsc_contents        => 'Red eye.',
+}
+
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resources', 'dsc_single_resource.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    set_dsc_resource(
+      agents,
+      dsc_type,
+      dsc_module,
+      :Ensure          => 'Absent',
+      :DestinationPath => dsc_props[:dsc_destinationpath]
+    )
+  end
+end
+
+# Setup
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Create File'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+  end
+end
+
+# New manifest to remove value.
+dsc_props[:ensure] = 'present'
+dsc_props[:dsc_ensure] = 'absent'
+dsc_remove_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
+
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => dsc_remove_manifest)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Remove File'
+    on(agent, puppet('agent -t --environment production'), :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify that the File is Absent. (dsc_ensure takes precedence)'
+    assert_dsc_resource(
+      agent,
+      dsc_type,
+      dsc_module,
+      :Ensure          => dsc_props[:dsc_ensure],
+      :DestinationPath => dsc_props[:dsc_destinationpath],
+      :Contents        => dsc_props[:dsc_contents],
+    )
+  end
+end


### PR DESCRIPTION
I recently discovered that the DSC module supports both "ensure" and
"dsc_ensure" for ensurable resources. The tests exercise combinations of
both ensurable parameters.