### PR TITLE
(MODULES-2770) Restrict to WMF 5.0 RTM Version

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -262,7 +262,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
 end
 
 Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10240.16384'))
+  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods


### PR DESCRIPTION
This commit updates the PowerShell version to the RTM version of
WMF 5.0 instead of the pre-release version it used to use.