### PR TITLE
(MODULES-3409) Add deprecation warning for powershell and stdlib modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ All [Puppet metaparameters](https://docs.puppet.com/references/latest/metaparame
 
 ### Optionally Configure the DSC LCM RefreshMode
 
+*WARNING* The dsc::lcm_config class will be removed in the v1.5 release of this module
+
 Prior to the WMF5 Production Preview, the DSC Local Configuration Manager (LCM) `RefreshMode` had to be set to `'Disabled'` for the module to work. That limitation has been removed in the [WMF 5 Production Preview][wmf5-blog-post], but the module still supports configuring this setting if you wish to change it.
 
 ~~~puppet

--- a/manifests/lcm_config.pp
+++ b/manifests/lcm_config.pp
@@ -2,6 +2,8 @@ define dsc::lcm_config (
   $refresh_mode = 'Disabled'
 ) {
 
+  warning("The dsc::lcm_config class will be removed in the v1.5 release of this module")
+
   validate_re($refresh_mode, '^(Disabled|Push)$', 'refresh_mode must be one of \'Disabled\', \'Push\'')
 
   exec { "dsc_provider_set_lcm_refreshmode_${refresh_mode}":


### PR DESCRIPTION
This adds a warning that we will remove the dsc::lcm_config manifest, which removes puppetlabs-powershell module and puppetlabs-stdlib.

Configuring the LCM was only necessary in the preview version of WMF 5.0, and is not needed for puppet to function with dsc in the RTM version which we moved to in MODULES-2770.