### PR TITLE
(MODULES-3343) Nano server compatibility

### DIFF
--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -55,7 +55,7 @@ Puppet (including 3.x), or to a Puppet version newer than 3.x.
   end
 
   def self.powershell_args
-    ps_args = ['-NoProfile', '-NonInteractive', '-Sta', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command']
+    ps_args = ['-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command']
     ps_args << '-' if !Facter.value(:uses_win32console)
     ps_args
   end

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -49,7 +49,7 @@ module PuppetX
 
           $asyncResult = $ps.BeginInvoke()
 
-          if (!$asyncResult.AsyncWaitHandle.WaitOne(#{timeout_ms}, $false))
+          if (!$asyncResult.AsyncWaitHandle.WaitOne(#{timeout_ms}))
           {
             throw "Catastrophic failure: PowerShell DSC resource timeout (#{timeout_ms} ms) exceeded while executing"
           }


### PR DESCRIPTION
- Use the CoreCLR compatible `WaitHandle.WaitOne(timeout)`
- Don't invoke `powershell.exe` with `-Sta`