### PR TITLE
(MODULES-3179) Add DSC Reference to the module when importing types

### DIFF
--- a/build/dsc.rake
+++ b/build/dsc.rake
@@ -61,6 +61,9 @@ eod
         cmd += "git submodule update --init --recursive"
 
         sh cmd
+        
+        saved_git_ref = (`git rev-parse --short HEAD`).strip
+        puts "Using Powershell DSC git reference #{saved_git_ref}"
       else
         puts "Importing custom types from '#{dsc_resources_path}'"
         FileUtils.mkdir_p "#{dsc_resources_path_tmp}"
@@ -92,6 +95,9 @@ eod
       if !is_custom_resource
         puts "Copying vendored resources from #{default_dsc_module_path}/build/vendor/wmf_dsc_resources to #{dsc_resources_path}"
         FileUtils.cp_r "#{default_dsc_module_path}/build/vendor/wmf_dsc_resources/.", "#{dsc_resources_path}/"
+        
+        m = Dsc::Manager.new
+        m.save_powershell_dsc_git_reference(saved_git_ref)        
       else
         puts "Adding custom types to '#{default_dsc_resources_path}'"
         FileUtils.cp_r "#{dsc_resources_path_tmp}/.", "#{default_dsc_resources_path}/"

--- a/build/dsc/manager.rb
+++ b/build/dsc/manager.rb
@@ -12,6 +12,7 @@ module Dsc
 
       @import_folder            = "#{@module_path}/import"
       @dsc_modules_folder       = "#{@import_folder}/dsc_resources"
+      @dsc_git_reference        = "#{@import_folder}/dsc_resources/dsc_reference.txt"
       @dmtf_mof_folder          = "#{@module_path}/build/vendor/dmtf_mof"
 
       @type_template_file       = "#{@dsc_lib_path}/templates/dsc_type.rb.erb"
@@ -210,8 +211,23 @@ module Dsc
           end
           file.write("\n")
         end
+        
+        gitref = get_powershell_dsc_git_reference        
+        file.write("\nThe vendored Powershell DSC Resource can be rebuilt using `DSC_REF=#{gitref}`") if gitref
       end
     end
+
+    def save_powershell_dsc_git_reference(gitref)
+      File.open(@dsc_git_reference, 'w') { |file|
+        file.write("#{gitref}")
+      }      
+    end
+
+    def get_powershell_dsc_git_reference()
+      File.open(@dsc_git_reference, 'r') { |file|
+        file.gets()
+      } if File.exist?(@dsc_git_reference)      
+    end    
 
     def clean_dsc_types
       puppet_type_path = "#{@target_module_path}/#{@puppet_type_subpath}"

--- a/types.md
+++ b/types.md
@@ -510,3 +510,5 @@ Puppet Type | DSC Resource | Github Repo
 ----------- | ----------------- | -----
 dsc_xwordpresssite | [xWordPressSite](https://github.com/puppetlabs/puppetlabs-dsc/tree/master/lib/puppet_x/dsc_resources/xWordPress/DscResources/MSFT_xWordPressSite) | [repo](https://github.com/PowerShell/xWordPress)
 
+
+The vendored Powershell DSC Resource can be rebuilt using `DSC_REF=09b9a46`


### PR DESCRIPTION
This commit addes the DSC_REF environment variable to the types.md
file to help signify which git reference was used during the build
process.  This does not affect the operation of the module or the
DSC resources, but it's used for documentation purposes only.

example types.md;
```
...
...
##### xWordPress

Puppet Type | DSC Resource | Github Repo
----------- | ----------------- | -----
dsc_xwordpresssite | [xWordPressSite](https://github.com/puppetlabs/puppetlabs-dsc/tree/master/lib/puppet_x/dsc_resources/xWordPress/DscResources/MSFT_xWordPressSite) | [repo](https://github.com/PowerShell/xWordPress)


Git reference for DSC: 84a467c
```