### PR TITLE
(FM-5017) Update Puppet Agent for Acceptance Tests

### DIFF
--- a/tests/acceptance/pre-suite/01_puppet_agent_install.rb
+++ b/tests/acceptance/pre-suite/01_puppet_agent_install.rb
@@ -2,11 +2,12 @@ test_name 'Install Puppet Agent'
 
 confine(:to, :platform => 'windows')
 
-#Init
-puppet_agent_version = ENV['BEAKER_PUPPET_AGENT_VERSION'] || '1.3.2'
-
 step 'Install Puppet Agent'
-install_puppet_agent_on(agents, :version => puppet_agent_version)
+if ENV['BEAKER_PUPPET_AGENT_VERSION']
+  install_puppet_agent_on(agents, :version => ENV['BEAKER_PUPPET_AGENT_VERSION'])
+else
+  install_puppet_agent_on(agents)
+end
 
 step 'Prevent Puppet Service from Running'
 on(agents, puppet('resource service puppet ensure=stopped enable=false'))


### PR DESCRIPTION
The acceptance tests were hardcoded to run against 1.3.2 to work-around a
Beaker limitation. The newer versions of Beaker now support installing the
latest Puppet Agent without specifying a version number. Updated the pre-suite
for acceptance tests to now automatically grab the latest version.