### PR TITLE
(MODULES-3288) Multi-line values do not work in DSCResources

### DIFF
--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -143,6 +143,8 @@ Puppet (including 3.x), or to a Puppet version newer than 3.x.
 
   def self.format_dsc_value(dsc_value)
     case
+    when dsc_value.class.name == 'String' && dsc_value.lines.count > 1
+      "@'\n#{dsc_value}\n'@"
     when dsc_value.class.name == 'String'
       "'#{escape_quotes(dsc_value)}'"
     when dsc_value.class.ancestors.include?(Numeric)

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -35,9 +35,9 @@ module PuppetX
           $runspace.Open()
         }
 
-        $powershell_code = @'
+        $powershell_code = {
 #{powershell_code}
-'@
+}
         $ps = $null
 
         try

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -1,6 +1,7 @@
 require 'securerandom'
 require 'open3'
 require 'ffi'
+require 'base64'
 
 module PuppetX
   module Dsc
@@ -25,6 +26,7 @@ module PuppetX
       def execute(powershell_code, timeout_ms = 300 * 1000)
         output_ready_event_name =  "Global\\#{SecureRandom.uuid}"
         output_ready_event = self.class.create_event(output_ready_event_name)
+        powershell_code_base64 = Base64.encode64(powershell_code)
 
         # always need a trailing newline to ensure PowerShell parses code
         code = <<-CODE
@@ -35,9 +37,10 @@ module PuppetX
           $runspace.Open()
         }
 
-        $powershell_code = {
-#{powershell_code}
-}
+        $powershell_code_base64 = '#{powershell_code_base64}'
+        $powershell_code_bytes  = [System.Convert]::FromBase64String($powershell_code_base64)
+        $powershell_code = [System.Text.Encoding]::UTF8.GetString($powershell_code_bytes)
+
         $ps = $null
 
         try

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -43,6 +43,18 @@ $count
       expect(result).not_to eq(nil)
     end
 
+    it "should execute here strings" do
+      result = manager.execute(<<-CODE
+$foo = @'
+foo
+bar
+'@
+$foo
+      CODE
+      )[:stdout]
+      expect(result).to eq("foo\nbar\n")
+    end
+
     it "should reuse the same PowerShell process for multiple calls" do
       first_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]
       second_pid = manager.execute('[Diagnostics.Process]::GetCurrentProcess().Id')[:stdout]

--- a/spec/unit/puppet/provider/powershell_spec.rb
+++ b/spec/unit/puppet/provider/powershell_spec.rb
@@ -18,7 +18,15 @@ describe Puppet::Type.type(:dsc_file).provider(:powershell) do
   end
 
   describe "when quotes are present" do
+    it "should handle multi-line strings" do
+      actual   = <<-ACTUAL
+      The 'Cats' go '$meow'!
+      The 'Dogs' go "woof"!
+      ACTUAL
+      expected = /@'\n\s+The 'Cats' go '\$meow'!\n\s+The 'Dogs' go "woof"!\n\n'@/
 
+      expect(subject.class.format_dsc_value(actual)).to match(expected)
+    end
     it "should handle single quotes" do
       expect(subject.class.format_dsc_value("The 'Cats' go 'meow'!")).to match(/'The ''Cats'' go ''meow''!'/)
     end


### PR DESCRIPTION
Enable multi-line DSC values. 

It uses Powershell here string formatting when the value given has multiple lines. Single line strings are still formatted inside single quotes. This required changing the Powershell manager to use a code block instead of a here string for storing the script to run, because you cannot nest a single quoted here string inside of another.