### PR TITLE
(maint) Add test artifacts to PMT Ignore

### DIFF
--- a/.pmtignore
+++ b/.pmtignore
@@ -8,8 +8,11 @@ import/
 build/
 docs/
 tests/
+log/
+junit/
+tmp/
 
-# Normally the spec directory is included in module distribution, however due to large number of 
+# Normally the spec directory is included in module distribution, however due to large number of
 # files generated, they are ignored when packaging the module.  The spec tests are not required
 # for the module to operate
 spec/


### PR DESCRIPTION
Previously some artifacts created from testing, for example Beaker, the DSC
module are accidentally added to the package during a `puppet module build`.
This commit adds log, junit and tmp to the Puppet Module Tool ignore file.