### PR TITLE
(maint) Fix minor linting error in lcm_config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,6 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "vendor/**/*.pp"]
-PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}'
 PuppetLint.configuration.send("disable_class_inherits_from_params_class")
 PuppetLint.configuration.send("disable_80chars")
 

--- a/manifests/lcm_config.pp
+++ b/manifests/lcm_config.pp
@@ -2,7 +2,7 @@ define dsc::lcm_config (
   $refresh_mode = 'Disabled'
 ) {
 
-  warning("The dsc::lcm_config class will be removed in the v1.5 release of this module")
+  warning('The dsc::lcm_config class will be removed in the v1.5 release of this module')
 
   validate_re($refresh_mode, '^(Disabled|Push)$', 'refresh_mode must be one of \'Disabled\', \'Push\'')
 


### PR DESCRIPTION
The Puppet Lint configuration for the log format was not working as intended and
was masking the Lint errors.  This commit removs the configuration item as it
is not needed.

This commit updates the lcm_config to use single quotes as per puppet lint style
guidelines.