### PR TITLE
(MODULES-3764) Fix WaitForAll blacklist test

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/waitforall/negative/waitforall_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforall/negative/waitforall_blacklist.rb
@@ -18,7 +18,7 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resourc
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
 # Verify
-error_msg = /Error:.*Invalid resource type dsc_waitforall/
+error_msg = /Error:.*resource.*dsc_waitforall/
 
 # Tests
 agents.each do |agent|

--- a/tests/acceptance/tests/basic_dsc_resources/waitforany/negative/waitforany_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforany/negative/waitforany_blacklist.rb
@@ -18,7 +18,7 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resourc
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
 # Verify
-error_msg = /Error:.*Invalid resource type dsc_waitforany/
+error_msg = /Error:.*resource.*dsc_waitforany/
 
 # Tests
 agents.each do |agent|

--- a/tests/acceptance/tests/basic_dsc_resources/waitforsome/negative/waitforsome_blacklist.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/waitforsome/negative/waitforsome_blacklist.rb
@@ -18,7 +18,7 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resourc
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
 # Verify
-error_msg = /Error:.*Invalid resource type dsc_waitforsome/
+error_msg = /Error:.*resource.*dsc_waitforsome/
 
 # Tests
 agents.each do |agent|

--- a/tests/integration/tests/user_scenarios/negative/blacklist_xchrome.rb
+++ b/tests/integration/tests/user_scenarios/negative/blacklist_xchrome.rb
@@ -17,7 +17,7 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resourc
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
 # Verify
-error_msg = /Invalid resource type dsc_msft_xchrome/
+error_msg = /Error:.*resource.*dsc_msft_xchrome/
 
 # Setup
 step 'Inject "site.pp" on Master'

--- a/tests/integration/tests/user_scenarios/negative/blacklist_xfirefox.rb
+++ b/tests/integration/tests/user_scenarios/negative/blacklist_xfirefox.rb
@@ -17,7 +17,7 @@ dsc_manifest_template_path = File.join(local_files_root_path, 'basic_dsc_resourc
 dsc_manifest = ERB.new(File.read(dsc_manifest_template_path), 0, '>').result(binding)
 
 # Verify
-error_msg = /Invalid resource type dsc_msft_xfirefox/
+error_msg = /Error:.*resource.*dsc_msft_xfirefox/
 
 # Setup
 step 'Inject "site.pp" on Master'


### PR DESCRIPTION
With https://github.com/puppetlabs/puppet/commit/01db61e24 in Puppet 4.6.x+ we
see that with https://github.com/puppetlabs/puppet/blob/5fcc9b3f803b62e84287e1976a5f1a2eb6311f27/lib/puppet/pops/evaluator/runtime3_resource_support.rb#L31
the message has changed and we need to adjust the matcher to account for both
the old and new way of this message occurring.

As an example, the message for `dsc_waitforsome` when not found as
a valid type was changed from `Invalid resource type dsc_waitforsome`
to `Unknown resource type: 'dsc_waitforsome'`, causing the matching
to fail.