### PR TITLE
(MODULES-2414) Update Test Pre-suites

### DIFF
--- a/tests/acceptance/pre-suite/02_dsc_module_install.rb
+++ b/tests/acceptance/pre-suite/02_dsc_module_install.rb
@@ -4,21 +4,27 @@ confine(:to, :platform => 'windows')
 
 # Init
 proj_root = File.expand_path(File.join(File.dirname(__FILE__), '../../../'))
-
-staging = { :module_name => 'puppetlabs-dsc' }
 local = { :module_name => 'dsc', :source => proj_root }
-
-# Check to see if module version is specified.
-staging[:version] = ENV['MODULE_VERSION'] if ENV['MODULE_VERSION']
+pmt_cmd = "module install puppetlabs-dsc --module_working_dir C:/Windows/Temp"
 
 agents.each do |agent|
-  step 'Install DSC Module Dependencies'
-  on(agent, puppet('module install puppetlabs-stdlib'))
-  on(agent, puppet('module install puppetlabs-powershell'))
-  on(agent, puppet('module install puppetlabs-reboot'))
+  # Beaker option set if "BEAKER_FORGE_HOST" environment variable is present
+  if options[:forge_host]
+    # Check to see if module version is specified.
+    pmt_cmd << " --version #{ENV['MODULE_VERSION']}" if ENV['MODULE_VERSION']
 
-  step 'Install DSC Module'
-  local[:target_module_path] = agent['distmoduledir']
-  # in CI install from staging forge, otherwise from local
-  install_dev_puppet_module_on(agent, options[:forge_host] ? staging : local)
+    step 'Install DSC Module from Forge'
+    # Work-around for limitation found in PUP-4866.
+    with_forge_stubbed_on(agent) do
+      on(agent, puppet(pmt_cmd))
+    end
+  else
+    step 'Install DSC Module Dependencies'
+    on(agent, puppet('module install puppetlabs-stdlib'))
+    on(agent, puppet('module install puppetlabs-powershell'))
+    on(agent, puppet('module install puppetlabs-reboot'))
+
+    step 'Install DSC Module from Local Source'
+    install_dev_puppet_module_on(agent, local)
+  end
 end

--- a/tests/integration/pre-suite/01_dsc_module_install.rb
+++ b/tests/integration/pre-suite/01_dsc_module_install.rb
@@ -1,17 +1,23 @@
 test_name 'FM-2626 - C68506 - Plug-in Sync Module from Master with Prerequisites Satisfied on Agent'
 
-step 'Install DSC Module Dependencies'
-on(master, puppet('module install puppetlabs-stdlib'))
-on(master, puppet('module install puppetlabs-powershell'))
-on(master, puppet('module install puppetlabs-reboot'))
-
-step 'Install DSC Module'
+# Init
 proj_root = File.expand_path(File.join(File.dirname(__FILE__), '../../../'))
 staging = { :module_name => 'puppetlabs-dsc' }
 local = { :module_name => 'dsc', :source => proj_root, :target_module_path => master['distmoduledir'] }
 
-# Check to see if module version is specified.
-staging[:version] = ENV['MODULE_VERSION'] if ENV['MODULE_VERSION']
+# Beaker option set if "BEAKER_FORGE_HOST" environment variable is present
+if options[:forge_host]
+  # Check to see if module version is specified.
+  staging[:version] = ENV['MODULE_VERSION'] if ENV['MODULE_VERSION']
 
-# in CI install from staging forge, otherwise from local
-install_dev_puppet_module_on(master, options[:forge_host] ? staging : local)
+  step 'Install DSC Module from Forge'
+  install_dev_puppet_module_on(master, staging)
+else
+  step 'Install DSC Module Dependencies'
+  on(master, puppet('module install puppetlabs-stdlib'))
+  on(master, puppet('module install puppetlabs-powershell'))
+  on(master, puppet('module install puppetlabs-reboot'))
+
+  step 'Install DSC Module from Local Source'
+  install_dev_puppet_module_on(master, local)
+end


### PR DESCRIPTION
Update the pre-suites for acceptance and integration tests. Re-organize the
integration pre-suite so that module dependencies are only installed if
installing module from local source. Change the acceptance pre-suite to build
a PMT command-line to work-around the PUP-4866 issue.