### PR TITLE
Fix dsc_xpowershellexecutionpolicy with non localsystem account 

### DIFF
--- a/lib/puppet_x/dsc_resources/xPowerShellExecutionPolicy/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.psm1
+++ b/lib/puppet_x/dsc_resources/xPowerShellExecutionPolicy/DSCResources/MSFT_xPowerShellExecutionPolicy/MSFT_xPowerShellExecutionPolicy.psm1
@@ -35,7 +35,7 @@ function Set-TargetResource
         Try
         {
             Write-Verbose "Setting the execution policy of PowerShell."
-            Set-ExecutionPolicy -ExecutionPolicy $ExecutionPolicy -Force -ErrorAction Stop
+            Set-ExecutionPolicy -ExecutionPolicy $ExecutionPolicy -Force -ErrorAction Stop -Scope LocalMachine
         }
         Catch
         {
@@ -64,7 +64,7 @@ function Test-TargetResource
         $ExecutionPolicy
     )
 
-    If($(Get-ExecutionPolicy) -eq $ExecutionPolicy)
+    If($(Get-ExecutionPolicy -Scope LocalMachine) -eq $ExecutionPolicy)
     {
         return $true
     }


### PR DESCRIPTION
If 'puppet agent' is started as an user with local admin privileges, Puppet keeps applying dsc_xpowershellexecutionpolicy even though the policy is already set correctly.

Checking and setting the PowerShell Execution Policy within the scope of LocalMachine fixes this issue.
