### PR TITLE
(FM-3886) Fix Puppet/PE requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,11 +28,11 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.3.0 < 2015.3.0"
+      "version_requirement": ">= 3.8.0 < 2015.4.0"
     },
     {
       "name": "puppet",
-      "version_requirement": ">= 3.5.0 < 5.0.0"
+      "version_requirement": ">= 3.8.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
The minimum Puppet/PE Version is 3.8.0. Update to allow
for the newest PE version to be allowed as well.