### PR TITLE
(MODULES-3674) Update DSC Resource build documentation

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -62,9 +62,8 @@ MAINTAINERS.md:
     - "Puppet Windows Team `windows |at| puppet |dot| com`"
 NOTICE:
   copyright_holders:
+    - name: 'Puppet, Inc.'
+      begin: 2015
     - name: 'Marc Sutter, original author'
       begin: 2014
       end: 2015
-    - name: 'Puppet, Inc.'
-      begin: 2015
-      end: 'latest'

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 Puppet Module - puppetlabs-dsc
 
+Copyright 2015 Puppet, Inc.
 Copyright 2014 - 2015 Marc Sutter, original author
-Copyright 2015 - 2016 Puppet, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -444,8 +444,8 @@ We want to keep it as easy as possible to contribute changes so that our modules
 
 For more information, see our [module contribution guide.](https://docs.puppet.com/forge/contributing.html)
 
-* The Puppet types are built from the source code of each DSC Resources MOF schema files. If you want to build the types, read the [Quick-start and Building](README_BUILD.md#quick-start).
-* If you want the build Puppet types for your own custom DSC Resources, read [Build Custom DSC Resource Types](README_BUILD.md#build-custom-dsc-resource-types).
+* The Puppet types are built from the source code of each DSC Resources MOF schema files. If you want to build the types, read the [Quick-start and Building](https://github.com/puppetlabs/puppetlabs-dsc/blob/master/README_BUILD.md#quick-start).
+* If you want the build Puppet types for your own custom DSC Resources, read [Build Custom DSC Resource Types](https://github.com/puppetlabs/puppetlabs-dsc/blob/master/README_BUILD.md#build-custom-dsc-resource-types).
 
 ### Version Strategy
 
@@ -453,7 +453,7 @@ This module generally follows [Semantic Versioning](http://semver.org/) for choo
 
 * Minor, for example from version 2.0.0 to 2.1.0
 
-A minor change may also include [rebuilding the DSC resource types](README_BUILD.md). Puppet wants to keep pace with the released DSC Resources from the PowerShell team repository, but this engenders risk as Puppet adopts third party code. Normally this would mean making major version bumps, but since this is anticipated to be frequent that would be too much churn.
+A minor change may also include [rebuilding the DSC resource types](https://github.com/puppetlabs/puppetlabs-dsc/blob/master/README_BUILD.md). Puppet wants to keep pace with the released DSC Resources from the PowerShell team repository, but this engenders risk as Puppet adopts third party code. Normally this would mean making major version bumps, but since this is anticipated to be frequent that would be too much churn.
 
 ### Contributors
 

--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -27,18 +27,39 @@ rake dsc:types:build       # Build DSC types in (lib/puppet/type)
 rake dsc:types:clean       # Cleanup DSC types in (lib/puppet/type)
 ~~~
 
-The default task 'bundle exec rake' will run all of this tasks.
-
 ## Building
 
 When building the types and specs, keep the following considerations in mind:
 
-* Resources must be built with a non-Windows box due to limitations in the gems that the builder uses to generate types and specs.
-* You must use Ruby 1.9.3 to build the types (again due to a limitation in the builder dependencies).
-* The builder requires a MOF file and a PSD1 to build a type. Those need to be present for it to be successful.
-* The MOF file encoding should be UTF-8. This ensures the most compatibility with the mof gem.
-* If you do a DSC build from a fresh clone, it will build the latest DSC resources, which may or may not be what you want to do. To avoid this, you should set the environment variable `DSC_REF` to the SHA1 of https://github.com/PowerShell/DscResources commit that you want to build Puppet DSC resource types from.
-* When updating the Puppet DSC resource types and specs, please include the SHA1 commit that the types were built from in your git commit message. This makes it easier to track down exactly what version of `DscResources` we have built against.
+* Resources must be built with a non-Windows computer due to limitations in the gems that the builder uses to generate types and specs.
+* You must use Ruby 1.9.3 to build the types, again due to a limitation in the builder dependencies.
+* The builder requires a `MOF` and `PSD1` file to build a type. Both need to be present for the build to be successful.
+* The `MOF` file encoding should be UTF-8. This ensures the most compatibility with the mof gem.
+* Git client needs to be version 2.2.0 or above
+
+### The DSC tag file
+
+The DSC tag file, called `dsc_resource_release_tags.yml`, determines which versions of the DSC Resources to build.  If a DSC resource is not listed in the file, the latest version that has been released to the PowerShell gallery will be used during the build, and then added to the `dsc_resource_release_tags.yml` file. An example file is shown below:
+
+~~~ yaml
+---
+xActiveDirectory: 2.12.0.0-PSGallery
+xAdcsDeployment: 1.0.0.0-PSGallery
+xAzure: 0.2.0.0-PSGallery
+xAzurePack: 1.4.0.0-PSGallery
+xBitlocker: 1.1.0.0-PSGallery
+xCertificate: 2.1.0.0-PSGallery
+xComputerManagement: 1.7.0.0-PSGallery
+...
+...
+~~~
+
+* Note that while the tag file will typically contain PowerShell Gallery tags, any type of [git reference](https://git-scm.com/book/en/v2/Git-Internals-Git-References) can be used, such as a commit SHA.
+* The `DSC_REF` environment variable is still honored by the build process however it is no longer necessary as the DSC resource versions are explicitly set in the tag file.
+
+### How to rebuild all DSC resources with the latest version
+
+The simplest way to rebuild all DSC resources with the latest version is to delete the `dsc_resource_release_tags.yml` prior to building. Alternatively, you can pass `true` to the `update_versions` argument of the `dsc:resources:import` rake task.
 
 ## Build Custom DSC Resource Types
 You can build puppet types based on your own powershell source code.
@@ -61,7 +82,7 @@ the folder structure should be `MyModule/MyModule.psd1` and not `MyModule/Someth
 
 When importing or creating custom types, follow these steps:
 
-1. Build the module with `DSC_REF=e6974e1 bundle exec rake dsc:build`, where `e6974e1` is the SHA of the repository https://github.com/PowerShell/DscResources that the current Puppet types are based on.
+1. Build the module with `bundle exec rake dsc:build`
 2. Now take your own modules path and import your types: `bundle exec rake dsc:resources:import["path/to/your/types"]`. This should be the parent path that contains a folder (or folders) of DSC Resources.
    e.g. run `bundle exec rake dsc:resources:import["build/vendor/custom"]`.
    ![Module Layout - Import the Parent Directory](docs/images/dir_struct_import.png)

--- a/build/dsc.rake
+++ b/build/dsc.rake
@@ -73,18 +73,19 @@ eod
       end
 
       blacklist = ['xChrome', 'xDSCResourceDesigner', 'xDscDiagnostics',
-                   'xFireFox', 'xSafeHarbor', 'xSystemSecurity']
+                   'xFirefox', 'xSafeHarbor', 'xSystemSecurity'] # Case sensitive
       puts "Cleaning out black-listed DSC resources: #{blacklist}"
-      blacklist.each { |res| FileUtils.rm_rf("#{dsc_resources_path_tmp}/xDSCResources/#{res}") }
+      blacklist.each { |res| FileUtils.rm_rf("#{dsc_resources_path_tmp}/xDscResources/#{res}") }
 
       resource_tags = {}
       resource_tags = YAML::load_file("#{dsc_resources_file}") if File.exist? dsc_resources_file
 
       puts "Getting latest release tags for DSC resources..."
-      Dir["#{dsc_resources_path_tmp}/xDSCResources/*"].each do |dsc_resource_path|
+      Dir["#{dsc_resources_path_tmp}/xDscResources/*"].each do |dsc_resource_path|
         dsc_resource_name = Pathname.new(dsc_resource_path).basename
         FileUtils.cd(dsc_resource_path) do
           # --date-order probably doesn't matter
+          # Requires git version 2.2.0 or higher - https://github.com/git/git/commit/9271095cc5571e306d709ebf8eb7f0a388254d9d
           tags_raw = %x{ git log --tags --pretty=format:'%D' --simplify-by-decoration --date-order }
           # If the conversion of string to version starts to result in errors,
           # we should explore pushing this out out to a method where we can
@@ -133,7 +134,7 @@ eod
       FileUtils.rm_rf(Dir["#{dsc_resources_path_tmp}/**/.{gitattributes,gitignore,gitmodules}"])
       FileUtils.rm_rf(Dir["#{dsc_resources_path_tmp}/**/*.{pptx,docx,sln,cmd,xml,pssproj,pfx,html,txt,xlsm,csv,png,git,yml,md}"])
 
-      vendor_subdir = is_custom_resource ? '' : '/xDSCResources'
+      vendor_subdir = is_custom_resource ? '' : '/xDscResources' # Case sensitive
       puts "Copying vendored resources from #{dsc_resources_path_tmp}#{vendor_subdir} to #{vendor_dsc_resources_path}"
       FileUtils.cp_r "#{dsc_resources_path_tmp}#{vendor_subdir}/.", vendor_dsc_resources_path, :remove_destination => true
       FileUtils.cp_r "#{dsc_resources_path_tmp}#{vendor_subdir}/.", dsc_resources_path


### PR DESCRIPTION
In commit c81a958 the DSC Resource update
process was changed to use a `dsc_resource_release_tags.yml` file to track
the versions of each DSC Resource.  This PR updates the README_BUILD.md
file to document these changes and how to rebuild all resources with the latest
version.  This PR also changes the links in the `README.md` to the
`README_BUILD.md` file to be absolute, not relative references.  This allows
people to click on this link in the Puppet Forge website and link directly into
the Github repository instead of getting a `Page not found` from the Forge.

Previously a few directory names had incorrect casing which caused
DSC Resource builds to fail on Ubuntu based linux computers.  This
PR fixes the case of these directories to the correct name.