### PR TITLE
(maint) json_pure in 1.9.x

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -22,6 +22,9 @@ Gemfile:
       - gem: puppet-blacksmith
       - gem: mime-types
         version: '~>2.99'
+      - gem: json_pure
+        version: '<=2.0.1'
+        condition: 'RUBY_VERSION =~ /^1\./'
     ':system_tests':
       - gem: beaker
       - gem: master_manipulator

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development do
   gem 'pry',                                 :require => false
   gem 'puppet-blacksmith',                   :require => false
   gem 'mime-types', '~>2.99',                :require => false
+  gem 'json_pure', '<=2.0.1',                :require => false if RUBY_VERSION =~ /^1\./
 end
 
 group :system_tests do


### PR DESCRIPTION
json_pure just released 2.0.2 on July 26th, restricting to at least
Ruby v2. Unfortunately DSC building requires 1.9.3 and testing on
older versions of Puppet also requires 1.9.x to be able to install
Puppet, which depends on json_pure.

Restrict to json_pure 2.0.1 or less when running Ruby 1.x.