### PR TITLE
(MODULES-3410) DSC fixtures uses incorrect PowerShell version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,10 @@
 fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
-    powershell: "puppetlabs/powershell"
+    powershell:
+      repo: "puppetlabs/powershell"
+      # pin to version 1.0.6 to match metadata version string reqs
+      ref: "1.0.6"
     reboot: "puppetlabs/reboot"
   symlinks:
     "dsc": "#{source_dir}"


### PR DESCRIPTION
Previously, the DSC fixtures would use the latest (2.0.1) version
of Powershell instead of 1.0.6, as specified in the metadata.json.

This commit pins the powershell module to version 1.0.6 in the
fixtures.yml file as puppet_spec_helper does not correctly handle
version range strings.