### PR TITLE
(Modules-4014) Restrict to Powershell v5

### DIFF
--- a/lib/puppet_x/puppetlabs/compatible_powershell_version.rb
+++ b/lib/puppet_x/puppetlabs/compatible_powershell_version.rb
@@ -5,45 +5,13 @@ module PuppetX
     module Dsc
       class CompatiblePowerShellVersion
         def self.compatible_version?
-          value = false
-
           powershell_version = PuppetX::PuppetLabs::Dsc::PowerShellVersion.version
 
           return false if powershell_version.nil?
 
-          # PowerShell v1 - definitely not good to go. Really the entire module
-          # may not even work but I digress
-          return false if Gem::Version.new(powershell_version) < Gem::Version.new(2)
-
-          # PowerShell v3+, we are good to go b/c .NET 4+
-          # https://msdn.microsoft.com/en-us/powershell/scripting/setup/windows-powershell-system-requirements
-          # Look at Microsoft .NET Framwork Requirements section.
-          if Gem::Version.new(powershell_version) >= Gem::Version.new(3)
-            return true
-          end
-
-          # If we are using PowerShell v2, we need to see what the latest
-          # version of .NET is that we have
-          # https://msdn.microsoft.com/en-us/library/hh925568.aspx
-          if Puppet::Util::Platform.windows?
-            require 'win32/registry'
-
-            begin
-              # At this point in the check, PowerShell is using .NET Framework
-              # 2.x family, so we only need to verify v3.5 key exists.
-              # If we were verifying all compatible types we would look for
-              # any of these keys: v3.5, v4.0, v4
-              hive = Win32::Registry::HKEY_LOCAL_MACHINE
-              # redirection doesn't actually matter here - disable it anyway
-              hive.open('SOFTWARE\Microsoft\NET Framework Setup\NDP\v3.5', Win32::Registry::KEY_READ | 0x100) do |reg|
-                value = true
-              end
-            rescue Win32::Registry::Error => e
-              value = false
-            end
-          end
-
-          value
+          # We require at least PowerShell v5, where Invoke-DscResource was first
+          # introduced and most bug fixes are found.
+          Gem::Version.new(powershell_version) >= Gem::Version.new(5)
         end
       end
     end

--- a/spec/integration/puppet_x/puppetlabs/compatible_powershell_version_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/compatible_powershell_version_spec.rb
@@ -1,0 +1,33 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet/type'
+require 'puppet_x/puppetlabs/compatible_powershell_version'
+
+describe PuppetX::PuppetLabs::Dsc::CompatiblePowerShellVersion, :if => Puppet::Util::Platform.windows? do
+  before(:each) do
+    @ps = PuppetX::PuppetLabs::Dsc::CompatiblePowerShellVersion
+  end
+
+  describe "when powershell is installed" do
+
+    describe "when evaluating powershell version" do
+
+      it "should reject powershell version less than 5" do
+        Win32::Registry.any_instance.expects(:[]).with('PowerShellVersion').returns('4.0.0.0')
+
+        version = @ps.compatible_version?
+
+        expect(version).to eq false
+      end
+
+
+      it "should allow a powershell version 5 or greater" do
+        Win32::Registry.any_instance.expects(:[]).with('PowerShellVersion').returns('5.1.0.0')
+
+        version = @ps.compatible_version?
+
+        expect(version).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This restricts the dsc module from running on PowerShell versions less than 5

~~**NOTE** - PR #261 needs to be merged first~~