### PR TITLE
(MODULES-4201) Fix building custom DSC Resources

### DIFF
--- a/build/dsc/manager.rb
+++ b/build/dsc/manager.rb
@@ -286,6 +286,25 @@ module Dsc
       end
       output.join(', ')
     end
+    
+    def find_valid_files(directory)
+      valid_files = Dir.glob("#{directory}/**/*").reject do |f|
+        # reject the .git folder or special git files
+        f =~ /\/\.(git|gitattributes|gitignore|gitmodules)/ ||
+        # reject binary and other file extensions
+        f =~ /\.(pptx|docx|sln|cmd|xml|pssproj|pfx|html|txt|xlsm|csv|png|git|yml|md)$/i ||
+        # reject test / sample / example code
+        f =~ /\/.*([Ss]ample|[Ee]xample|[Tt]est).*/ ||
+        # reject stuff that is a Composite DSC Resource
+        f =~ /(xChrome|xDSCResourceDesigner|xDscDiagnostics|xFirefox|xSafeHarbor|xSystemSecurity).*/ ||
+        # reject duplicated resources
+        f =~ /(xSharePoint|PSDscResources).*/ ||
+        # and don't keep track of dirs
+        Dir.exists?(f)
+      end
+      
+      valid_files
+    end
 
     private
 


### PR DESCRIPTION
Trying to build custom DSC Resources would fail from duplicate directories being copied, as well as not keeping the copied custom DSC Resources during build.

This PR fixes this by re-organizing the import method to have two sections, one for importing the official Microsoft DSC Resources and one for handling custom DSC Resources. This reduces the confusion over where the files should be at any one time.