### PR TITLE
(FM-5671) PsDscRunAsCredential Support

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -95,6 +95,22 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
     defaultto { :<%= resource.default_ensure_value %> }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
 <%  resource.properties.each do |property| -%>
   # Name:         <%= property.name %>
   # Type:         <%= property.type %>

--- a/build/vendor/wmf_dsc_resources/PSDesiredStateConfiguration/DSCResources/MSFT_FileDirectoryConfiguration/MSFT_FileDirectoryConfiguration.schema.mof
+++ b/build/vendor/wmf_dsc_resources/PSDesiredStateConfiguration/DSCResources/MSFT_FileDirectoryConfiguration/MSFT_FileDirectoryConfiguration.schema.mof
@@ -13,6 +13,5 @@ class MSFT_FileDirectoryConfiguration : OMI_BaseResource
   [Write, ValueMap{"ReadOnly","Hidden","System","Archive"}, Values{"ReadOnly","Hidden","System","Archive"}] String Attributes[];
   [Write] String DependsOn[];
   [Write] boolean MatchSource;
-  [Write, EmbeddedInstance("MSFT_Credential")] String PsDscRunAsCredential;
 };
 

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_archive) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_environment) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_file) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DestinationPath
   # Type:         string
   # IsMandatory:  True
@@ -246,22 +262,6 @@ Puppet::Type.newtype(:dsc_file) do
     newvalues(true, false)
     munge do |value|
       PuppetX::Dsc::TypeHelpers.munge_boolean(value.to_s)
-    end
-  end
-
-  # Name:         PsDscRunAsCredential
-  # Type:         MSFT_Credential
-  # IsMandatory:  False
-  # Values:       None
-  newparam(:dsc_psdscrunascredential) do
-    def mof_type; 'MSFT_Credential' end
-    def mof_is_embedded?; true end
-    desc "PsDscRunAsCredential"
-    validate do |value|
-      unless value.kind_of?(Hash)
-        fail("Invalid value '#{value}'. Should be a hash")
-      end
-      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("PsDscRunAsCredential", value)
     end
   end
 

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_group) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -36,6 +36,22 @@ Puppet::Type.newtype(:dsc_log) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Message
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_package) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_registry) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Key
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_runbookdirectory.rb
+++ b/lib/puppet/type/dsc_runbookdirectory.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_runbookdirectory) do
     defaultto { :published }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_script) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GetScript
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_service) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_smavariable.rb
+++ b/lib/puppet/type/dsc_smavariable.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_smavariable) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_spaccessserviceapp.rb
+++ b/lib/puppet/type/dsc_spaccessserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spaccessserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spalternateurl.rb
+++ b/lib/puppet/type/dsc_spalternateurl.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_spalternateurl) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spantivirussettings.rb
+++ b/lib/puppet/type/dsc_spantivirussettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spantivirussettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ScanOnDownload
   # Type:         boolean
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spappcatalog.rb
+++ b/lib/puppet/type/dsc_spappcatalog.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spappcatalog) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         SiteUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spappdomain.rb
+++ b/lib/puppet/type/dsc_spappdomain.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spappdomain) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         AppDomain
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spappmanagementserviceapp.rb
+++ b/lib/puppet/type/dsc_spappmanagementserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spappmanagementserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spbcsserviceapp.rb
+++ b/lib/puppet/type/dsc_spbcsserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spbcsserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spblobcachesettings.rb
+++ b/lib/puppet/type/dsc_spblobcachesettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spblobcachesettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spcacheaccounts.rb
+++ b/lib/puppet/type/dsc_spcacheaccounts.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spcacheaccounts) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spcontentdatabase.rb
+++ b/lib/puppet/type/dsc_spcontentdatabase.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spcontentdatabase) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spcreatefarm.rb
+++ b/lib/puppet/type/dsc_spcreatefarm.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spcreatefarm) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         FarmConfigDatabaseName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spdatabaseaag.rb
+++ b/lib/puppet/type/dsc_spdatabaseaag.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spdatabaseaag) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DatabaseName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spdesignersettings.rb
+++ b/lib/puppet/type/dsc_spdesignersettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spdesignersettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spdiagnosticloggingsettings.rb
+++ b/lib/puppet/type/dsc_spdiagnosticloggingsettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spdiagnosticloggingsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         LogPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spdistributedcacheservice.rb
+++ b/lib/puppet/type/dsc_spdistributedcacheservice.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spdistributedcacheservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spexcelserviceapp.rb
+++ b/lib/puppet/type/dsc_spexcelserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spexcelserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spfarmadministrators.rb
+++ b/lib/puppet/type/dsc_spfarmadministrators.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spfarmadministrators) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spfarmsolution.rb
+++ b/lib/puppet/type/dsc_spfarmsolution.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spfarmsolution) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spfeature.rb
+++ b/lib/puppet/type/dsc_spfeature.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_spfeature) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_sphealthanalyzerrulestate.rb
+++ b/lib/puppet/type/dsc_sphealthanalyzerrulestate.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_sphealthanalyzerrulestate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spinstall.rb
+++ b/lib/puppet/type/dsc_spinstall.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spinstall) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         BinaryDir
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spinstallprereqs.rb
+++ b/lib/puppet/type/dsc_spinstallprereqs.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spinstallprereqs) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InstallerPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spirmsettings.rb
+++ b/lib/puppet/type/dsc_spirmsettings.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spirmsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spjoinfarm.rb
+++ b/lib/puppet/type/dsc_spjoinfarm.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spjoinfarm) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         FarmConfigDatabaseName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spmanagedaccount.rb
+++ b/lib/puppet/type/dsc_spmanagedaccount.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spmanagedaccount) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         AccountName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spmanagedmetadataserviceapp.rb
+++ b/lib/puppet/type/dsc_spmanagedmetadataserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spmanagedmetadataserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spmanagedpath.rb
+++ b/lib/puppet/type/dsc_spmanagedpath.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_spmanagedpath) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spofficeonlineserverbinding.rb
+++ b/lib/puppet/type/dsc_spofficeonlineserverbinding.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spofficeonlineserverbinding) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Zone
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spoutgoingemailsettings.rb
+++ b/lib/puppet/type/dsc_spoutgoingemailsettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spoutgoingemailsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_sppasswordchangesettings.rb
+++ b/lib/puppet/type/dsc_sppasswordchangesettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_sppasswordchangesettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         MailAddress
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spperformancepointserviceapp.rb
+++ b/lib/puppet/type/dsc_spperformancepointserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spperformancepointserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spquotatemplate.rb
+++ b/lib/puppet/type/dsc_spquotatemplate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spquotatemplate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsearchcontentsource.rb
+++ b/lib/puppet/type/dsc_spsearchcontentsource.rb
@@ -63,6 +63,22 @@ Puppet::Type.newtype(:dsc_spsearchcontentsource) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsearchcrawlrule.rb
+++ b/lib/puppet/type/dsc_spsearchcrawlrule.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spsearchcrawlrule) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsearchindexpartition.rb
+++ b/lib/puppet/type/dsc_spsearchindexpartition.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spsearchindexpartition) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Index
   # Type:         uint32
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsearchserviceapp.rb
+++ b/lib/puppet/type/dsc_spsearchserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spsearchserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsearchtopology.rb
+++ b/lib/puppet/type/dsc_spsearchtopology.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spsearchtopology) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ServiceAppName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsecurestoreserviceapp.rb
+++ b/lib/puppet/type/dsc_spsecurestoreserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spsecurestoreserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spserviceapppool.rb
+++ b/lib/puppet/type/dsc_spserviceapppool.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spserviceapppool) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spserviceappproxygroup.rb
+++ b/lib/puppet/type/dsc_spserviceappproxygroup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spserviceappproxygroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spserviceappsecurity.rb
+++ b/lib/puppet/type/dsc_spserviceappsecurity.rb
@@ -62,6 +62,22 @@ Puppet::Type.newtype(:dsc_spserviceappsecurity) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ServiceAppName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spserviceinstance.rb
+++ b/lib/puppet/type/dsc_spserviceinstance.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spserviceinstance) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsessionstateservice.rb
+++ b/lib/puppet/type/dsc_spsessionstateservice.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_spsessionstateservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DatabaseName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spshelladmins.rb
+++ b/lib/puppet/type/dsc_spshelladmins.rb
@@ -61,6 +61,22 @@ Puppet::Type.newtype(:dsc_spshelladmins) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsite.rb
+++ b/lib/puppet/type/dsc_spsite.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spsite) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spstateserviceapp.rb
+++ b/lib/puppet/type/dsc_spstateserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spstateserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spsubscriptionsettingsserviceapp.rb
+++ b/lib/puppet/type/dsc_spsubscriptionsettingsserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spsubscriptionsettingsserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_sptimerjobstate.rb
+++ b/lib/puppet/type/dsc_sptimerjobstate.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_sptimerjobstate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spusageapplication.rb
+++ b/lib/puppet/type/dsc_spusageapplication.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spusageapplication) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spuserprofileproperty.rb
+++ b/lib/puppet/type/dsc_spuserprofileproperty.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spuserprofileproperty) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spuserprofilesection.rb
+++ b/lib/puppet/type/dsc_spuserprofilesection.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spuserprofilesection) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spuserprofileserviceapp.rb
+++ b/lib/puppet/type/dsc_spuserprofileserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spuserprofileserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spuserprofileserviceapppermissions.rb
+++ b/lib/puppet/type/dsc_spuserprofileserviceapppermissions.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spuserprofileserviceapppermissions) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ProxyName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spuserprofilesyncconnection.rb
+++ b/lib/puppet/type/dsc_spuserprofilesyncconnection.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncconnection) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spuserprofilesyncservice.rb
+++ b/lib/puppet/type/dsc_spuserprofilesyncservice.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         UserProfileServiceAppName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spvisioserviceapp.rb
+++ b/lib/puppet/type/dsc_spvisioserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spvisioserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spweb.rb
+++ b/lib/puppet/type/dsc_spweb.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spweb) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebappblockedfiletypes.rb
+++ b/lib/puppet/type/dsc_spwebappblockedfiletypes.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spwebappblockedfiletypes) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebappgeneralsettings.rb
+++ b/lib/puppet/type/dsc_spwebappgeneralsettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spwebappgeneralsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebapplication.rb
+++ b/lib/puppet/type/dsc_spwebapplication.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spwebapplication) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebapplicationappdomain.rb
+++ b/lib/puppet/type/dsc_spwebapplicationappdomain.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spwebapplicationappdomain) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebApplication
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebapppermissions.rb
+++ b/lib/puppet/type/dsc_spwebapppermissions.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spwebapppermissions) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebapppolicy.rb
+++ b/lib/puppet/type/dsc_spwebapppolicy.rb
@@ -61,6 +61,22 @@ Puppet::Type.newtype(:dsc_spwebapppolicy) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebappproxygroup.rb
+++ b/lib/puppet/type/dsc_spwebappproxygroup.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spwebappproxygroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebAppUrl
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebappsiteuseanddeletion.rb
+++ b/lib/puppet/type/dsc_spwebappsiteuseanddeletion.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spwebappsiteuseanddeletion) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebappthrottlingsettings.rb
+++ b/lib/puppet/type/dsc_spwebappthrottlingsettings.rb
@@ -61,6 +61,22 @@ Puppet::Type.newtype(:dsc_spwebappthrottlingsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwebappworkflowsettings.rb
+++ b/lib/puppet/type/dsc_spwebappworkflowsettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_spwebappworkflowsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Url
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spwordautomationserviceapp.rb
+++ b/lib/puppet/type/dsc_spwordautomationserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spwordautomationserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_spworkmanagementserviceapp.rb
+++ b/lib/puppet/type/dsc_spworkmanagementserviceapp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_spworkmanagementserviceapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_user) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         UserName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_windowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_windowsoptionalfeature.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
     defaultto { :enable }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xadcomputer.rb
+++ b/lib/puppet/type/dsc_xadcomputer.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xadcomputer) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ComputerName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xadcscertificationauthority.rb
+++ b/lib/puppet/type/dsc_xadcscertificationauthority.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         CAType
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xadcsonlineresponder.rb
+++ b/lib/puppet/type/dsc_xadcsonlineresponder.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xadcsonlineresponder) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         IsSingleInstance
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xadcswebenrollment.rb
+++ b/lib/puppet/type/dsc_xadcswebenrollment.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xadcswebenrollment) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         CAConfig
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xaddomain) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaddomaindefaultpasswordpolicy.rb
+++ b/lib/puppet/type/dsc_xaddomaindefaultpasswordpolicy.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xaddomaindefaultpasswordpolicy) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xadgroup.rb
+++ b/lib/puppet/type/dsc_xadgroup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xadgroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xadorganizationalunit.rb
+++ b/lib/puppet/type/dsc_xadorganizationalunit.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xadorganizationalunit) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xadrecyclebin.rb
+++ b/lib/puppet/type/dsc_xadrecyclebin.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xadrecyclebin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ForestFQDN
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xaduser) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xarchive) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Destination
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackadmin.rb
+++ b/lib/puppet/type/dsc_xazurepackadmin.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xazurepackadmin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
+++ b/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Namespace
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackfqdn.rb
+++ b/lib/puppet/type/dsc_xazurepackfqdn.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Namespace
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackidentityprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackidentityprovider.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Target
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackrelyingparty.rb
+++ b/lib/puppet/type/dsc_xazurepackrelyingparty.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Target
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackresourceprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackresourceprovider.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         AuthenticationSite
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xazurepacksetup.rb
+++ b/lib/puppet/type/dsc_xazurepacksetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Role
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurepackupdate.rb
+++ b/lib/puppet/type/dsc_xazurepackupdate.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xazurepackupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Role
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazureservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ServiceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         RuleName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazurestorageaccount) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         StorageAccountName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazuresubscription) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazurevm) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         StorageAccountName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xazurevmdscextension.rb
+++ b/lib/puppet/type/dsc_xazurevmdscextension.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xazurevmdscextension) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         VMName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xblautobitlocker.rb
+++ b/lib/puppet/type/dsc_xblautobitlocker.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DriveType
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xblbitlocker.rb
+++ b/lib/puppet/type/dsc_xblbitlocker.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         MountPoint
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xbltpm.rb
+++ b/lib/puppet/type/dsc_xbltpm.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xbltpm) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcertificateimport.rb
+++ b/lib/puppet/type/dsc_xcertificateimport.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_xcertificateimport) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Thumbprint
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcertreq.rb
+++ b/lib/puppet/type/dsc_xcertreq.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xcertreq) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Subject
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xcluster) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xclusterdisk.rb
+++ b/lib/puppet/type/dsc_xclusterdisk.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xclusterdisk) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Number
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xclusternetwork.rb
+++ b/lib/puppet/type/dsc_xclusternetwork.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xclusternetwork) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Address
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xclusterpreferredowner.rb
+++ b/lib/puppet/type/dsc_xclusterpreferredowner.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xclusterpreferredowner) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ClusterGroup
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xcomputer) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xcredssp.rb
+++ b/lib/puppet/type/dsc_xcredssp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xcredssp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdatabase) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Credentials
   # Type:         MSFT_Credential
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdatabaselogin.rb
+++ b/lib/puppet/type/dsc_xdatabaselogin.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdatabaselogin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdatabaseserver.rb
+++ b/lib/puppet/type/dsc_xdatabaseserver.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xdatabaseserver) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         LoginMode
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Credentials
   # Type:         MSFT_Credential
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
+++ b/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdefaultgatewayaddress) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Address
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdfsnamespacefolder.rb
+++ b/lib/puppet/type/dsc_xdfsnamespacefolder.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xdfsnamespacefolder) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdfsnamespaceroot.rb
+++ b/lib/puppet/type/dsc_xdfsnamespaceroot.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xdfsnamespaceroot) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdfsnamespaceserverconfiguration.rb
+++ b/lib/puppet/type/dsc_xdfsnamespaceserverconfiguration.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xdfsnamespaceserverconfiguration) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         IsSingleInstance
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdfsreplicationgroup.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdfsreplicationgroupconnection.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupconnection.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupconnection) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdfsreplicationgroupfolder.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupfolder.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupfolder) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdfsreplicationgroupmembership.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupmembership.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupmembership) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdhcpclient.rb
+++ b/lib/puppet/type/dsc_xdhcpclient.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdhcpclient) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         State
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdhcpserverauthorization.rb
+++ b/lib/puppet/type/dsc_xdhcpserverauthorization.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdhcpserverauthorization) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DnsName
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ScopeID
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ScopeID
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xdhcpserverscope) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         IPStartRange
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdisk.rb
+++ b/lib/puppet/type/dsc_xdisk.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xdisk) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DriveLetter
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdismfeature.rb
+++ b/lib/puppet/type/dsc_xdismfeature.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdismfeature) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdnsarecord.rb
+++ b/lib/puppet/type/dsc_xdnsarecord.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xdnsarecord) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsconnectionsuffix.rb
+++ b/lib/puppet/type/dsc_xdnsconnectionsuffix.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdnsconnectionsuffix) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InterfaceAlias
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsrecord.rb
+++ b/lib/puppet/type/dsc_xdnsrecord.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_xdnsrecord) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Address
   # Type:         string[]
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xdnsserveradzone.rb
+++ b/lib/puppet/type/dsc_xdnsserveradzone.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdnsserveradzone) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsserverforwarder.rb
+++ b/lib/puppet/type/dsc_xdnsserverforwarder.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xdnsserverforwarder) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         IsSingleInstance
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsserverprimaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserverprimaryzone.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdnsserverprimaryzone) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         EndpointName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xenvironment.rb
+++ b/lib/puppet/type/dsc_xenvironment.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xenvironment) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchantimalwarescanning.rb
+++ b/lib/puppet/type/dsc_xexchantimalwarescanning.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Enabled
   # Type:         boolean
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchautomountpoint.rb
+++ b/lib/puppet/type/dsc_xexchautomountpoint.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchclientaccessserver.rb
+++ b/lib/puppet/type/dsc_xexchclientaccessserver.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         MailboxServer
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexcheventloglevel.rb
+++ b/lib/puppet/type/dsc_xexcheventloglevel.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexcheventloglevel) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchexchangecertificate.rb
+++ b/lib/puppet/type/dsc_xexchexchangecertificate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Thumbprint
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchexchangeserver.rb
+++ b/lib/puppet/type/dsc_xexchexchangeserver.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchimapsettings.rb
+++ b/lib/puppet/type/dsc_xexchimapsettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchimapsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Server
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchinstall.rb
+++ b/lib/puppet/type/dsc_xexchinstall.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xexchinstall) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchjetstress.rb
+++ b/lib/puppet/type/dsc_xexchjetstress.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchjetstress) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Type
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchjetstresscleanup.rb
+++ b/lib/puppet/type/dsc_xexchjetstresscleanup.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         JetstressPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchmailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabase.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchmailboxserver.rb
+++ b/lib/puppet/type/dsc_xexchmailboxserver.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchmailboxserver) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchmaintenancemode.rb
+++ b/lib/puppet/type/dsc_xexchmaintenancemode.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchmaintenancemode) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Enabled
   # Type:         boolean
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchoutlookanywhere.rb
+++ b/lib/puppet/type/dsc_xexchoutlookanywhere.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchpopsettings.rb
+++ b/lib/puppet/type/dsc_xexchpopsettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchpopsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Server
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchreceiveconnector.rb
+++ b/lib/puppet/type/dsc_xexchreceiveconnector.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchtransportservice.rb
+++ b/lib/puppet/type/dsc_xexchtransportservice.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchtransportservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchumcallroutersettings.rb
+++ b/lib/puppet/type/dsc_xexchumcallroutersettings.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchumcallroutersettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Server
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchumservice.rb
+++ b/lib/puppet/type/dsc_xexchumservice.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchumservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchwaitforadprep.rb
+++ b/lib/puppet/type/dsc_xexchwaitforadprep.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchwaitfordag.rb
+++ b/lib/puppet/type/dsc_xexchwaitfordag.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Identity
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xfirewall) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xgroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GroupName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xhostsfile.rb
+++ b/lib/puppet/type/dsc_xhostsfile.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xhostsfile) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         hostName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xhotfix.rb
+++ b/lib/puppet/type/dsc_xhotfix.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xhotfix) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiisfeaturedelegation.rb
+++ b/lib/puppet/type/dsc_xiisfeaturedelegation.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xiisfeaturedelegation) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         SectionName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiishandler.rb
+++ b/lib/puppet/type/dsc_xiishandler.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xiishandler) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiislogging.rb
+++ b/lib/puppet/type/dsc_xiislogging.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xiislogging) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         LogPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiismimetypemapping.rb
+++ b/lib/puppet/type/dsc_xiismimetypemapping.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xiismimetypemapping) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Extension
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xiismodule) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
+++ b/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xinternetexplorerhomepage) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         StartPage
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xipaddress) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         IPAddress
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmicrosoftupdate.rb
+++ b/lib/puppet/type/dsc_xmicrosoftupdate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xmicrosoftupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmountimage.rb
+++ b/lib/puppet/type/dsc_xmountimage.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xmountimage) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmppreference.rb
+++ b/lib/puppet/type/dsc_xmppreference.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xmppreference) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DatabaseName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         UserName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         MySqlVersion
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         UserName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xnetadapterbinding.rb
+++ b/lib/puppet/type/dsc_xnetadapterbinding.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xnetadapterbinding) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InterfaceAlias
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xnetbios.rb
+++ b/lib/puppet/type/dsc_xnetbios.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xnetbios) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InterfaceAlias
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xnetconnectionprofile.rb
+++ b/lib/puppet/type/dsc_xnetconnectionprofile.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xnetconnectionprofile) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InterfaceAlias
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xnetworkteam.rb
+++ b/lib/puppet/type/dsc_xnetworkteam.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xnetworkteam) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xofflinedomainjoin.rb
+++ b/lib/puppet/type/dsc_xofflinedomainjoin.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xofflinedomainjoin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         IsSingleInstance
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xpackage) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xpendingreboot.rb
+++ b/lib/puppet/type/dsc_xpendingreboot.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xpfximport.rb
+++ b/lib/puppet/type/dsc_xpfximport.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_xpfximport) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Thumbprint
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
+++ b/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xpowershellexecutionpolicy) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ExecutionPolicy
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdremoteapp.rb
+++ b/lib/puppet/type/dsc_xrdremoteapp.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_xrdremoteapp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Alias
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xrdsessioncollection) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         CollectionName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         CollectionName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         SessionHost
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xregistry.rb
+++ b/lib/puppet/type/dsc_xregistry.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xregistry) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Key
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xremotefile) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DestinationPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xrobocopy.rb
+++ b/lib/puppet/type/dsc_xrobocopy.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Source
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xroute.rb
+++ b/lib/puppet/type/dsc_xroute.rb
@@ -42,6 +42,22 @@ Puppet::Type.newtype(:dsc_xroute) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InterfaceAlias
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscdpmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscdpmconsolesetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscdpmconsolesetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscdpmdatabaseserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscdpmserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscheduledtask.rb
+++ b/lib/puppet/type/dsc_xscheduledtask.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscheduledtask) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         TaskName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomadmin.rb
+++ b/lib/puppet/type/dsc_xscomadmin.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xscomadmin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscomconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscomconsolesetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscomconsoleupdate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscomconsoleupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscommanagementpack.rb
+++ b/lib/puppet/type/dsc_xscommanagementpack.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xscommanagementpack) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscommanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscommanagementserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscommanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscommanagementserverupdate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscommanagementserverupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomreportingserversetup.rb
+++ b/lib/puppet/type/dsc_xscomreportingserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserverupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscript.rb
+++ b/lib/puppet/type/dsc_xscript.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xscript) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         GetScript
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscsmapowershellsetup.rb
+++ b/lib/puppet/type/dsc_xscsmapowershellsetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscsmapowershellsetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscspfserver.rb
+++ b/lib/puppet/type/dsc_xscspfserver.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscspfserver) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscspfserversetup.rb
+++ b/lib/puppet/type/dsc_xscspfserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscspfserverupdate.rb
+++ b/lib/puppet/type/dsc_xscspfserverupdate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscspfserverupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscspfsetting.rb
+++ b/lib/puppet/type/dsc_xscspfsetting.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xscspfsetting) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscspfstamp.rb
+++ b/lib/puppet/type/dsc_xscspfstamp.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscspfstamp) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscsrserversetup.rb
+++ b/lib/puppet/type/dsc_xscsrserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscsrserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscsrserverupdate.rb
+++ b/lib/puppet/type/dsc_xscsrserverupdate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscsrserverupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscvmmadmin.rb
+++ b/lib/puppet/type/dsc_xscvmmadmin.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xscvmmadmin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xscvmmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscvmmconsolesetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscvmmconsoleupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserverupdate) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlalias.rb
+++ b/lib/puppet/type/dsc_xsqlalias.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlalias) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlaogroupensure.rb
+++ b/lib/puppet/type/dsc_xsqlaogroupensure.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xsqlaogroupensure) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlaogroupjoin.rb
+++ b/lib/puppet/type/dsc_xsqlaogroupjoin.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xsqlaogroupjoin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqldatabaserecoverymodel.rb
+++ b/lib/puppet/type/dsc_xsqldatabaserecoverymodel.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqldatabaserecoverymodel) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DatabaseName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserveralwaysonservice.rb
+++ b/lib/puppet/type/dsc_xsqlserveralwaysonservice.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserveralwaysonservice) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverconfiguration.rb
+++ b/lib/puppet/type/dsc_xsqlserverconfiguration.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserverconfiguration) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverdatabase.rb
+++ b/lib/puppet/type/dsc_xsqlserverdatabase.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserverdatabase) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Database
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverdatabaseowner.rb
+++ b/lib/puppet/type/dsc_xsqlserverdatabaseowner.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqlserverdatabaseowner) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Database
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverdatabasepermissions.rb
+++ b/lib/puppet/type/dsc_xsqlserverdatabasepermissions.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqlserverdatabasepermissions) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Database
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverdatabaserole.rb
+++ b/lib/puppet/type/dsc_xsqlserverdatabaserole.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserverdatabaserole) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xsqlserverendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlserverendpoint.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserverendpoint) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         EndPointName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverfailoverclustersetup.rb
+++ b/lib/puppet/type/dsc_xsqlserverfailoverclustersetup.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserverfailoverclustersetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Action
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverfirewall.rb
+++ b/lib/puppet/type/dsc_xsqlserverfirewall.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xsqlserverfirewall) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverlogin.rb
+++ b/lib/puppet/type/dsc_xsqlserverlogin.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserverlogin) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xsqlservermaxdop.rb
+++ b/lib/puppet/type/dsc_xsqlservermaxdop.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlservermaxdop) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xsqlservermemory.rb
+++ b/lib/puppet/type/dsc_xsqlservermemory.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlservermemory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xsqlservernetwork.rb
+++ b/lib/puppet/type/dsc_xsqlservernetwork.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqlservernetwork) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverpowerplan.rb
+++ b/lib/puppet/type/dsc_xsqlserverpowerplan.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserverpowerplan) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverrsconfig.rb
+++ b/lib/puppet/type/dsc_xsqlserverrsconfig.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqlserverrsconfig) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
+++ b/lib/puppet/type/dsc_xsqlserverrssecureconnectionlevel.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsqlserverrssecureconnectionlevel) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         InstanceName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsqlserversetup.rb
+++ b/lib/puppet/type/dsc_xsqlserversetup.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xsqlserversetup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         SourcePath
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xsslsettings.rb
+++ b/lib/puppet/type/dsc_xsslsettings.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsslsettings) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsystemrestore.rb
+++ b/lib/puppet/type/dsc_xsystemrestore.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsystemrestore) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xsystemrestorepoint.rb
+++ b/lib/puppet/type/dsc_xsystemrestorepoint.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xsystemrestorepoint) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Description
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xtimezone.rb
+++ b/lib/puppet/type/dsc_xtimezone.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xtimezone) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         IsSingleInstance
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xuser.rb
+++ b/lib/puppet/type/dsc_xuser.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xuser) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         UserName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xvhd) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -61,6 +61,22 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         VhdPath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DomainName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xwaitforavailabilitygroup.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwaitforavailabilitygroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitfordisk.rb
+++ b/lib/puppet/type/dsc_xwaitfordisk.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwaitfordisk) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         DiskNumber
   # Type:         uint32
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -63,6 +63,22 @@ Puppet::Type.newtype(:dsc_xwebapplication) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Website
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebapppooldefaults.rb
+++ b/lib/puppet/type/dsc_xwebapppooldefaults.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwebapppooldefaults) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ApplyTo
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         WebsitePath
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebpackagedeploy.rb
+++ b/lib/puppet/type/dsc_xwebpackagedeploy.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xwebpackagedeploy) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         SourcePath
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -85,6 +85,22 @@ Puppet::Type.newtype(:dsc_xwebsite) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xwebsitedefaults.rb
+++ b/lib/puppet/type/dsc_xwebsitedefaults.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwebsitedefaults) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         ApplyTo
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -41,6 +41,22 @@ Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Website
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwefcollector.rb
+++ b/lib/puppet/type/dsc_xwefcollector.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xwefcollector) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Ensure
   # Type:         string
   # IsMandatory:  False

--- a/lib/puppet/type/dsc_xwefsubscription.rb
+++ b/lib/puppet/type/dsc_xwefsubscription.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         SubscriptionID
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwindowsfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsfeature.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xwindowsfeature) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Name
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -40,6 +40,22 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Path
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwindowsupdateagent.rb
+++ b/lib/puppet/type/dsc_xwindowsupdateagent.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwindowsupdateagent) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         IsSingleInstance
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -38,6 +38,22 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         LogName
   # Type:         string
   # IsMandatory:  True

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -39,6 +39,22 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
     defaultto { :present }
   end
 
+  # Name:         PsDscRunAsCredential
+  # Type:         MSFT_Credential
+  # IsMandatory:  False
+  # Values:       None
+  newparam(:dsc_psdscrunascredential) do
+    def mof_type; 'MSFT_Credential' end
+    def mof_is_embedded?; true end
+    desc "PsDscRunAsCredential"
+    validate do |value|
+      unless value.kind_of?(Hash)
+        fail("Invalid value '#{value}'. Should be a hash")
+      end
+      PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+  end
+
   # Name:         Uri
   # Type:         string
   # IsMandatory:  True

--- a/spec/unit/puppet/type/dsc_file_spec.rb
+++ b/spec/unit/puppet/type/dsc_file_spec.rb
@@ -25,7 +25,6 @@ describe Puppet::Type.type(:dsc_file) do
       :dsc_attributes => 'ReadOnly',
       :dsc_dependson => ["foo", "bar", "spec"],
       :dsc_matchsource => true,
-      :dsc_psdscrunascredential => {"user"=>"user", "password"=>"password"},
     )}.to_not raise_error
   end
 
@@ -489,26 +488,6 @@ describe Puppet::Type.type(:dsc_file) do
 
   it 'should not accept uint for dsc_matchsource' do
     expect{dsc_file[:dsc_matchsource] = 16}.to raise_error(Puppet::ResourceError)
-  end
-
-  it "should not accept empty password for dsc_psdscrunascredential" do
-    expect{dsc_file[:dsc_psdscrunascredential] = {"user"=>"user", "password"=>""}}.to raise_error(Puppet::ResourceError)
-  end
-
-  it 'should not accept array for dsc_psdscrunascredential' do
-    expect{dsc_file[:dsc_psdscrunascredential] = ["foo", "bar", "spec"]}.to raise_error(Puppet::ResourceError)
-  end
-
-  it 'should not accept boolean for dsc_psdscrunascredential' do
-    expect{dsc_file[:dsc_psdscrunascredential] = true}.to raise_error(Puppet::ResourceError)
-  end
-
-  it 'should not accept int for dsc_psdscrunascredential' do
-    expect{dsc_file[:dsc_psdscrunascredential] = -16}.to raise_error(Puppet::ResourceError)
-  end
-
-  it 'should not accept uint for dsc_psdscrunascredential' do
-    expect{dsc_file[:dsc_psdscrunascredential] = 16}.to raise_error(Puppet::ResourceError)
   end
 
   # Configuration PROVIDER TESTS


### PR DESCRIPTION
This adds the PsDscRunAsCredential parameter to all Puppet types
generated from all the DSC Resources.

WMF5 DSC added the PsDscRunAsCredential to every DSC Resource, which
allows the the DSC engine to execute a DSC Resource under a user context
instead of the SYSTEM context the DSC engine normally runs under. This
parameter is dynamically added to all DSC Resources at runtime and not
part of the schema.mof files we rely on to generate our types. This
means we have to 'hardcode' it in our type generation.

The File DSC Resource schema was modified to remove PsDscRunAsCredential
as it was erroneously added when the file was first added to the repo.
This file is only for us when we build types, so it does not affect any
vendor DSC Resources