### PR TITLE
(MODULES-5743) Support Sensitive in MSFT_Credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ dsc_example_resource { 'examplefoo':
 
 DSC uses `MSFT_Credential` objects to pass credentials to DSC Resources. Supply a hash to any `credential` parameter, and Puppet handles creating the `credential` object for you.
 
+Optionally use the Puppet [Sensitive type](https://puppet.com/docs/puppet/latest/lang_data_sensitive.html) to ensure logs and reports redact the password.
+
 ~~~puppet
 dsc_user { 'jane-doe':
   dsc_username             => 'jane-doe',
@@ -182,7 +184,7 @@ dsc_user { 'jane-doe':
   dsc_ensure               => present,
   dsc_password             => {
     'user' => 'jane-doe',
-    'password' => 'jane-password'
+    'password' => Sensitive('jane-password')
   },
   dsc_passwordneverexpires => false,
   dsc_disabled             => true,

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -84,7 +84,7 @@ EOT
     Puppet.debug "PowerShell Version: #{version}"
     script_content = ps_script_content('test')
     Puppet.debug "\n" + script_content
-    
+
     fail DSC_MODULE_POWERSHELL_UPGRADE_MSG if !PuppetX::Dsc::PowerShellManager.compatible_version_of_powershell?
 
     if !PuppetX::Dsc::PowerShellManager.supported?
@@ -179,6 +179,8 @@ EOT
       "@(" + dsc_value.collect{|m| format_dsc_value(m)}.join(', ') + ")"
     when dsc_value.class.name == 'Hash'
       "@{" + dsc_value.collect{|k, v| format_dsc_value(k) + ' = ' + format_dsc_value(v)}.join('; ') + "}"
+    when dsc_value.class.name == 'Puppet::Pops::Types::PSensitiveType::Sensitive'
+      "'#{escape_quotes(dsc_value.unwrap)}'"
     else
       fail "unsupported type #{dsc_value.class} of value '#{dsc_value}'"
     end

--- a/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_type_helpers.rb
@@ -48,8 +48,10 @@ module PuppetX
         required = ['user', 'password']
         required.each do |key|
           if value[key]
-            fail "#{key} for #{name} should be a String" unless value[key].is_a? String
-            fail "#{key} must not be empty" if value[key].empty?
+            unless (value[key].is_a? String) || (value[key].is_a? Puppet::Pops::Types::PSensitiveType::Sensitive)
+              fail "#{key} for #{name} should be a String or Sensitive value"
+            end
+            fail "#{key} must not be empty" if value[key].to_s.empty?
           end
         end
 

--- a/spec/unit/puppet_x/puppetlabs/dsc_type_helpers_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/dsc_type_helpers_spec.rb
@@ -1,0 +1,23 @@
+#! /usr/bin/env ruby
+require 'spec_helper'
+require 'puppet_x/puppetlabs/dsc_type_helpers'
+
+describe PuppetX::Dsc::TypeHelpers do
+  describe "#validate_MSFT_Credential" do
+
+    it "should allow plaintext strings as passwords" do
+      cred = { 'user' => 'bob', 'password' => 'password' }
+      expect {
+        subject.class.validate_MSFT_Credential('foo', cred)
+      }.to_not raise_error
+    end
+
+    it "should allow Sensitive type passwords" do
+      sensitive_pass = Puppet::Pops::Types::PSensitiveType::Sensitive.new('password')
+      cred = { 'user' => 'bob', 'password' => sensitive_pass }
+      expect {
+        subject.class.validate_MSFT_Credential('foo', cred)
+      }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
 - Previously a password could not be specified in a MSFT_Credential
   based attribute of a given resource, due to strict validation that
   was only allowing strings.

   Sensitive was initially added in Puppet 4.6.0 and fully fleshed out
   by Puppet 4.8.0. This module currently supports a minimum of
   Puppet 4.7.0 and therefore users should be expected to use
   Sensitive for password fields (example updated in README).

 - Added new tests for type helpers demonstrating the ability for
   MSFT_Credential to allow Sensitive.