### PR TITLE
(MODULES-3119) Remove unncessary files from module build

### DIFF
--- a/.pmtignore
+++ b/.pmtignore
@@ -2,5 +2,14 @@ import/
 /spec/fixtures/
 .tmp
 *.lock
+*.local
 .rbenv-gemsets
 .ruby-version
+build/
+docs/
+tests/
+
+# Normally the spec directory is included in module distribution, however due to large number of 
+# files generated, they are ignored when packaging the module.  The spec tests are not required
+# for the module to operate
+spec/


### PR DESCRIPTION
This commit adds extra directories to the PMT Ignore file as, build, docs and tests are
not required at runtime for DSC module.  Also added *.local to ignore local development
files.  While the addition of these files will not cause any errors, they are removed
to keep the module installation as lean as possible.