### PR TITLE
(MODULES-3431) Fix revendor integration failure

### DIFF
--- a/tests/integration/tests/user_scenarios/create_mysql_database_server.rb
+++ b/tests/integration/tests/user_scenarios/create_mysql_database_server.rb
@@ -61,7 +61,6 @@ dsc_group {'add_#{user}_to_admin_group':
 ->
 dsc_xmysqlserver {'mysql':
   dsc_ensure        => 'Present',
-  dsc_servicename   => '#{mysql_instance}',
   dsc_rootpassword  => {'user' => '#{user}', 'password' => '#{user_password}'},
 }
 MANIFEST
@@ -82,7 +81,6 @@ end
 pp2 = <<-MANIFEST
 dsc_xmysqlserver {'mysql':
   dsc_ensure        => 'Present',
-  dsc_servicename   => '#{mysql_instance}',
   dsc_rootpassword  => {'user' => '#{user}', 'password' => '#{user_password}'},
 }
 ->


### PR DESCRIPTION
 - In commit 7fb9f22e1137ea92270150b0ef1ccef73307e83e resources were
   regenerated and revendored.

   Unfortunately the dsc_xmysqlserver type changed as a result, removing
   the dsc_servicename parameter.  This invalidates the test in this
   commit.