### PR TITLE
(MODULES-3363) Support arbitrary Ensure values

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -86,11 +86,13 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
 
   ensurable do
     newvalue(:exists?) { provider.exists? }
-    newvalue(:<%= begin resource.ensure_value rescue 'present' end %>) { provider.create }
+<%  resource.valid_ensure_present_values.each do |property| -%>
+    newvalue(:<%= property.downcase %>) { provider.create }
+<%  end -%>
 <%  if resource.absentable? -%>
     newvalue(:<%= resource.absent_value %>)  { provider.destroy }
 <%  end -%>
-    defaultto { :<%= begin resource.ensure_value rescue 'present' end %> }
+    defaultto { :<%= resource.default_ensure_value %> }
   end
 
 <%  resource.properties.each do |property| -%>

--- a/build/dsc/templates/dsc_type_spec.rb.erb
+++ b/build/dsc/templates/dsc_type_spec.rb.erb
@@ -42,8 +42,8 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
   end
 <%  if resource.ensurable? -%>
 
-  it 'should default to ensure => <%= resource.ensure_value %>' do
-    expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq :<%= resource.ensure_value %>
+  it 'should default to ensure => <%= resource.default_ensure_value %>' do
+    expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq :<%= resource.default_ensure_value %>
   end
 <%  end # resource.ensurable? -%>
 <%  resource.properties.each do |property| -%>
@@ -278,24 +278,24 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
 <%  end # unless ['msft_filedirectoryconfiguration'].... -%>
 <%  if resource.ensurable? -%>
 
-    describe "when dsc_ensure is '<%= resource.ensure_value %>'" do
+    describe "when dsc_ensure is '<%= resource.default_ensure_value %>'" do
 
       before(:each) do
-        dsc_<%= resource.friendlyname.downcase %>.original_parameters[:dsc_ensure] = '<%= resource.ensure_value %>'
-        dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure] = '<%= resource.ensure_value %>'
+        dsc_<%= resource.friendlyname.downcase %>.original_parameters[:dsc_ensure] = '<%= resource.default_ensure_value %>'
+        dsc_<%= resource.friendlyname.downcase %>[:dsc_ensure] = '<%= resource.default_ensure_value %>'
         @provider = described_class.provider(:powershell).new(dsc_<%= resource.friendlyname.downcase %>)
       end
 
-      it "should update :ensure to :<%= resource.ensure_value %>" do
-        expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq(:<%= resource.ensure_value %>)
+      it "should update :ensure to :<%= resource.default_ensure_value %>" do
+        expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq(:<%= resource.default_ensure_value %>)
       end
 
-      it "should compute powershell dsc test script in which ensure value is '<%= resource.ensure_value %>'" do
-        expect(@provider.ps_script_content('test')).to match(/ensure = '<%= resource.ensure_value %>'/)
+      it "should compute powershell dsc test script in which ensure value is '<%= resource.default_ensure_value %>'" do
+        expect(@provider.ps_script_content('test')).to match(/ensure = '<%= resource.default_ensure_value %>'/)
       end
 
-      it "should compute powershell dsc set script in which ensure value is '<%= resource.ensure_value %>'" do
-        expect(@provider.ps_script_content('set')).to match(/ensure = '<%= resource.ensure_value %>'/)
+      it "should compute powershell dsc set script in which ensure value is '<%= resource.default_ensure_value %>'" do
+        expect(@provider.ps_script_content('set')).to match(/ensure = '<%= resource.default_ensure_value %>'/)
       end
 
     end
@@ -314,8 +314,8 @@ describe Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>) do
         expect(dsc_<%= resource.friendlyname.downcase %>[:ensure]).to eq(:<%= resource.absent_value %>)
       end
 
-      it "should compute powershell dsc test script in which ensure value is '<%= resource.ensure_value %>'" do
-        expect(@provider.ps_script_content('test')).to match(/ensure = '<%= resource.ensure_value %>'/)
+      it "should compute powershell dsc test script in which ensure value is '<%= resource.default_ensure_value %>'" do
+        expect(@provider.ps_script_content('test')).to match(/ensure = '<%= resource.default_ensure_value %>'/)
       end
 
       it "should compute powershell dsc set script in which ensure value is '<%= resource.absent_value %>'" do

--- a/lib/puppet/type/dsc_runbookdirectory.rb
+++ b/lib/puppet/type/dsc_runbookdirectory.rb
@@ -1,0 +1,141 @@
+require 'pathname'
+
+Puppet::Type.newtype(:dsc_runbookdirectory) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
+
+
+  @doc = %q{
+    The DSC RunbookDirectory resource type.
+    Automatically generated from
+    'xSCSMA/DSCResources/MSFT_xRunbookDirectory/MSFT_xRunbookDirectory.schema.mof'
+
+    To learn more about PowerShell Desired State Configuration, please
+    visit https://technet.microsoft.com/en-us/library/dn249912.aspx.
+
+    For more information about built-in DSC Resources, please visit
+    https://technet.microsoft.com/en-us/library/dn249921.aspx.
+
+    For more information about xDsc Resources, please visit
+    https://github.com/PowerShell/DscResources.
+  }
+
+  validate do
+      fail('dsc_runbookpath is a required attribute') if self[:dsc_runbookpath].nil?
+      fail('dsc_webserviceendpoint is a required attribute') if self[:dsc_webserviceendpoint].nil?
+    end
+
+  def dscmeta_resource_friendly_name; 'RunbookDirectory' end
+  def dscmeta_resource_name; 'MSFT_xRunbookDirectory' end
+  def dscmeta_module_name; 'xSCSMA' end
+  def dscmeta_module_version; '1.3.0.0' end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:published) { provider.create }
+    newvalue(:draft) { provider.create }
+    newvalue(:absent)  { provider.destroy }
+    defaultto { :published }
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Published", "Draft", "Absent"]
+  newparam(:dsc_ensure) do
+    def mof_type; 'string' end
+    def mof_is_embedded?; false end
+    desc "Ensure - The import state of runbooks found at RunbookPath. This can be Published, Draft, or Absent Valid values are Published, Draft, Absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Published', 'published', 'Draft', 'draft', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Published, Draft, Absent")
+      end
+    end
+  end
+
+  # Name:         RunbookPath
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_runbookpath) do
+    def mof_type; 'string' end
+    def mof_is_embedded?; false end
+    desc "RunbookPath - Path to Runbook(s) to be imported. Accepts wildcards."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Matches
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_matches) do
+    def mof_type; 'boolean' end
+    def mof_is_embedded?; false end
+    desc "Matches - Describes the validity of the imported Runbook(s)."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
+    end
+  end
+
+  # Name:         WebServiceEndpoint
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_webserviceendpoint) do
+    def mof_type; 'string' end
+    def mof_is_embedded?; false end
+    desc "WebServiceEndpoint - URL of SMA's web service endpoint."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Port
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_port) do
+    def mof_type; 'uint32' end
+    def mof_is_embedded?; false end
+    desc "Port - Port of the SMA web site. Defaults to the SMA default of 9090."
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
+    end
+  end
+
+
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
+end
+
+Puppet::Type.type(:dsc_runbookdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10240.16384'))
+  defaultfor :operatingsystem => :windows
+
+  mk_resource_methods
+end

--- a/lib/puppet/type/dsc_smavariable.rb
+++ b/lib/puppet/type/dsc_smavariable.rb
@@ -1,0 +1,170 @@
+require 'pathname'
+
+Puppet::Type.newtype(:dsc_smavariable) do
+  require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc'
+  require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_type_helpers'
+
+
+  @doc = %q{
+    The DSC SmaVariable resource type.
+    Automatically generated from
+    'xSCSMA/DSCResources/MSFT_xSmaVariable/MSFT_xSmaVariable.schema.mof'
+
+    To learn more about PowerShell Desired State Configuration, please
+    visit https://technet.microsoft.com/en-us/library/dn249912.aspx.
+
+    For more information about built-in DSC Resources, please visit
+    https://technet.microsoft.com/en-us/library/dn249921.aspx.
+
+    For more information about xDsc Resources, please visit
+    https://github.com/PowerShell/DscResources.
+  }
+
+  validate do
+      fail('dsc_name is a required attribute') if self[:dsc_name].nil?
+      fail('dsc_webserviceendpoint is a required attribute') if self[:dsc_webserviceendpoint].nil?
+    end
+
+  def dscmeta_resource_friendly_name; 'SmaVariable' end
+  def dscmeta_resource_name; 'MSFT_xSmaVariable' end
+  def dscmeta_module_name; 'xSCSMA' end
+  def dscmeta_module_version; '1.3.0.0' end
+
+  newparam(:name, :namevar => true ) do
+  end
+
+  ensurable do
+    newvalue(:exists?) { provider.exists? }
+    newvalue(:present) { provider.create }
+    newvalue(:absent)  { provider.destroy }
+    defaultto { :present }
+  end
+
+  # Name:         Ensure
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       ["Present", "Absent"]
+  newparam(:dsc_ensure) do
+    def mof_type; 'string' end
+    def mof_is_embedded?; false end
+    desc "Ensure - Desired state of SMA variable Valid values are Present, Absent."
+    validate do |value|
+      resource[:ensure] = value.downcase
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+      unless ['Present', 'present', 'Absent', 'absent'].include?(value)
+        fail("Invalid value '#{value}'. Valid values are Present, Absent")
+      end
+    end
+  end
+
+  # Name:         Name
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_name) do
+    def mof_type; 'string' end
+    def mof_is_embedded?; false end
+    desc "Name - Name of SMA variable."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         value
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_value) do
+    def mof_type; 'string' end
+    def mof_is_embedded?; false end
+    desc "value - Value of SMA variable."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Description
+  # Type:         string
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_description) do
+    def mof_type; 'string' end
+    def mof_is_embedded?; false end
+    desc "Description - Description of SMA variable."
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Set
+  # Type:         boolean
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_set) do
+    def mof_type; 'boolean' end
+    def mof_is_embedded?; false end
+    desc "Set - Set is true if existing SMA variable matches configuration."
+    validate do |value|
+    end
+    newvalues(true, false)
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
+    end
+  end
+
+  # Name:         WebServiceEndpoint
+  # Type:         string
+  # IsMandatory:  True
+  # Values:       None
+  newparam(:dsc_webserviceendpoint) do
+    def mof_type; 'string' end
+    def mof_is_embedded?; false end
+    desc "WebServiceEndpoint - Web service endpoint of SMA instance."
+    isrequired
+    validate do |value|
+      unless value.kind_of?(String)
+        fail("Invalid value '#{value}'. Should be a string")
+      end
+    end
+  end
+
+  # Name:         Port
+  # Type:         uint32
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_port) do
+    def mof_type; 'uint32' end
+    def mof_is_embedded?; false end
+    desc "Port - Port to reach the web service endpoint. Defaults to the SMA default of 9090."
+    validate do |value|
+      unless (value.kind_of?(Numeric) && value >= 0) || (value.to_i.to_s == value && value.to_i >= 0)
+          fail("Invalid value #{value}. Should be a unsigned Integer")
+      end
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_integer(value)
+    end
+  end
+
+
+  def builddepends
+    pending_relations = super()
+    PuppetX::Dsc::TypeHelpers.ensure_reboot_relationship(self, pending_relations)
+  end
+end
+
+Puppet::Type.type(:dsc_smavariable).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
+  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10240.16384'))
+  defaultfor :operatingsystem => :windows
+
+  mk_resource_methods
+end

--- a/lib/puppet_x/dsc_resources/xSCSMA/DSCResources/MSFT_xRunbookDirectory/MSFT_xRunbookDirectory.psm1
+++ b/lib/puppet_x/dsc_resources/xSCSMA/DSCResources/MSFT_xRunbookDirectory/MSFT_xRunbookDirectory.psm1
@@ -1,0 +1,250 @@
+data LocalizedData 
+{ 
+    # culture="en-US" 
+    ConvertFrom-StringData -StringData @' 
+ FindingRunbookDefinition = Finding runbook definition for {0}. 
+ ExistinRunbookDefinition = Existing Runbook definition found.
+ CreatingTempFile = Creating temp file at {0}.
+ RunbookFoundMatches = Runbook found matches. No import needed.
+ RunbookDifferencesFound = Runbook differences found. Import needed.
+ RemovingTempFile = Removing temp file at {0}.
+ ImportTwice = Importing all runbooks twice to build all dependencies.
+ ImportingRunbook = Importing Runbook {0}.
+ ImportNotRequired = An import is not required.
+ ImportRequired = An import is required.
+ ImportCount = Import number {0}.
+ RemovingRunbook = Removing runbook {0}.
+ FailedToRemoveRunbook = Failed to remove Runbook {0}.
+'@ 
+} 
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet("Published", "Draft", "Absent")]
+        [System.String]
+        $Ensure = "Published",
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $RunbookPath,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WebServiceEndpoint,
+
+        [Uint32]
+        $Port = 9090
+    )
+
+    $RunbookPathItems = Get-Item $RunbookPath -Filter *.ps1
+
+    $ensureStatus = "Absent"
+    $match = $true
+    forEach ($RunbookPathItem in $RunbookPathItems)
+    {
+        if( $match )
+        {
+            Write-Verbose ( $($LocalizedData.FindingRunbookDefinition) -f $RunbookPathItem.BaseName )
+
+            # Get runbook definition if one exist
+            $runbookFound = $false
+            try
+            {
+                if( $Ensure -eq "Published" )
+                {
+                    $runbookDefinition = Get-SmaRunbookDefinition -Name $($RunbookPathItem.BaseName) -WebServiceEndpoint $WebServiceEndpoint -Port $port -Type 'Published' -ErrorAction Stop
+
+                    $ensureStatus = "Published"
+                }
+                else
+                {
+                    $runbookDefinition = Get-SmaRunbookDefinition -Name $($RunbookPathItem.BaseName) -WebServiceEndpoint $WebServiceEndpoint -Port $port -Type 'Draft' -ErrorAction Stop
+
+                    $ensureStatus = "Draft"
+                }
+
+                $runbookFound = $true
+                Write-Verbose ( $LocalizedData.ExistinRunbookDefinition )
+            }
+            catch
+            {
+                Write-Verbose $_ 
+                $match = $false
+            }
+
+            if( $runbookFound )
+            {
+                # Can't compare the value of the $runbookDefinition.Content variable to a file, so writing it to a file, then will compare that.
+                $runbookTempPath = "$env:TEMP\$($RunbookPathItem.BaseName).ps1"
+
+                Write-Verbose ( $($LocalizedData.CreatingTempFile) -f $runbookTempPath)
+                $runbookDefinition.Content.ToString() | Out-File -FilePath $runbookTempPath
+
+                $compare = Compare-Object -ReferenceObject (Get-Content $RunbookPathItem.FullName) -DifferenceObject (Get-Content $runbookTempPath)
+                if( $compare -eq $null )
+                {
+                    Write-Verbose ( $LocalizedData.RunbookFoundMatches )
+                }
+                Else
+                {
+                    # Compare-Object sometimes returns new lines as a difference, this can cause repeated re-imports if that new line is at the top of the ps1
+                    # since SMA will strip this out on import.
+
+                    foreach( $difference in $compare )
+                    {
+                        if( $difference.InputObject -ne "" )
+                        {
+                            Write-Verbose ( $LocalizedData.RunbookDifferencesFound )
+                            $match = $false
+                        }
+                    }
+
+                    if( $match )
+                    {
+                        Write-Verbose ( $LocalizedData.RunbookFoundMatches )
+                    }
+                }
+
+                Write-Verbose ( $($LocalizedData.RemovingTempFile) -f $runbookTempPath )
+                Remove-Item -Path $runbookTempPath
+            }
+        }
+    }
+
+    $returnValue = @{
+        Ensure = [System.String]$ensureStatus
+        RunbookPath = [System.String]$RunbookPath
+        WebServiceEndpoint = [System.String]$WebServiceEndpoint
+        Port = [System.String]$Port
+        Matches = [System.Boolean]$match
+    }
+
+    $returnValue
+}
+
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet("Published", "Draft", "Absent")]
+        [System.String]
+        $Ensure = "Published",
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $RunbookPath,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WebServiceEndpoint,
+
+        [Uint32]
+        $Port = 9090
+    )
+
+    $RunbookPathItems = Get-Item $RunbookPath -Filter *.ps1
+
+    if( $Ensure -eq "Absent")
+    {
+        forEach ($RunbookPathItem in $RunbookPathItems)
+        {
+            try
+            {
+                Write-Verbose ( $($LocalizedData.RemovingRunbook) -f $RunbookPathItem.BaseName)
+
+                Remove-SmaRunbook -Name $RunbookPathItem.BaseName -WebServiceEndpoint $WebServiceEndpoint -Port $port -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose ( $($LocalizedData.FailedToRemoveRunbook) -f $RunbookPathItem.BaseName)
+            }
+        }
+    }
+    else
+    {
+        Write-Verbose ( $LocalizedData.ImportTwice )
+        for($k = 1; $k -lt 3; $k++)
+        {
+            Write-Verbose ( $($LocalizedData.ImportCount) -f $k )
+            forEach ($RunbookPathItem in $RunbookPathItems)
+            {
+                # try to edit an existing runbook with the same name, this saves a read to verify that the runbook exist.
+                # if error, assume the runbook has never been imported
+                Write-Verbose ( $($LocalizedData.ImportingRunbook) -f $RunbookPathItem.BaseName )
+                try
+                {
+                    Edit-SmaRunbook -Path $RunbookPathItem.FullName -Name $RunbookPathItem.BaseName -WebServiceEndpoint $WebServiceEndpoint -Port $port -Overwrite -ErrorAction Stop
+                }
+                catch
+                {
+                    Import-SmaRunbook -Path $RunbookPathItem.FullName -WebServiceEndpoint $WebServiceEndpoint -Port $port -ErrorAction Stop
+                }      
+            }
+        }
+
+        if( $Ensure -eq "Published" )
+        {
+            forEach ($RunbookPathItem in $RunbookPathItems)
+            {
+                Publish-SmaRunbook -Name $RunbookPathItem.BaseName -WebServiceEndpoint $WebServiceEndpoint -Port $port -ErrorAction Stop
+            }
+        }
+    }
+}
+
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet("Published", "Draft", "Absent")]
+        [System.String]
+        $Ensure = "Published",
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $RunbookPath,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WebServiceEndpoint,
+
+        [Uint32]
+        $Port = 9090
+    )
+
+    $results = Get-TargetResource @PSBoundParameters
+
+    if( ($Ensure -eq "Published") -or ($Ensure -eq "Draft") )
+    {
+        if( ($results.Ensure -eq $Ensure) -and ($results.Matches -eq $true) )
+        {
+            Write-Verbose ( $LocalizedData.ImportNotRequired )
+            return $true
+        }
+    }
+
+    if( ($results.Ensure -eq "Absent") -and ($Ensure -eq "Absent") )
+    {
+        Write-Verbose ( $LocalizedData.ImportNotRequired )
+        return $true
+    }
+
+    Write-Verbose ( $LocalizedData.ImportRequired )
+    return $false
+}
+
+
+Export-ModuleMember -Function Get-TargetResource, Set-TargetResource, Test-TargetResource
+

--- a/lib/puppet_x/dsc_resources/xSCSMA/DSCResources/MSFT_xRunbookDirectory/MSFT_xRunbookDirectory.schema.mof
+++ b/lib/puppet_x/dsc_resources/xSCSMA/DSCResources/MSFT_xRunbookDirectory/MSFT_xRunbookDirectory.schema.mof
@@ -1,0 +1,10 @@
+[ClassVersion("1.0.0.0"), FriendlyName("RunbookDirectory")]
+class MSFT_xRunbookDirectory : OMI_BaseResource
+{
+    [Required, Description("The import state of runbooks found at RunbookPath. This can be Published, Draft, or Absent"), ValueMap{"Published","Draft","Absent"}, Values{"Published","Draft","Absent"}] String Ensure;    
+    [Key, Description("Path to Runbook(s) to be imported. Accepts wildcards.")] String RunbookPath;
+    [Read, Description("Describes the validity of the imported Runbook(s).")] Boolean Matches;
+    [Key, Description("URL of SMA's web service endpoint.")] String WebServiceEndpoint;
+    [Write, Description("Port of the SMA web site. Defaults to the SMA default of 9090.")] Uint32 Port;
+};
+

--- a/lib/puppet_x/dsc_resources/xSCSMA/DSCResources/MSFT_xSmaVariable/MSFT_xSmaVariable.psm1
+++ b/lib/puppet_x/dsc_resources/xSCSMA/DSCResources/MSFT_xSmaVariable/MSFT_xSmaVariable.psm1
@@ -1,0 +1,173 @@
+data LocalizedData  
+{  
+    # culture="en-US"  
+    ConvertFrom-StringData -StringData @'  
+ VariableDoesNotMatch = variable {0} has value {1} expected {2}.  
+ VariableDescriptionDoesNotMatch = variable {0} has description {1} expected {2}.
+ VariableNotFound = Failed to find variable {0}.
+'@  
+} 
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet("Present","Absent")]
+        [System.String]
+        $Ensure = "Present",
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $value,
+
+        [System.String]
+        $Description,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WebServiceEndpoint,
+
+        [System.UInt32]
+        $Port = 9090
+    )
+    
+    $Set = $true
+    try
+    {
+        $variable = Get-SmaVariable -Name $Name -WebServiceEndpoint $webserviceendpoint -port $port -ErrorAction Stop
+
+        $Ensure = "Present"
+
+        # check variable value match
+        if($variable.Value -ne $value)
+        {
+            Write-Verbose ( $($LocalizedData.VariableDoesNotMatch) -f $Name, $variable.Value, $value)
+            $Set = $false
+        }
+
+        # check description match
+        if($variable.Description -ne $Description )
+        {
+            # check description are not supposed to be empty
+            if( !(($variable.Description -eq $null) -and ($Description -eq ""))  )
+            {
+                Write-Verbose ( $($LocalizedData.VariableDescriptionDoesNotMatch) -f $Name, $variable.Description, $Description)
+                $Set = $false
+            }
+        }
+    }
+    catch
+    {
+        Write-Verbose ( $($LocalizedData.VariableNotFound) -f $Name)
+        $Set = $false
+        $Ensure = "Absent"
+    }
+    
+    $returnValue = @{
+        Ensure = [System.String]$Ensure
+        Name = [System.String]$variable.Name
+        value = [System.String]$variable.Value
+        Description = [System.String]$variable.Description
+        Set = [System.Boolean]$Set
+        WebServiceEndpoint = [System.String]$WebServiceEndpoint
+        Port = [System.UInt32]$Port
+    }
+
+    $returnValue
+}
+
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet("Present","Absent")]
+        [System.String]
+        $Ensure = "Present",
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $value,
+
+        [System.String]
+        $Description,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WebServiceEndpoint,
+
+        [System.UInt32]
+        $Port = 9090
+    )
+
+    If($Ensure -eq "Present")
+    {
+        Set-SmaVariable -Name $Name -Value $value -Description $Description -WebServiceEndpoint $webserviceendpoint -port $port -ErrorAction Stop
+    }
+    else
+    {
+        Remove-SmaVariable -Name $Name -WebServiceEndpoint $webserviceendpoint -port $port -ErrorAction Stop
+    }
+}
+
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet("Present","Absent")]
+        [System.String]
+        $Ensure = "Present",
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $value,
+
+        [System.String]
+        $Description,
+
+        [parameter(Mandatory = $true)]
+        [System.String]
+        $WebServiceEndpoint,
+
+        [System.UInt32]
+        $Port = 9090
+    )
+    
+    $result = Get-TargetResource @PSBoundParameters
+
+    if( ($Ensure -eq "Present") -and ($result.Ensure -eq "Present") -and ($result.set -eq $true))
+    {
+        return $true
+    }
+    elseif( ($result.Ensure -eq "Absent") -and ($Ensure -eq "Absent") )
+    {
+        return $true
+    }
+
+    return $false
+}
+
+
+Export-ModuleMember -Function Get-TargetResource, Set-TargetResource, Test-TargetResource
+

--- a/lib/puppet_x/dsc_resources/xSCSMA/DSCResources/MSFT_xSmaVariable/MSFT_xSmaVariable.schema.mof
+++ b/lib/puppet_x/dsc_resources/xSCSMA/DSCResources/MSFT_xSmaVariable/MSFT_xSmaVariable.schema.mof
@@ -1,0 +1,14 @@
+
+[ClassVersion("1.0.0.0"), FriendlyName("SmaVariable")]
+class MSFT_xSmaVariable : OMI_BaseResource
+{
+    [Required, Description("Desired state of SMA variable"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Key, Description("Name of SMA variable.")] String Name;
+    [Required, Description("Value of SMA variable.")] String value;
+    [Write, Description("Description of SMA variable.")] String Description;
+    [Read, Description("Set is true if existing SMA variable matches configuration.")] Boolean Set;
+    [Key, Description("Web service endpoint of SMA instance.")] String WebServiceEndpoint;
+    [Write, Description("Port to reach the web service endpoint. Defaults to the SMA default of 9090.")] Uint32 Port;
+};
+
+

--- a/lib/puppet_x/dsc_resources/xSCSMA/xSCSMA.psd1
+++ b/lib/puppet_x/dsc_resources/xSCSMA/xSCSMA.psd1
@@ -53,3 +53,4 @@ PrivateData = @{
 
 } # End of PrivateData hashtable
 }
+

--- a/spec/unit/puppet/type/dsc_runbookdirectory_spec.rb
+++ b/spec/unit/puppet/type/dsc_runbookdirectory_spec.rb
@@ -1,0 +1,304 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_runbookdirectory) do
+
+  let :dsc_runbookdirectory do
+    Puppet::Type.type(:dsc_runbookdirectory).new(
+      :name     => 'foo',
+      :dsc_runbookpath => 'foo',
+      :dsc_webserviceendpoint => 'foo',
+    )
+  end
+
+  it 'should allow all properties to be specified' do
+    expect { Puppet::Type.type(:dsc_runbookdirectory).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Published',
+      :dsc_runbookpath => 'foo',
+      :dsc_matches => true,
+      :dsc_webserviceendpoint => 'foo',
+      :dsc_port => 32,
+    )}.to_not raise_error
+  end
+
+  it "should stringify normally" do
+    expect(dsc_runbookdirectory.to_s).to eq("Dsc_runbookdirectory[foo]")
+  end
+
+  it 'should default to ensure => published' do
+    expect(dsc_runbookdirectory[:ensure]).to eq :published
+  end
+
+  it 'should accept dsc_ensure predefined value Published' do
+    dsc_runbookdirectory[:dsc_ensure] = 'Published'
+    expect(dsc_runbookdirectory[:dsc_ensure]).to eq('Published')
+  end
+
+  it 'should accept dsc_ensure predefined value published' do
+    dsc_runbookdirectory[:dsc_ensure] = 'published'
+    expect(dsc_runbookdirectory[:dsc_ensure]).to eq('published')
+  end
+
+  it 'should accept dsc_ensure predefined value published and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_runbookdirectory[:dsc_ensure] = 'published'
+    expect(dsc_runbookdirectory[:ensure]).to eq(dsc_runbookdirectory[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Draft' do
+    dsc_runbookdirectory[:dsc_ensure] = 'Draft'
+    expect(dsc_runbookdirectory[:dsc_ensure]).to eq('Draft')
+  end
+
+  it 'should accept dsc_ensure predefined value draft' do
+    dsc_runbookdirectory[:dsc_ensure] = 'draft'
+    expect(dsc_runbookdirectory[:dsc_ensure]).to eq('draft')
+  end
+
+  it 'should accept dsc_ensure predefined value draft and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_runbookdirectory[:dsc_ensure] = 'draft'
+    expect(dsc_runbookdirectory[:ensure]).to eq(dsc_runbookdirectory[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_runbookdirectory[:dsc_ensure] = 'Absent'
+    expect(dsc_runbookdirectory[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_runbookdirectory[:dsc_ensure] = 'absent'
+    expect(dsc_runbookdirectory[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_runbookdirectory[:dsc_ensure] = 'absent'
+    expect(dsc_runbookdirectory[:ensure]).to eq(dsc_runbookdirectory[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_runbookdirectory[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_runbookdirectory[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_runbookdirectory[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_runbookdirectory[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_runbookdirectory[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_runbookpath is specified' do
+    #dsc_runbookdirectory[:dsc_runbookpath]
+    expect { Puppet::Type.type(:dsc_runbookdirectory).new(
+      :name     => 'foo',
+      :dsc_webserviceendpoint => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_runbookpath is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_runbookpath' do
+    expect{dsc_runbookdirectory[:dsc_runbookpath] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_runbookpath' do
+    expect{dsc_runbookdirectory[:dsc_runbookpath] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_runbookpath' do
+    expect{dsc_runbookdirectory[:dsc_runbookpath] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_runbookpath' do
+    expect{dsc_runbookdirectory[:dsc_runbookpath] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_matches' do
+    expect{dsc_runbookdirectory[:dsc_matches] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_matches' do
+    dsc_runbookdirectory[:dsc_matches] = true
+    expect(dsc_runbookdirectory[:dsc_matches]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_matches" do
+    dsc_runbookdirectory[:dsc_matches] = 'true'
+    expect(dsc_runbookdirectory[:dsc_matches]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_matches" do
+    dsc_runbookdirectory[:dsc_matches] = 'false'
+    expect(dsc_runbookdirectory[:dsc_matches]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_matches" do
+    dsc_runbookdirectory[:dsc_matches] = 'True'
+    expect(dsc_runbookdirectory[:dsc_matches]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_matches" do
+    dsc_runbookdirectory[:dsc_matches] = 'False'
+    expect(dsc_runbookdirectory[:dsc_matches]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_matches" do
+    dsc_runbookdirectory[:dsc_matches] = :true
+    expect(dsc_runbookdirectory[:dsc_matches]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_matches" do
+    dsc_runbookdirectory[:dsc_matches] = :false
+    expect(dsc_runbookdirectory[:dsc_matches]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_matches' do
+    expect{dsc_runbookdirectory[:dsc_matches] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_matches' do
+    expect{dsc_runbookdirectory[:dsc_matches] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_webserviceendpoint is specified' do
+    #dsc_runbookdirectory[:dsc_webserviceendpoint]
+    expect { Puppet::Type.type(:dsc_runbookdirectory).new(
+      :name     => 'foo',
+      :dsc_runbookpath => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_webserviceendpoint is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_webserviceendpoint' do
+    expect{dsc_runbookdirectory[:dsc_webserviceendpoint] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_webserviceendpoint' do
+    expect{dsc_runbookdirectory[:dsc_webserviceendpoint] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_webserviceendpoint' do
+    expect{dsc_runbookdirectory[:dsc_webserviceendpoint] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_webserviceendpoint' do
+    expect{dsc_runbookdirectory[:dsc_webserviceendpoint] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_port' do
+    expect{dsc_runbookdirectory[:dsc_port] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_port' do
+    expect{dsc_runbookdirectory[:dsc_port] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_port' do
+    dsc_runbookdirectory[:dsc_port] = 32
+    expect(dsc_runbookdirectory[:dsc_port]).to eq(32)
+  end
+
+  it 'should not accept signed (negative) value for dsc_port' do
+    value = -32
+    expect(value).to be < 0
+    expect{dsc_runbookdirectory[:dsc_port] = value}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept string-like uint for dsc_port' do
+    dsc_runbookdirectory[:dsc_port] = '16'
+    expect(dsc_runbookdirectory[:dsc_port]).to eq(16)
+  end
+
+  it 'should accept string-like uint for dsc_port' do
+    dsc_runbookdirectory[:dsc_port] = '32'
+    expect(dsc_runbookdirectory[:dsc_port]).to eq(32)
+  end
+
+  it 'should accept string-like uint for dsc_port' do
+    dsc_runbookdirectory[:dsc_port] = '64'
+    expect(dsc_runbookdirectory[:dsc_port]).to eq(64)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_runbookdirectory)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_runbookdirectory)
+    end
+
+    describe "when dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Invoke-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Invoke-DscResource/)
+      end
+
+      it "should compute powershell dsc test script with method Test" do
+        expect(@provider.ps_script_content('test')).to match(/Method\s+=\s*'test'/)
+      end
+
+      it "should compute powershell dsc set script with Invoke-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Invoke-DscResource/)
+      end
+
+      it "should compute powershell dsc test script with method Set" do
+        expect(@provider.ps_script_content('set')).to match(/Method\s+=\s*'set'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'published'" do
+
+      before(:each) do
+        dsc_runbookdirectory.original_parameters[:dsc_ensure] = 'published'
+        dsc_runbookdirectory[:dsc_ensure] = 'published'
+        @provider = described_class.provider(:powershell).new(dsc_runbookdirectory)
+      end
+
+      it "should update :ensure to :published" do
+        expect(dsc_runbookdirectory[:ensure]).to eq(:published)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'published'" do
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'published'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'published'" do
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'published'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_runbookdirectory.original_parameters[:dsc_ensure] = 'absent'
+        dsc_runbookdirectory[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_runbookdirectory)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_runbookdirectory[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'published'" do
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'published'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/puppet/type/dsc_smavariable_spec.rb
+++ b/spec/unit/puppet/type/dsc_smavariable_spec.rb
@@ -1,0 +1,323 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+describe Puppet::Type.type(:dsc_smavariable) do
+
+  let :dsc_smavariable do
+    Puppet::Type.type(:dsc_smavariable).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+      :dsc_webserviceendpoint => 'foo',
+    )
+  end
+
+  it 'should allow all properties to be specified' do
+    expect { Puppet::Type.type(:dsc_smavariable).new(
+      :name     => 'foo',
+      :dsc_ensure => 'Present',
+      :dsc_name => 'foo',
+      :dsc_value => 'foo',
+      :dsc_description => 'foo',
+      :dsc_set => true,
+      :dsc_webserviceendpoint => 'foo',
+      :dsc_port => 32,
+    )}.to_not raise_error
+  end
+
+  it "should stringify normally" do
+    expect(dsc_smavariable.to_s).to eq("Dsc_smavariable[foo]")
+  end
+
+  it 'should default to ensure => present' do
+    expect(dsc_smavariable[:ensure]).to eq :present
+  end
+
+  it 'should accept dsc_ensure predefined value Present' do
+    dsc_smavariable[:dsc_ensure] = 'Present'
+    expect(dsc_smavariable[:dsc_ensure]).to eq('Present')
+  end
+
+  it 'should accept dsc_ensure predefined value present' do
+    dsc_smavariable[:dsc_ensure] = 'present'
+    expect(dsc_smavariable[:dsc_ensure]).to eq('present')
+  end
+
+  it 'should accept dsc_ensure predefined value present and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_smavariable[:dsc_ensure] = 'present'
+    expect(dsc_smavariable[:ensure]).to eq(dsc_smavariable[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should accept dsc_ensure predefined value Absent' do
+    dsc_smavariable[:dsc_ensure] = 'Absent'
+    expect(dsc_smavariable[:dsc_ensure]).to eq('Absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent' do
+    dsc_smavariable[:dsc_ensure] = 'absent'
+    expect(dsc_smavariable[:dsc_ensure]).to eq('absent')
+  end
+
+  it 'should accept dsc_ensure predefined value absent and update ensure with this value (ensure end value should be a symbol)' do
+    dsc_smavariable[:dsc_ensure] = 'absent'
+    expect(dsc_smavariable[:ensure]).to eq(dsc_smavariable[:dsc_ensure].downcase.to_sym)
+  end
+
+  it 'should not accept values not equal to predefined values' do
+    expect{dsc_smavariable[:dsc_ensure] = 'invalid value'}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_ensure' do
+    expect{dsc_smavariable[:dsc_ensure] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_ensure' do
+    expect{dsc_smavariable[:dsc_ensure] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_ensure' do
+    expect{dsc_smavariable[:dsc_ensure] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_ensure' do
+    expect{dsc_smavariable[:dsc_ensure] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_name is specified' do
+    #dsc_smavariable[:dsc_name]
+    expect { Puppet::Type.type(:dsc_smavariable).new(
+      :name     => 'foo',
+      :dsc_webserviceendpoint => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_name is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_name' do
+    expect{dsc_smavariable[:dsc_name] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_name' do
+    expect{dsc_smavariable[:dsc_name] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_name' do
+    expect{dsc_smavariable[:dsc_name] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_name' do
+    expect{dsc_smavariable[:dsc_name] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_value' do
+    expect{dsc_smavariable[:dsc_value] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_value' do
+    expect{dsc_smavariable[:dsc_value] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_value' do
+    expect{dsc_smavariable[:dsc_value] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_value' do
+    expect{dsc_smavariable[:dsc_value] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_description' do
+    expect{dsc_smavariable[:dsc_description] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_description' do
+    expect{dsc_smavariable[:dsc_description] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_description' do
+    expect{dsc_smavariable[:dsc_description] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_description' do
+    expect{dsc_smavariable[:dsc_description] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_set' do
+    expect{dsc_smavariable[:dsc_set] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept boolean for dsc_set' do
+    dsc_smavariable[:dsc_set] = true
+    expect(dsc_smavariable[:dsc_set]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'true' and munge this value to boolean for dsc_set" do
+    dsc_smavariable[:dsc_set] = 'true'
+    expect(dsc_smavariable[:dsc_set]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'false' and munge this value to boolean for dsc_set" do
+    dsc_smavariable[:dsc_set] = 'false'
+    expect(dsc_smavariable[:dsc_set]).to eq(false)
+  end
+
+  it "should accept boolean-like value 'True' and munge this value to boolean for dsc_set" do
+    dsc_smavariable[:dsc_set] = 'True'
+    expect(dsc_smavariable[:dsc_set]).to eq(true)
+  end
+
+  it "should accept boolean-like value 'False' and munge this value to boolean for dsc_set" do
+    dsc_smavariable[:dsc_set] = 'False'
+    expect(dsc_smavariable[:dsc_set]).to eq(false)
+  end
+
+  it "should accept boolean-like value :true and munge this value to boolean for dsc_set" do
+    dsc_smavariable[:dsc_set] = :true
+    expect(dsc_smavariable[:dsc_set]).to eq(true)
+  end
+
+  it "should accept boolean-like value :false and munge this value to boolean for dsc_set" do
+    dsc_smavariable[:dsc_set] = :false
+    expect(dsc_smavariable[:dsc_set]).to eq(false)
+  end
+
+  it 'should not accept int for dsc_set' do
+    expect{dsc_smavariable[:dsc_set] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_set' do
+    expect{dsc_smavariable[:dsc_set] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should require that dsc_webserviceendpoint is specified' do
+    #dsc_smavariable[:dsc_webserviceendpoint]
+    expect { Puppet::Type.type(:dsc_smavariable).new(
+      :name     => 'foo',
+      :dsc_name => 'foo',
+    )}.to raise_error(Puppet::Error, /dsc_webserviceendpoint is a required attribute/)
+  end
+
+  it 'should not accept array for dsc_webserviceendpoint' do
+    expect{dsc_smavariable[:dsc_webserviceendpoint] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_webserviceendpoint' do
+    expect{dsc_smavariable[:dsc_webserviceendpoint] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept int for dsc_webserviceendpoint' do
+    expect{dsc_smavariable[:dsc_webserviceendpoint] = -16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept uint for dsc_webserviceendpoint' do
+    expect{dsc_smavariable[:dsc_webserviceendpoint] = 16}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept array for dsc_port' do
+    expect{dsc_smavariable[:dsc_port] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should not accept boolean for dsc_port' do
+    expect{dsc_smavariable[:dsc_port] = true}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept uint for dsc_port' do
+    dsc_smavariable[:dsc_port] = 32
+    expect(dsc_smavariable[:dsc_port]).to eq(32)
+  end
+
+  it 'should not accept signed (negative) value for dsc_port' do
+    value = -32
+    expect(value).to be < 0
+    expect{dsc_smavariable[:dsc_port] = value}.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should accept string-like uint for dsc_port' do
+    dsc_smavariable[:dsc_port] = '16'
+    expect(dsc_smavariable[:dsc_port]).to eq(16)
+  end
+
+  it 'should accept string-like uint for dsc_port' do
+    dsc_smavariable[:dsc_port] = '32'
+    expect(dsc_smavariable[:dsc_port]).to eq(32)
+  end
+
+  it 'should accept string-like uint for dsc_port' do
+    dsc_smavariable[:dsc_port] = '64'
+    expect(dsc_smavariable[:dsc_port]).to eq(64)
+  end
+
+  # Configuration PROVIDER TESTS
+
+  describe "powershell provider tests" do
+
+    it "should successfully instanciate the provider" do
+      described_class.provider(:powershell).new(dsc_smavariable)
+    end
+
+    before(:each) do
+      @provider = described_class.provider(:powershell).new(dsc_smavariable)
+    end
+
+    describe "when dscmeta_module_name existing/is defined " do
+
+      it "should compute powershell dsc test script with Invoke-DscResource" do
+        expect(@provider.ps_script_content('test')).to match(/Invoke-DscResource/)
+      end
+
+      it "should compute powershell dsc test script with method Test" do
+        expect(@provider.ps_script_content('test')).to match(/Method\s+=\s*'test'/)
+      end
+
+      it "should compute powershell dsc set script with Invoke-DscResource" do
+        expect(@provider.ps_script_content('set')).to match(/Invoke-DscResource/)
+      end
+
+      it "should compute powershell dsc test script with method Set" do
+        expect(@provider.ps_script_content('set')).to match(/Method\s+=\s*'set'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'present'" do
+
+      before(:each) do
+        dsc_smavariable.original_parameters[:dsc_ensure] = 'present'
+        dsc_smavariable[:dsc_ensure] = 'present'
+        @provider = described_class.provider(:powershell).new(dsc_smavariable)
+      end
+
+      it "should update :ensure to :present" do
+        expect(dsc_smavariable[:ensure]).to eq(:present)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'present'" do
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'present'/)
+      end
+
+    end
+
+    describe "when dsc_ensure is 'absent'" do
+
+      before(:each) do
+        dsc_smavariable.original_parameters[:dsc_ensure] = 'absent'
+        dsc_smavariable[:dsc_ensure] = 'absent'
+        @provider = described_class.provider(:powershell).new(dsc_smavariable)
+      end
+
+      it "should update :ensure to :absent" do
+        expect(dsc_smavariable[:ensure]).to eq(:absent)
+      end
+
+      it "should compute powershell dsc test script in which ensure value is 'present'" do
+        expect(@provider.ps_script_content('test')).to match(/ensure = 'present'/)
+      end
+
+      it "should compute powershell dsc set script in which ensure value is 'absent'" do
+        expect(@provider.ps_script_content('set')).to match(/ensure = 'absent'/)
+      end
+
+    end
+
+  end
+end

--- a/types.md
+++ b/types.md
@@ -19,6 +19,8 @@ dsc_script | [Script](https://github.com/puppetlabs/puppetlabs-dsc/tree/master/b
 dsc_service | [Service](https://github.com/puppetlabs/puppetlabs-dsc/tree/master/build/vendor/wmf_dsc_resources/PSDesiredStateConfiguration/DSCResources/MSFT_ServiceResource) | import/dsc_resources/PSDesiredStateConfiguration/DSCResources/MSFT_ServiceResource/MSFT_ServiceResource.schema.mof
 dsc_user | [User](https://github.com/puppetlabs/puppetlabs-dsc/tree/master/build/vendor/wmf_dsc_resources/PSDesiredStateConfiguration/DSCResources/MSFT_UserResource) | import/dsc_resources/PSDesiredStateConfiguration/DSCResources/MSFT_UserResource/MSFT_UserResource.schema.mof
 dsc_windowsoptionalfeature | [WindowsOptionalFeature](https://github.com/puppetlabs/puppetlabs-dsc/tree/master/build/vendor/wmf_dsc_resources/PSDesiredStateConfiguration/DSCResources/MSFT_WindowsOptionalFeature) | import/dsc_resources/PSDesiredStateConfiguration/DSCResources/MSFT_WindowsOptionalFeature/MSFT_WindowsOptionalFeature.schema.mof
+dsc_runbookdirectory | [RunbookDirectory](https://github.com/puppetlabs/puppetlabs-dsc/tree/master/build/vendor/wmf_dsc_resources/xSCSMA/DSCResources/MSFT_xRunbookDirectory) | import/dsc_resources/xSCSMA/DSCResources/MSFT_xRunbookDirectory/MSFT_xRunbookDirectory.schema.mof
+dsc_smavariable | [SmaVariable](https://github.com/puppetlabs/puppetlabs-dsc/tree/master/build/vendor/wmf_dsc_resources/xSCSMA/DSCResources/MSFT_xSmaVariable) | import/dsc_resources/xSCSMA/DSCResources/MSFT_xSmaVariable/MSFT_xSmaVariable.schema.mof
 
 #### Community x Prefixed types
 


### PR DESCRIPTION
Some DSC Resources use arbitrary values for `Present` or `Absent`. The
xRunbookDirectory DSC Resource in the xSCSMA module uses `Published`
and `Draft` as valid `Present` values for `Ensure`.

Modify the type building process to explicitly treat some resources as
exceptional cases by defining a custom hash for each MOF schema type.
This provides a way to identify non-standard resources easily, and a
process which will fail hard when new resources are introduced that
don't follow the model / aren't explicitly handled by the hash. It is
allowed to omit the :absent member of the hash for resource types
that are not absentable.

Move any inline special handling for enable / disable of the built-in
MOF type MSFT_WindowsOptionalFeature to this new hash, in addition to
MSFT_xRunbookDirectory.  This normalizes all exclusions under one
process.

Further remove any exception handling inside type / spec generation
templates, and move it out to the new helpers responsible for finding
and detecting the `Ensure` values -- raise exceptions in specific
cases that likely indicate a poorly defined / implemented MOF that
should be explicitly defined in the exclusion hash.

Types have been regenerated against the first commit after 90eba64,
which happens to be the first that includes the updated xSCSMA, which
will fail without these new type building changes:

https://github.com/PowerShell/DscResources/commit/e6974e102b8af1c4283d1d48fdce1395b949a0bd

As a result, this includes 2 new types:

dsc_runbookdirectory
dsc_smavariable


Supercedes #202 