### PR TITLE
(maint) modulesync 70360747 and additions to PMT ignore

### DIFF
--- a/.pmtignore
+++ b/.pmtignore
@@ -8,8 +8,11 @@ import/
 build/
 docs/
 tests/
+log/
+junit/
+tmp/
 
-# Normally the spec directory is included in module distribution, however due to large number of 
+# Normally the spec directory is included in module distribution, however due to large number of
 # files generated, they are ignored when packaging the module.  The spec tests are not required
 # for the module to operate
 spec/

--- a/Gemfile
+++ b/Gemfile
@@ -110,14 +110,14 @@ if explicitly_require_windows_gems
     gem "win32-eventlog", "0.5.3","<= 0.6.5",    :require => false
     gem "win32-process", "0.6.5","<= 0.7.5",     :require => false
     gem "win32-security", "~> 0.1.2","<= 0.2.5", :require => false
-    gem "win32-service", "0.7.2","<= 0.8.7",     :require => false
+    gem "win32-service", "0.7.2","<= 0.8.8",     :require => false
     gem "minitar", "0.5.4",                      :require => false
   else
     gem "ffi", "~> 1.9.0",                       :require => false
     gem "win32-eventlog", "~> 0.5","<= 0.6.5",   :require => false
     gem "win32-process", "~> 0.6","<= 0.7.5",    :require => false
     gem "win32-security", "~> 0.1","<= 0.2.5",   :require => false
-    gem "win32-service", "~> 0.7","<= 0.8.7",    :require => false
+    gem "win32-service", "~> 0.7","<= 0.8.8",    :require => false
     gem "minitar", "~> 0.5.4",                   :require => false
   end
 
@@ -144,7 +144,7 @@ else
     gem "win32-eventlog", "<= 0.6.5",   :require => false
     gem "win32-process", "<= 0.7.5",    :require => false
     gem "win32-security", "<= 0.2.5",   :require => false
-    gem "win32-service", "<= 0.8.7",    :require => false
+    gem "win32-service", "<= 0.8.8",    :require => false
   end
 end
 


### PR DESCRIPTION
Previously some artifacts created from testing, for example Beaker, the DSC
module are accidentally added to the package during a `puppet module build`.
This commit adds log, junit and tmp to the Puppet Module Tool ignore file.

modsync update for SHA 70360747 