### PR TITLE
(MODULES-3640) Update modulesync 30fc4ab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,10 @@ end
 puppetversion = ENV['PUPPET_GEM_VERSION'] || ENV['GEM_PUPPET_VERSION'] || ENV['PUPPET_LOCATION'] || '>= 0'
 gem 'puppet', *location_for(puppetversion)
 
+# json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure 2.0.1
+# if using ruby 1.x
+gem 'json_pure', '<=2.0.1', :require => false if RUBY_VERSION =~ /^1\./
+
 # Only explicitly specify Facter/Hiera if a version has been specified.
 # Otherwise it can lead to strange bundler behavior. If you are seeing weird
 # gem resolution behavior, try setting `DEBUG_RESOLVER` environment variable


### PR DESCRIPTION
See MODULES-3640 for more context. tldr; json_pure as of 2.0.2 requires ruby 2 - because Puppet tests against many different versions of ruby, including 1.9.3, we need to ensure we can still get json_pure. The original json_pure dependency is expressed by puppetlabs/puppet (unversioned).