### PR TITLE
(maint) Fix PowerShell manifest error checking

### DIFF
--- a/build/dsc/psmodule.rb
+++ b/build/dsc/psmodule.rb
@@ -10,7 +10,7 @@ module Dsc
     end
 
     def version
-      raise "ModuleVersion not found for module #{@name} / #{@module_manifest_path}" if attributes['ModuleVersion'].empty?
+      raise "ModuleVersion not found for module #{@name} / #{@module_manifest_path}" if attributes['ModuleVersion'].nil?
       attributes['ModuleVersion']
     end
 


### PR DESCRIPTION
This commit changes the psd1 manifest parsing code to check for nil
instead of empty on the hash of attributes from the manifest.
Previously if the hash did not have a 'ModuleVersion' because of a
failed parse, the code looked to see if the hash was empty, causing an
exception that does not contain the DSC Resource that failed parsing.
Using nil instead keeps the full formed error message