### PR TITLE
(MODULES-3627) Allow PowerShell dependency up to v3

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,10 +1,7 @@
 fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
-    powershell:
-      repo: "puppetlabs/powershell"
-      # pin to version 1.0.6 to match metadata version string reqs
-      ref: "1.0.6"
+    powershell: "puppetlabs/powershell"
     reboot: "puppetlabs/reboot"
   symlinks:
     "dsc": "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "puppetlabs/powershell",
-      "version_requirement": ">= 1.0.1 < 2.0.0"
+      "version_requirement": ">= 1.0.1 < 3.0.0"
     },
     {
       "name": "puppetlabs/reboot",


### PR DESCRIPTION
The currently released version of PowerShell at v2 is now
considered compatible with DSC, so allow installing a newer
version of PowerShell when using the DSC module.