### PR TITLE
(DO NOT MERGE YET)(MODULES-4551) Update powershell_manager code

### DIFF
--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -55,13 +55,15 @@ Puppet (including 3.x), or to a Puppet version newer than 3.x.
   end
 
   def self.powershell_args
-    ps_args = ['-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command']
+    ps_args = ['-NoProfile', '-NonInteractive', '-NoLogo', '-ExecutionPolicy', 'Bypass']
     ps_args << '-' if !Facter.value(:uses_win32console)
     ps_args
   end
 
   def ps_manager
-    PuppetX::Dsc::PowerShellManager.instance("#{command(:powershell)} #{self.class.powershell_args.join(' ')}")
+    debug_output = Puppet::Util::Log.level == :debug
+    manager_args = "#{command(:powershell)} #{self.class.powershell_args().join(' ')}"
+    PuppetX::Dsc::PowerShellManager.instance(manager_args, debug_output)
   end
 
   COMMAND_TIMEOUT = 1200000 # 20 minutes

--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -1,222 +1,319 @@
 require 'securerandom'
 require 'open3'
-require 'ffi'
 
 module PuppetX
   module Dsc
     class PowerShellManager
-      extend Puppet::Util::Windows::String
-      extend FFI::Library
-
       @@instances = {}
 
-      def self.instance(cmd)
-        @@instances[:cmd] ||= PowerShellManager.new(cmd)
+      def self.instance(cmd, debug = false)
+        key = cmd + debug.to_s
+        manager = @@instances[key]
+
+        if manager.nil? || !manager.alive?
+          # ignore any errors trying to tear down this unusable instance
+          manager.exit if manager rescue nil
+          @@instances[key] = PowerShellManager.new(cmd, debug)
+        end
+
+         @@instances[key]
       end
 
-      def initialize(cmd)
-        @stdin, @stdout, @ps_process = Open3.popen2(cmd)
+      def self.win32console_enabled?
+        @win32console_enabled ||= defined?(Win32) &&
+          defined?(Win32::Console) &&
+          Win32::Console.class == Class
+      end
+
+      def self.supported?
+        Puppet::Util::Platform.windows? && !win32console_enabled?
+      end
+
+      def initialize(cmd, debug)
+        @usable = true
+
+        named_pipe_name = "#{SecureRandom.uuid}PuppetPsHost"
+
+        ps_args = ['-File', self.class.init_path, "\"#{named_pipe_name}\""]
+        ps_args << '"-EmitDebugOutput"' if debug
+        # @stderr should never be written to as PowerShell host redirects output
+        stdin, @stdout, @stderr, @ps_process = Open3.popen3("#{cmd} #{ps_args.join(' ')}")
+        stdin.close
 
         Puppet.debug "#{Time.now} #{cmd} is running as pid: #{@ps_process[:pid]}"
+
+        pipe_path = "\\\\.\\pipe\\#{named_pipe_name}"
+        # wait for the pipe server to signal ready, and fail if no response in 10 seconds
+
+        # wait up to 10 seconds in 0.2 second intervals to be able to open the pipe
+        50.times do
+          begin
+            # pipe is opened in binary mode and must always
+            @pipe = File.open(pipe_path, 'r+b')
+            break
+          rescue
+            sleep 0.2
+          end
+        end
+
+        fail "Failure waiting for PowerShell process #{@ps_process[:pid]} to start pipe server" if @pipe.nil?
+
+        Puppet.debug "#{Time.now} PowerShell initialization complete for pid: #{@ps_process[:pid]}"
 
         at_exit { exit }
       end
 
-      def execute(powershell_code, timeout_ms = 300 * 1000)
-        output_ready_event_name =  "Global\\#{SecureRandom.uuid}"
-        output_ready_event = self.class.create_event(output_ready_event_name)
+      def alive?
+        # powershell process running
+        @ps_process.alive? &&
+          # explicitly set during a read / write failure, like broken pipe EPIPE
+          @usable &&
+          # an explicit failure state might not have been hit, but IO may be closed
+          self.class.is_stream_valid?(@pipe) &&
+          self.class.is_stream_valid?(@stdout) &&
+          self.class.is_stream_valid?(@stderr)
+      end
 
-        # always need a trailing newline to ensure PowerShell parses code
-        code = <<-CODE
-        $event = [Threading.EventWaitHandle]::OpenExisting("#{output_ready_event_name}")
-        if ($runspace -eq $null)
-        {
-          $runspace = [RunspaceFactory]::CreateRunspace()
-          $runspace.Open()
-        }
+      def execute(powershell_code, timeout_ms = nil, working_dir = nil)
+        code = make_ps_code(powershell_code, timeout_ms, working_dir)
 
-        $powershell_code = @'
-#{powershell_code}
-'@
-        $ps = $null
 
-        try
-        {
-          # http://learn-powershell.net/2012/05/13/using-background-runspaces-instead-of-psjobs-for-better-performance/
-          $ps = [powershell]::create()
-          $ps.Runspace = $runspace
-          [Void]$ps.AddScript($powershell_code)
+        # err is drained stderr pipe (not captured by redirection inside PS)
+        # or during a failure, a Ruby callstack array
+        out, native_stdout, err = exec_read_result(code)
 
-          $asyncResult = $ps.BeginInvoke()
+        # an error was caught during execution that has invalidated any results
+        return { :exitcode => -1, :stderr => err } if !@usable && out.nil?
 
-          if (!$asyncResult.AsyncWaitHandle.WaitOne(#{timeout_ms}))
-          {
-            throw "Catastrophic failure: PowerShell DSC resource timeout (#{timeout_ms} ms) exceeded while executing"
-          }
+        out[:exitcode] = out[:exitcode].to_i if !out[:exitcode].nil?
+        # if err contains data it must be "real" stderr output
+        # which should be appended to what PS has already captured
+        out[:stderr] = out[:stderr].nil? ? [] : [out[:stderr]]
+        out[:stderr] += err if !err.nil?
+        out[:native_stdout] = native_stdout
 
-          $output = $ps.EndInvoke($asyncResult)
-          Write-Output $output
-        }
-        catch
-        {
-          try
-          {
-            if ($runspace) { $runspace.Dispose() }
-          }
-          finally
-          {
-            $runspace = $null
-          }
-          @{
-            indesiredstate = $false
-            rebootrequired = $false
-            errormessage = $_.Exception.Message
-          } | ConvertTo-Json -Compress
-        }
-        finally
-        {
-          [Void]$event.Set()
-          [Void]$event.Dispose()
-          if ($ps -ne $null) { [Void]$ps.Dispose() }
-        }
-
-        CODE
-
-        out = exec_read_result(code, output_ready_event)
-
-        { :stdout => out }
-      ensure
-        FFI::WIN32.CloseHandle(output_ready_event) if output_ready_event
+        out
       end
 
       def exit
+        @usable = false
+
         Puppet.debug "PowerShellManager exiting..."
-        @stdin.puts "\nexit\n"
-        @stdin.close
-        @stdout.close
+        # pipe may still be open, but if stdout / stderr are dead PS process is in trouble
+        # and will block forever on a write to the pipe
+        # its safer to close pipe on Ruby side, which gracefully shuts down PS side
+        @pipe.close if !@pipe.closed?
+        @stdout.close if !@stdout.closed?
+        @stderr.close if !@stderr.closed?
 
-        exit_msg = "PowerShell process did not terminate in reasonable time"
+        # wait up to 2 seconds for the watcher thread to fully exit
+        @ps_process.join(2)
+      end
+
+      def self.init_path
+        # a PowerShell -File compatible path to bootstrap the instance
+        path = File.expand_path('../../../templates', __FILE__)
+        path = File.join(path, 'init_ps.ps1').gsub('/', '\\')
+        "\"#{path}\""
+      end
+
+      def make_ps_code(powershell_code, timeout_ms = nil, working_dir = nil)
         begin
-          Timeout.timeout(3) do
-            Puppet.debug "Awaiting PowerShell process termination..."
-            @exit_status = @ps_process.value
-          end
-        rescue Timeout::Error
+          timeout_ms = Integer(timeout_ms)
+          # Lower bound protection. The polling resolution is only 50ms
+          if (timeout_ms < 50) then timeout_ms = 50 end
+        rescue
+          timeout_ms = 300 * 1000
         end
+        # PS side expects Invoke-PowerShellUserCode is always the return value here
+        <<-CODE
+$params = @{
+  Code = @'
+#{powershell_code}
+'@
+  TimeoutMilliseconds = #{timeout_ms}
+  WorkingDirectory = "#{working_dir}"
+}
 
-        exit_msg = "PowerShell process exited: #{@exit_status}" if @exit_status
-        Puppet.debug(exit_msg)
-        if @ps_process.alive?
-          Puppet.debug("Forcefully terminating PowerShell process.")
-          Process.kill('KILL', @ps_process[:pid])
-        end
+Invoke-PowerShellUserCode @params
+        CODE
       end
 
       private
 
       def self.is_readable?(stream, timeout = 0.5)
+        raise Errno::EPIPE if !is_stream_valid?(stream)
         read_ready = IO.select([stream], [], [], timeout)
         read_ready && stream == read_ready[0][0]
       end
 
-      def self.create_event(name, manual_reset = false, initial_state = false)
-        handle = FFI::Pointer::NULL_HANDLE
+      # when a stream has been closed by handle, but Ruby still has a file
+      # descriptor for it, it can be tricky to determine that it's actually dead
+      # the .fileno will still return an int, and calling get_osfhandle against
+      # it returns what the CRT thinks is a valid Windows HANDLE value, but
+      # that may no longer exist
+      def self.is_stream_valid?(stream)
+        # when a stream is closed, its obviously invalid, but Ruby doesn't always know
+        !stream.closed? &&
+        # so calling stat will yield an EBADF when underlying OS handle is bad
+        # as this resolves to a HANDLE and then calls the Windows API
+        !stream.stat.nil?
+      # any exceptions mean the stream is dead
+      rescue
+        false
+      end
 
-        FFI::Pointer.from_string_to_wide_string(name) do |name_ptr|
-          handle = CreateEventW(FFI::Pointer::NULL,
-            manual_reset ? 1 : FFI::WIN32_FALSE,
-            initial_state ? 1 : FFI::WIN32_FALSE,
-            name_ptr)
+      # copied directly from Puppet 3.7+ to support Puppet 3.5+
+      def self.wide_string(str)
+        # ruby (< 2.1) does not respect multibyte terminators, so it is possible
+        # for a string to contain a single trailing null byte, followed by garbage
+        # causing buffer overruns.
+        #
+        # See http://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=41920&view=revision
+        newstr = str + "\0".encode(str.encoding)
+        newstr.encode!('UTF-16LE')
+      end
 
-          if handle == FFI::Pointer::NULL_HANDLE
-            msg = "Failed to create new event #{name}"
-            raise Puppet::Util::Windows::Error.new(msg)
-          end
+      # mutates the given bytes, removing the length prefixed vaule
+      def self.read_length_prefixed_string(bytes)
+        # 32-bit integer in Little Endian format
+        length = bytes.slice!(0, 4).unpack('V').first
+        return nil if length == 0
+        bytes.slice!(0, length).force_encoding(Encoding::UTF_8)
+      end
+
+      # bytes is a binary string containing a list of length-prefixed
+      # key / value pairs (of UTF-8 encoded strings)
+      # this method mutates the incoming value
+      def self.ps_output_to_hash(bytes)
+        hash = {}
+        while !bytes.empty?
+          hash[read_length_prefixed_string(bytes).to_sym] = read_length_prefixed_string(bytes)
         end
 
-        handle
+        hash
       end
 
-      WAIT_ABANDONED = 0x00000080
-      WAIT_OBJECT_0 = 0x00000000
-      WAIT_TIMEOUT = 0x00000102
-      WAIT_FAILED = 0xFFFFFFFF
+      # 1 byte command identifier
+      #     0 - Exit
+      #     1 - Execute
+      def pipe_command(command)
+        case command
+        when :exit
+          "\x00"
+        when :execute
+          "\x01"
+        end
+      end
 
-      def self.wait_on(wait_object, timeout_ms = 50)
-        wait_result = Puppet::Util::Windows::Process::WaitForSingleObject(
-          wait_object, timeout_ms)
+      # Data format is:
+      # 4 bytes - Little Endian encoded 32-bit integer length of string
+      #           Intel CPUs are little endian, hence the .NET Framework typically is
+      # variable length - UTF8 encoded string bytes
+      def pipe_data(data)
+        msg = data.encode(Encoding::UTF_8)
+        # https://ruby-doc.org/core-1.9.3/Array.html#method-i-pack
+        [msg.bytes.length].pack('V') + msg.force_encoding(Encoding::BINARY)
+      end
 
-        case wait_result
-        when WAIT_OBJECT_0
-          Puppet.debug "Wait object signaled"
-        when WAIT_TIMEOUT
-          Puppet.debug "Waited #{timeout_ms} milliseconds..."
-        # only applicable to mutexes - should never happen here
-        when WAIT_ABANDONED
-          msg = 'Catastrophic failure: wait object in inconsistent state'
-          raise Puppet::Util::Windows::Error.new(msg)
-        when WAIT_FAILED
-          msg = 'Catastrophic failure: waiting on object to be signaled'
-          raise Puppet::Util::Windows::Error.new(msg)
+      def write_pipe(input)
+        # for compat with Ruby 2.1 and lower, its important to use syswrite and not write
+        # otherwise the pipe breaks after writing 1024 bytes
+        written = @pipe.syswrite(input)
+        @pipe.flush()
+
+        if written != input.length
+          msg = "Only wrote #{written} out of #{input.length} expected bytes to PowerShell pipe"
+          raise Errno::EPIPE.new(msg)
+        end
+      end
+
+      def read_from_pipe(pipe, timeout = 0.1, &block)
+        if self.class.is_readable?(pipe, timeout)
+          l = pipe.readpartial(4096)
+          Puppet.debug "#{Time.now} PIPE> #{l}"
+          # since readpartial may return a nil at EOF, skip returning that value
+          yield l if !l.nil?
         end
 
-        wait_result
+        nil
       end
 
-      def write_stdin(input)
-        @stdin.puts(input)
-      rescue => e
-        msg = "Error writing STDIN / reading STDOUT: #{e}"
-        raise Puppet::Util::Windows::Error.new(msg)
-      end
-
-      def drain_stdout
+      def drain_pipe_until_signaled(pipe, signal)
         output = []
-        while self.class.is_readable?(@stdout, 0.1) do
-          l = @stdout.gets
-          Puppet.debug "#{Time.now} STDOUT> #{l}"
-          output << l
+
+        read_from_pipe(pipe) { |s| output << s } until !signal.locked?
+
+        # there's ultimately a bit of a race here
+        # read one more time after signal is received
+        read_from_pipe(pipe, 0) { |s| output << s } until !self.class.is_readable?(pipe)
+
+        # string has been binary up to this point, so force UTF-8 now
+        output == [] ?
+          [] :
+          [output.join('').force_encoding(Encoding::UTF_8)]
+      end
+
+      def read_streams
+        pipe_done_reading = Mutex.new
+        pipe_done_reading.lock
+        start_time = Time.now
+
+        stdout_reader = Thread.new { drain_pipe_until_signaled(@stdout, pipe_done_reading) }
+        stderr_reader = Thread.new { drain_pipe_until_signaled(@stderr, pipe_done_reading) }
+        pipe_reader = Thread.new(@pipe) do |pipe|
+          # read a Little Endian 32-bit integer for length of response
+          expected_response_length = pipe.sysread(4).unpack('V').first
+          return nil if expected_response_length == 0
+
+          # reads the expected bytes as a binary string or fails
+          pipe.sysread(expected_response_length)
         end
-        output
-      end
 
-      def read_stdout(output_ready_event, wait_interval_ms = 50)
-        output = []
-        waited = 0
+        Puppet.debug "Waited #{Time.now - start_time} total seconds."
 
-        # drain the pipe while waiting for the event signal
-        while WAIT_TIMEOUT == self.class.wait_on(output_ready_event, wait_interval_ms)
-          output << drain_stdout
-          waited += wait_interval_ms
+        # block until sysread has completed or errors
+        begin
+          output = pipe_reader.value
+          output = self.class.ps_output_to_hash(output) if !output.nil?
+        ensure
+          # signal stdout / stderr readers via mutex
+          # so that Ruby doesn't crash waiting on an invalid event
+          pipe_done_reading.unlock
         end
 
-        Puppet.debug "Waited #{waited} total milliseconds."
+        # given redirection on PowerShell side, this should always be empty
+        stdout = stdout_reader.value
 
-        # once signaled, ensure everything has been drained
-        output << drain_stdout
-
-        output.join('')
-      rescue => e
-        msg = "Error reading STDOUT: #{e}"
-        raise Puppet::Util::Windows::Error.new(msg)
+        [
+          output,
+          stdout == [] ? nil : stdout.join(''), # native stdout
+          stderr_reader.value # native stderr
+        ]
+      ensure
+        # failsafe if the prior unlock was never reached / Mutex wasn't unlocked
+        pipe_done_reading.unlock if pipe_done_reading.locked?
+        # wait for all non-nil threads to see mutex unlocked and finish
+        [pipe_reader, stdout_reader, stderr_reader].compact.each(&:join)
       end
 
-      def exec_read_result(powershell_code, output_ready_event)
-        write_stdin(powershell_code)
-        read_stdout(output_ready_event)
+      def exec_read_result(powershell_code)
+        write_pipe(pipe_command(:execute))
+        write_pipe(pipe_data(powershell_code))
+        read_streams()
+      # if any pipes are broken, the manager is totally hosed
+      # bad file descriptors mean closed stream handles
+      # EOFError is a closed pipe (could be as a result of tearing down process)
+      rescue Errno::EPIPE, Errno::EBADF, EOFError => e
+        @usable = false
+        return nil, nil, [e.inspect, e.backtrace].flatten
+      # catch closed stream errors specifically
+      rescue IOError => ioerror
+        raise if !ioerror.message.start_with?('closed stream')
+        @usable = false
+        return nil, nil, [ioerror.inspect, ioerror.backtrace].flatten
       end
 
-      ffi_convention :stdcall
-
-      # https://msdn.microsoft.com/en-us/library/windows/desktop/ms682396(v=vs.85).aspx
-      # HANDLE WINAPI CreateEvent(
-      #   _In_opt_ LPSECURITY_ATTRIBUTES lpEventAttributes,
-      #   _In_     BOOL                  bManualReset,
-      #   _In_     BOOL                  bInitialState,
-      #   _In_opt_ LPCTSTR               lpName
-      # );
-      ffi_lib :kernel32
-      attach_function_private :CreateEventW, [:pointer, :win32_bool, :win32_bool, :lpcwstr], :handle
     end
   end
 end

--- a/lib/puppet_x/templates/init_ps.ps1
+++ b/lib/puppet_x/templates/init_ps.ps1
@@ -1,0 +1,787 @@
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory = $true)]
+  [String]
+  $NamedPipeName,
+
+  [Parameter(Mandatory = $false)]
+  [Switch]
+  $EmitDebugOutput = $False,
+
+  [Parameter(Mandatory = $false)]
+  [System.Text.Encoding]
+  $Encoding = [System.Text.Encoding]::UTF8
+)
+
+$script:EmitDebugOutput = $EmitDebugOutput
+# Necessary for [System.Console]::Error.WriteLine to roundtrip with UTF-8
+[System.Console]::OutputEncoding = $Encoding
+
+$hostSource = @"
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Security;
+using System.Text;
+using System.Threading;
+
+namespace Puppet
+{
+  public class PuppetPSHostRawUserInterface : PSHostRawUserInterface
+  {
+    public PuppetPSHostRawUserInterface()
+    {
+      buffersize      = new Size(120, 120);
+      backgroundcolor = ConsoleColor.Black;
+      foregroundcolor = ConsoleColor.White;
+      cursorposition  = new Coordinates(0, 0);
+      cursorsize      = 1;
+    }
+
+    private ConsoleColor backgroundcolor;
+    public override ConsoleColor BackgroundColor
+    {
+      get { return backgroundcolor; }
+      set { backgroundcolor = value; }
+    }
+
+    private Size buffersize;
+    public override Size BufferSize
+    {
+      get { return buffersize; }
+      set { buffersize = value; }
+    }
+
+    private Coordinates cursorposition;
+    public override Coordinates CursorPosition
+    {
+      get { return cursorposition; }
+      set { cursorposition = value; }
+    }
+
+    private int cursorsize;
+    public override int CursorSize
+    {
+      get { return cursorsize; }
+      set { cursorsize = value; }
+    }
+
+    private ConsoleColor foregroundcolor;
+    public override ConsoleColor ForegroundColor
+    {
+      get { return foregroundcolor; }
+      set { foregroundcolor = value; }
+    }
+
+    private Coordinates windowposition;
+    public override Coordinates WindowPosition
+    {
+      get { return windowposition; }
+      set { windowposition = value; }
+    }
+
+    private Size windowsize;
+    public override Size WindowSize
+    {
+      get { return windowsize; }
+      set { windowsize = value; }
+    }
+
+    private string windowtitle;
+    public override string WindowTitle
+    {
+      get { return windowtitle; }
+      set { windowtitle = value; }
+    }
+
+    public override bool KeyAvailable
+    {
+        get { return false; }
+    }
+
+    public override Size MaxPhysicalWindowSize
+    {
+        get { return new Size(165, 66); }
+    }
+
+    public override Size MaxWindowSize
+    {
+        get { return new Size(165, 66); }
+    }
+
+    public override void FlushInputBuffer()
+    {
+      throw new NotImplementedException();
+    }
+
+    public override BufferCell[,] GetBufferContents(Rectangle rectangle)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override KeyInfo ReadKey(ReadKeyOptions options)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override void ScrollBufferContents(Rectangle source, Coordinates destination, Rectangle clip, BufferCell fill)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override void SetBufferContents(Rectangle rectangle, BufferCell fill)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override void SetBufferContents(Coordinates origin, BufferCell[,] contents)
+    {
+      throw new NotImplementedException();
+    }
+  }
+
+  public class PuppetPSHostUserInterface : PSHostUserInterface
+  {
+    private PuppetPSHostRawUserInterface _rawui;
+    private StringBuilder _sb;
+    private StringWriter _errWriter;
+    private StringWriter _outWriter;
+
+    public PuppetPSHostUserInterface()
+    {
+      _sb = new StringBuilder();
+      _errWriter = new StringWriter(new StringBuilder());
+      // NOTE: StringWriter / StringBuilder are not technically thread-safe
+      // but PowerShell Write-XXX cmdlets and System.Console.Out.WriteXXX
+      // should not be executed concurrently within PowerShell, so should be safe
+      _outWriter = new StringWriter(_sb);
+    }
+
+    public override PSHostRawUserInterface RawUI
+    {
+      get
+      {
+        if ( _rawui == null){
+          _rawui = new PuppetPSHostRawUserInterface();
+        }
+        return _rawui;
+      }
+    }
+
+    public void ResetConsoleStreams()
+    {
+      System.Console.SetError(_errWriter);
+      System.Console.SetOut(_outWriter);
+    }
+
+    public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
+    {
+      _sb.Append(value);
+    }
+
+    public override void Write(string value)
+    {
+      _sb.Append(value);
+    }
+
+    public override void WriteDebugLine(string message)
+    {
+      _sb.AppendLine("DEBUG: " + message);
+    }
+
+    public override void WriteErrorLine(string value)
+    {
+      _sb.AppendLine(value);
+    }
+
+    public override void WriteLine(string value)
+    {
+      _sb.AppendLine(value);
+    }
+
+    public override void WriteVerboseLine(string message)
+    {
+      _sb.AppendLine("VERBOSE: " + message);
+    }
+
+    public override void WriteWarningLine(string message)
+    {
+      _sb.AppendLine("WARNING: " + message);
+    }
+
+    public override void WriteProgress(long sourceId, ProgressRecord record)
+    {
+    }
+
+    public string Output
+    {
+      get
+      {
+        _outWriter.Flush();
+        string text = _outWriter.GetStringBuilder().ToString();
+        _outWriter.GetStringBuilder().Length = 0; // Only .NET 4+ has .Clear()
+        return text;
+      }
+    }
+
+    public string StdErr
+    {
+      get
+      {
+        _errWriter.Flush();
+        string text = _errWriter.GetStringBuilder().ToString();
+        _errWriter.GetStringBuilder().Length = 0; // Only .NET 4+ has .Clear()
+        return text;
+      }
+    }
+
+    public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+    {
+      throw new NotImplementedException();
+    }
+
+    public override string ReadLine()
+    {
+      throw new NotImplementedException();
+    }
+
+    public override SecureString ReadLineAsSecureString()
+    {
+      throw new NotImplementedException();
+    }
+  }
+
+  public class PuppetPSHost : PSHost
+  {
+    private Guid _hostId = Guid.NewGuid();
+    private bool shouldExit;
+    private int exitCode;
+
+    private readonly PuppetPSHostUserInterface _ui = new PuppetPSHostUserInterface();
+
+    public PuppetPSHost () {}
+
+    public bool ShouldExit { get { return this.shouldExit; } }
+    public int ExitCode { get { return this.exitCode; } }
+    public void ResetExitStatus()
+    {
+      this.exitCode = 0;
+      this.shouldExit = false;
+    }
+    public void ResetConsoleStreams()
+    {
+      _ui.ResetConsoleStreams();
+    }
+
+    public override Guid InstanceId { get { return _hostId; } }
+    public override string Name { get { return "PuppetPSHost"; } }
+    public override Version Version { get { return new Version(1, 1); } }
+    public override PSHostUserInterface UI
+    {
+      get { return _ui; }
+    }
+    public override CultureInfo CurrentCulture
+    {
+        get { return Thread.CurrentThread.CurrentCulture; }
+    }
+    public override CultureInfo CurrentUICulture
+    {
+        get { return Thread.CurrentThread.CurrentUICulture; }
+    }
+
+    public override void EnterNestedPrompt() { throw new NotImplementedException(); }
+    public override void ExitNestedPrompt() { throw new NotImplementedException(); }
+    public override void NotifyBeginApplication() { return; }
+    public override void NotifyEndApplication() { return; }
+
+    public override void SetShouldExit(int exitCode)
+    {
+      this.shouldExit = true;
+      this.exitCode = exitCode;
+    }
+  }
+}
+"@
+
+Add-Type -TypeDefinition $hostSource -Language CSharp
+$global:DefaultWorkingDirectory = (Get-Location -PSProvider FileSystem).Path
+
+#this is a string so we can import into our dynamic PS instance
+$global:ourFunctions = @'
+function Get-ProcessEnvironmentVariables
+{
+  $processVars = [Environment]::GetEnvironmentVariables('Process').Keys |
+    % -Begin { $h = @{} } -Process { $h.$_ = (Get-Item Env:\$_).Value } -End { $h }
+
+  # eliminate Machine / User vars so that we have only process vars
+  'Machine', 'User' |
+    % { [Environment]::GetEnvironmentVariables($_).GetEnumerator() } |
+    ? { $processVars.ContainsKey($_.Name) -and ($processVars[$_.Name] -eq $_.Value) } |
+    % { $processVars.Remove($_.Name) }
+
+  $processVars.GetEnumerator() | Sort-Object Name
+}
+
+function Reset-ProcessEnvironmentVariables
+{
+  param($processVars)
+
+  # query Machine vars from registry, ensuring expansion EXCEPT for PATH
+  $vars = [Environment]::GetEnvironmentVariables('Machine').GetEnumerator() |
+    % -Begin { $h = @{} } -Process { $v = if ($_.Name -eq 'Path') { $_.Value } else { [Environment]::GetEnvironmentVariable($_.Name, 'Machine') }; $h."$($_.Name)" = $v } -End { $h }
+
+  # query User vars from registry, ensuring expansion EXCEPT for PATH
+  [Environment]::GetEnvironmentVariables('User').GetEnumerator() | % {
+      if ($_.Name -eq 'Path') { $vars[$_.Name] += ';' + $_.Value }
+      else
+      {
+        $value = [Environment]::GetEnvironmentVariable($_.Name, 'User')
+        $vars[$_.Name] = $value
+      }
+    }
+
+  $processVars.GetEnumerator() | % { $vars[$_.Name] = $_.Value }
+
+  Remove-Item -Path Env:\* -ErrorAction SilentlyContinue -WarningAction SilentlyContinue -Recurse
+
+  $vars.GetEnumerator() | % { Set-Item -Path "Env:\$($_.Name)" -Value $_.Value }
+}
+
+function Reset-ProcessPowerShellVariables
+{
+  param($psVariables)
+  $psVariables | %{
+    $tempVar = $_
+    if(-not(Get-Variable -Name $_.Name -ErrorAction SilentlyContinue)){
+      New-Variable -Name $_.Name -Value $_.Value -Description $_.Description -Option $_.Options -Visibility $_.Visibility
+    }
+  }
+}
+'@
+
+function Invoke-PowerShellUserCode
+{
+  [CmdletBinding()]
+  param(
+    [String]
+    $Code,
+
+    [Int]
+    $TimeoutMilliseconds,
+
+    [String]
+    $WorkingDirectory
+  )
+
+  if ($global:runspace -eq $null){
+    # CreateDefault2 requires PS3
+    if ([System.Management.Automation.Runspaces.InitialSessionState].GetMethod('CreateDefault2')){
+      $sessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault2()
+    }else{
+      $sessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
+    }
+
+    $global:puppetPSHost = New-Object Puppet.PuppetPSHost
+    $global:runspace = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace($global:puppetPSHost, $sessionState)
+    $global:runspace.Open()
+  }
+
+  try
+  {
+    $ps = $null
+    $global:puppetPSHost.ResetExitStatus()
+    $global:puppetPSHost.ResetConsoleStreams()
+
+    if ($PSVersionTable.PSVersion -ge [Version]'3.0') {
+      $global:runspace.ResetRunspaceState()
+    }
+
+    $ps = [System.Management.Automation.PowerShell]::Create()
+    $ps.Runspace = $global:runspace
+    [Void]$ps.AddScript($global:ourFunctions)
+    $ps.Invoke()
+
+    if ([string]::IsNullOrEmpty($WorkingDirectory)) {
+      [Void]$ps.Runspace.SessionStateProxy.Path.SetLocation($global:DefaultWorkingDirectory)
+    } else {
+      if (-not (Test-Path -Path $WorkingDirectory)) { Throw "Working directory `"$WorkingDirectory`" does not exist" }
+      [Void]$ps.Runspace.SessionStateProxy.Path.SetLocation($WorkingDirectory)
+    }
+
+    if(!$global:environmentVariables){
+      $ps.Commands.Clear()
+      $global:environmentVariables = $ps.AddCommand('Get-ProcessEnvironmentVariables').Invoke()
+    }
+
+    if($PSVersionTable.PSVersion -le [Version]'2.0'){
+      if(!$global:psVariables){
+        $global:psVariables = $ps.AddScript('Get-Variable').Invoke()
+      }
+
+      $ps.Commands.Clear()
+      [void]$ps.AddScript('Get-Variable -Scope Global | Remove-Variable -Force -ErrorAction SilentlyContinue -WarningAction SilentlyContinue')
+      $ps.Invoke()
+
+      $ps.Commands.Clear()
+      [void]$ps.AddCommand('Reset-ProcessPowerShellVariables').AddParameter('psVariables', $global:psVariables)
+      $ps.Invoke()
+    }
+
+    $ps.Commands.Clear()
+    [Void]$ps.AddCommand('Reset-ProcessEnvironmentVariables').AddParameter('processVars', $global:environmentVariables)
+    $ps.Invoke()
+
+    # we clear the commands before each new command
+    # to avoid command pollution
+    $ps.Commands.Clear()
+    [Void]$ps.AddScript($Code)
+
+    # out-default and MergeMyResults takes all output streams
+    # and writes it to the PSHost we create
+    # this needs to be the last thing executed
+    [void]$ps.AddCommand("out-default");
+
+    # if the call operator & established an exit code, exit with it
+    [Void]$ps.AddScript('if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }')
+
+    if($PSVersionTable.PSVersion -le [Version]'2.0'){
+      $ps.Commands.Commands[0].MergeMyResults([System.Management.Automation.Runspaces.PipelineResultTypes]::Error, [System.Management.Automation.Runspaces.PipelineResultTypes]::Output);
+    }else{
+      $ps.Commands.Commands[0].MergeMyResults([System.Management.Automation.Runspaces.PipelineResultTypes]::All, [System.Management.Automation.Runspaces.PipelineResultTypes]::Output);
+    }
+    $asyncResult = $ps.BeginInvoke()
+
+    if (!$asyncResult.AsyncWaitHandle.WaitOne($TimeoutMilliseconds)){
+      throw "Catastrophic failure: PowerShell module timeout ($TimeoutMilliseconds ms) exceeded while executing"
+    }
+
+    try
+    {
+      $ps.EndInvoke($asyncResult)
+    } catch [System.Management.Automation.IncompleteParseException] {
+      # https://msdn.microsoft.com/en-us/library/system.management.automation.incompleteparseexception%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
+      throw $_.Exception.Message
+    } catch {
+      if ($_.Exception.InnerException -ne $null)
+      {
+        throw $_.Exception.InnerException
+      } else {
+        throw $_.Exception
+      }
+    }
+
+    [Puppet.PuppetPSHostUserInterface]$ui = $global:puppetPSHost.UI
+    return @{
+      exitcode = $global:puppetPSHost.Exitcode;
+      stdout = $ui.Output;
+      stderr = $ui.StdErr;
+      errormessage = $null;
+    }
+  }
+  catch
+  {
+    try
+    {
+      if ($global:runspace) { $global:runspace.Dispose() }
+    }
+    finally
+    {
+      $global:runspace = $null
+    }
+    if(($global:puppetPSHost -ne $null) -and $global:puppetPSHost.ExitCode){
+      $ec = $global:puppetPSHost.ExitCode
+    }else{
+      # This is technically not true at this point as we do not
+      # know what exitcode we should return as an unexpected exception
+      # happened and the user did not set an exitcode. Our best guess
+      # is to return 1 so that we ensure Puppet reports this run as an error.
+      $ec = 1
+    }
+
+    if ($_.Exception.ErrorRecord.InvocationInfo -ne $null)
+    {
+      $output = $_.Exception.Message + "`n`r" + $_.Exception.ErrorRecord.InvocationInfo.PositionMessage
+    } else {
+      $output = $_.Exception.Message | Out-String
+    }
+
+    # make an attempt to read StdErr as it may contain info about failures
+    try { $err = $global:puppetPSHost.UI.StdErr } catch { $err = $null }
+    return @{
+      exitcode = $ec;
+      stdout = $null;
+      stderr = $err;
+      errormessage = $output;
+    }
+  }
+  finally
+  {
+    if ($ps -ne $null) { [Void]$ps.Dispose() }
+  }
+}
+
+function Write-SystemDebugMessage
+{
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [String]
+    $Message
+  )
+
+  if ($script:EmitDebugOutput -or ($DebugPreference -ne 'SilentlyContinue'))
+  {
+    [System.Diagnostics.Debug]::WriteLine($Message)
+  }
+}
+
+function Signal-Event
+{
+  [CmdletBinding()]
+  param(
+    [String]
+    $EventName
+  )
+
+  $event = [System.Threading.EventWaitHandle]::OpenExisting($EventName)
+
+  [Void]$event.Set()
+  [Void]$event.Close()
+  if ($PSVersionTable.CLRVersion.Major -ge 3) {
+    [Void]$event.Dispose()
+  }
+
+  Write-SystemDebugMessage -Message "Signaled event $EventName"
+}
+
+function ConvertTo-LittleEndianBytes
+{
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory = $true)]
+    [Int32]
+    $Value
+  )
+
+  $bytes = [BitConverter]::GetBytes($Value)
+  if (![BitConverter]::IsLittleEndian) { [Array]::Reverse($bytes) }
+
+  return $bytes
+}
+
+function ConvertTo-ByteArray
+{
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory = $true)]
+    [Hashtable]
+    $Hash,
+
+    [Parameter(Mandatory = $true)]
+    [System.Text.Encoding]
+    $Encoding
+  )
+
+  # Initialize empty byte array that can be appended to
+  $result = [Byte[]]@()
+  # and add length / name / length / value from Hashtable
+  $Hash.GetEnumerator() |
+    % {
+      $name = $Encoding.GetBytes($_.Name)
+      $result += (ConvertTo-LittleEndianBytes $name.Length) + $name
+
+      $value = @()
+      if ($_.Value -ne $null) { $value = $Encoding.GetBytes($_.Value.ToString()) }
+      $result += (ConvertTo-LittleEndianBytes $value.Length) + $value
+    }
+
+  return $result
+}
+
+function Write-StreamResponse
+{
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory = $true)]
+    [System.IO.Pipes.PipeStream]
+    $Stream,
+
+    [Parameter(Mandatory = $true)]
+    [Byte[]]
+    $Bytes
+  )
+
+  $length = ConvertTo-LittleEndianBytes -Value $Bytes.Length
+  $Stream.Write($length, 0, 4)
+  $Stream.Flush()
+
+  Write-SystemDebugMessage -Message "Wrote Int32 $($bytes.Length) as Byte[] $length to Stream"
+
+  $Stream.Write($bytes, 0, $bytes.Length)
+  $Stream.Flush()
+
+  Write-SystemDebugMessage -Message "Wrote $($bytes.Length) bytes of data to Stream"
+}
+
+function Read-Int32FromStream
+{
+  [CmdletBinding()]
+  param (
+   [Parameter(Mandatory = $true)]
+   [System.IO.Pipes.PipeStream]
+   $Stream
+  )
+
+  $length = New-Object Byte[] 4
+  # Read blocks until all 4 bytes available
+  $Stream.Read($length, 0, 4) | Out-Null
+  # value is sent in Little Endian, but if the CPU is not, in-place reverse the array
+  if (![BitConverter]::IsLittleEndian) { [Array]::Reverse($length) }
+  $value = [BitConverter]::ToInt32($length, 0)
+
+  Write-SystemDebugMessage -Message "Read Byte[] $length from stream as Int32 $value"
+
+  return $value
+}
+
+# Message format is:
+# 1 byte - command identifier
+#     0 - Exit
+#     1 - Execute
+#    -1 - Exit - automatically returned when ReadByte encounters a closed pipe
+# [optional] 4 bytes - Little Endian encoded 32-bit code block length for execute
+#                      Intel CPUs are little endian, hence the .NET Framework typically is
+# [optional] variable length - code block
+function ConvertTo-PipeCommand
+{
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory = $true)]
+    [System.IO.Pipes.PipeStream]
+    $Stream,
+
+    [Parameter(Mandatory = $true)]
+    [System.Text.Encoding]
+    $Encoding,
+
+    [Parameter(Mandatory = $false)]
+    [Int32]
+    $BufferChunkSize = 4096
+  )
+
+  # command identifier is a single value - ReadByte blocks until byte is ready / pipe closes
+  $command = $Stream.ReadByte()
+
+  Write-SystemDebugMessage -Message "Command id $command read from pipe"
+
+  switch ($command)
+  {
+    # Exit
+    # ReadByte returns a -1 when the pipe is closed on the other end
+    { @(0, -1) -contains $_ } { return @{ Command = 'Exit' }}
+
+    # Execute
+    1 { $parsed = @{ Command = 'Execute' } }
+
+    default { throw "Catastrophic failure: Unexpected Command $command received" }
+  }
+
+  # read size of incoming byte buffer
+  $parsed.Length = Read-Int32FromStream -Stream $Stream
+  Write-SystemDebugMessage -Message "Expecting $($parsed.Length) raw bytes of $($Encoding.EncodingName) characters"
+
+  # Read blocks until all bytes are read or EOF / broken pipe hit - tested with 5MB and worked fine
+  $parsed.RawData = New-Object Byte[] $parsed.Length
+  $read = $Stream.Read($parsed.RawData, 0, $parsed.Length)
+  if ($read -lt $parsed.Length)
+  {
+    throw "Catastrophic failure: Expected $($parsed.Length) raw bytes, only received $read"
+  }
+
+  # turn the raw bytes into the expected encoded string!
+  $parsed.Code = $Encoding.GetString($parsed.RawData)
+
+  return $parsed
+}
+
+function Start-PipeServer
+{
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory = $true)]
+    [String]
+    $CommandChannelPipeName,
+
+    [Parameter(Mandatory = $true)]
+    [System.Text.Encoding]
+    $Encoding
+  )
+
+  # this does not require versioning in the payload as client / server are tightly coupled
+  $server = New-Object System.IO.Pipes.NamedPipeServerStream($CommandChannelPipeName,
+    [System.IO.Pipes.PipeDirection]::InOut)
+
+  try
+  {
+    # block until Ruby process connects
+    $server.WaitForConnection()
+
+    Write-SystemDebugMessage -Message "Incoming Connection to $CommandChannelPipeName Received - Expecting Strings as $($Encoding.EncodingName)"
+
+    # Infinite Loop to process commands until EXIT received
+    $running = $true
+    while ($running)
+    {
+      # throws if an unxpected command id is read from pipe
+      $response = ConvertTo-PipeCommand -Stream $server -Encoding $Encoding
+
+      Write-SystemDebugMessage -Message "Received $($response.Command) command from client"
+
+      switch ($response.Command)
+      {
+        'Execute' {
+          Write-SystemDebugMessage -Message "[Execute] Invoking user code:`n`n $($response.Code)"
+
+          # assuming that the Ruby code always calls Invoked-PowerShellUserCode,
+          # result should already be returned as a hash
+          $result = Invoke-Expression $response.Code
+
+          $bytes = ConvertTo-ByteArray -Hash $result -Encoding $Encoding
+
+          Write-StreamResponse -Stream $server -Bytes $bytes
+        }
+        'Exit' { $running = $false }
+      }
+    }
+  }
+  catch [Exception]
+  {
+    Write-SystemDebugMessage -Message "PowerShell Pipe Server Failed!`n`n$_"
+    throw
+  }
+  finally
+  {
+    if ($server -ne $null) { $server.Dispose() }
+  }
+}
+
+Start-PipeServer -CommandChannelPipeName $NamedPipeName -Encoding $Encoding


### PR DESCRIPTION
 - Move to the binary pipe code introduced as part of PowerShell
   module version 2.1.0:
   https://github.com/puppetlabs/puppetlabs-powershell/tree/2.1.0

 - This fixes any existing issues with UTF-8 content being passed
   between the Ruby parent and PowerShell child process