### PR TITLE
(MODULES-2772) Unpin master_manipulator

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -22,7 +22,7 @@ Gemfile:
     ':system_tests':
       - gem: beaker
       - gem: master_manipulator
-        version: '1.1.2'
+        version: '~> 1.2'
     ':build':
       - gem: cim
       - gem: mof

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ end
 
 group :system_tests do
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')
-  gem 'master_manipulator', '1.1.2',  :require => false
+  gem 'master_manipulator', '~> 1.2',  :require => false
 end
 
 group :build do


### PR DESCRIPTION
There was a bug in master_manipulator that has been fixed which caused test
failures on PE 3.8.x. The master_manipulator gem was pinned to a known working
version which is no longer necessary.