### PR TITLE
(MODULES-5590) Fix PowerShell Manifest Parsing semicolons

### DIFF
--- a/build/dsc/psmodule.rb
+++ b/build/dsc/psmodule.rb
@@ -10,7 +10,7 @@ module Dsc
     end
 
     def version
-      raise "ModuleVersion not found for module #{@name} / #{@module_manifest_path}" if attributes['ModuleVersion'].empty?
+      raise "ModuleVersion not found for module #{@name} / #{@module_manifest_path}" if !attributes.key?('ModuleVersion') || attributes['ModuleVersion'].empty?
       attributes['ModuleVersion']
     end
 

--- a/build/dsc/psmodule.rb
+++ b/build/dsc/psmodule.rb
@@ -18,7 +18,7 @@ module Dsc
       begin
         unless @attributes
           attrs = {}
-          regex = /^(.*) *= *['"](.*)['"] *$/
+          regex = /^(.*) *= *['"](.*)['"] *(;)? *$/
           File.open(@module_manifest_path, 'r') do |psd1|
             content = File.read(psd1)
             utf8_encoded_content = utf8_encode_content(content)


### PR DESCRIPTION
This PR fixes the regex that parses the DSC Resource module manifest
files to correctly parse the module version.

A PowerShell psd1 manifest file follows the syntax for a PowerShell
hash. It allows newlines as well as semi-colons to deliminate each item
in the hash. It is not normal syntax to use semi-colons inside a hash
that is using newlines already, but it is still valid so the regex is
adjusted to accept it.