### PR TITLE
(MODULES-2709) Implement DSC timeout inside PS

### DIFF
--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -59,10 +59,12 @@ $bytes_in_k = (1024 * 64) + 1
       expect(result).not_to eq(nil)
     end
 
-    it "should return an error if the execution timeout is exceeded" do
+    it "should return a JSON response with a timeout error if the execution timeout is exceeded" do
       timeout_ms = 100
-      msg = /Catastrophic failure\: wait object timeout #{timeout_ms} exceeded/
-      expect { manager.execute('sleep 1', timeout_ms)[:stdout] }.to raise_error(Puppet::Util::Windows::Error, msg)
+      result = manager.execute('sleep 1', timeout_ms)
+      response = JSON.parse(result[:stdout])
+      msg = /Catastrophic failure\: PowerShell DSC resource timeout \(#{timeout_ms} ms\) exceeded while executing/
+      expect(response['errormessage']).to match(msg)
     end
 
     it "should not deadlock and return a valid JSON response given invalid unparseable PowerShell code" do


### PR DESCRIPTION
 - Previously, run timeouts were executed on the Ruby side, which had
   the side effect of allowing PowerShell code to continue to run in
   the background, which could lead to a host of timing problems.

   For instance, a long-running DSC invocation that entered a timeout
   state on the Ruby execution side, would efectively block any
   additional PowerShell code from running until it had completed.

   Rework the timeout to take effect on the PowerShell side.  Create
   runspaces as needed (when one does not exist, or when the previous
   runspace encountered a timeout and was forcefully Disposed of).
   Otherwise, reuse runspaces for performance to behave similarly to
   calling ScriptBlock.invoke().

   This should clear up any testing issues that have cropped up as a
   result of previous runs still executing that were timeout'd.