### PR TITLE
(maint) Correctly pass embedded instances

### DIFF
--- a/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/templates/invoke_dsc_resource.ps1.erb
@@ -42,7 +42,12 @@ $invokeParams = @{
       vals = vals.collect do |v|
         "(New-CimInstance -ClassName '#{p.mof_type.gsub('[]','')}' -ClientOnly -Property #{format_dsc_value(v)})"
       end
-      value = "[CimInstance[]]@(#{vals.join(',')})"
+      # Ensure that we pass a single CimInstance or array correctly based on MOF schema definition
+      if p.value.is_a?(Hash)
+        value = "[CimInstance]#{vals.first}"
+      else
+        value = "[CimInstance[]]@(#{vals.join(',')})"
+      end
     else
       value = format_dsc_value(p.value)
     end


### PR DESCRIPTION
 - When a MOF Schema references an `EmbeddedInstance` it will typically
   be a `String[]`, but can also be a String.

   In the case where the `EmbeddedInstance` is just a `String`, the
   PowerShell code should be passing a singular `CimInstance` instead
   of a `CimInstance[]`.

   An example of where this occurs is in the `MSFT_xWebsite` MOF, which
   has definitions for 2 `EmbeddedInstance` types, one of which is an
   array (which currently works), and one which is not:

>   [Write, EmbeddedInstance("MSFT_xWebBindingInformation")] String BindingInfo[];
>   [write, EmbeddedInstance("MSFT_xWebAuthenticationInformation"))] String AuthenticationInfo;

   Without this change, a value cannot be set for AuthenticationInfo
   as desired.  It currently passes to PowerShell Invoke-DscResource:

```powershell
   authenticationinfo = [CimInstance[]]@((New-CimInstance -ClassName 'MSFT_xWebAuthenticationInformation' -ClientOnly -Property @{'Anonymous' = $true}))
```

   Which generates the error:

>   Error: /Stage[main]/Main/Dsc_xwebsite[NewWebsite]: Could not evaluate: Convert property 'authenticationinfo' value from type 'INSTANCE[]' to type 'INSTANCE' failed

 - This change produces the correct PS code for Invoke-DscResource:

```powershell
   authenticationinfo = [CimInstance](New-CimInstance -ClassName 'MSFT_xWebAuthenticationInformation' -ClientOnly -Property @{'Anonymous' = $true})
```
