### PR TITLE
(maint) Fix (acceptance|integration)_tests.sh

### DIFF
--- a/tests/test_run_scripts/acceptance_tests.sh
+++ b/tests/test_run_scripts/acceptance_tests.sh
@@ -51,7 +51,10 @@ sleep 2
 export BEAKER_PUPPET_AGENT_VERSION=${ARGS[1]}
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
 
-bundle install --without build development test --path .bundle/gems
+bundle check
+if [[ $? != 0 ]]; then
+  bundle install --without build --path .bundle/gems
+fi
 
 bundle exec beaker \
   --preserve-hosts onfail \

--- a/tests/test_run_scripts/integration_tests.sh
+++ b/tests/test_run_scripts/integration_tests.sh
@@ -50,7 +50,10 @@ sleep 2
 export pe_dist_dir=${ARGS[1]}
 export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net
 
-bundle install --without build development test --path .bundle/gems
+bundle check
+if [[ $? != 0 ]]; then
+  bundle install --without build --path .bundle/gems
+fi
 
 bundle exec beaker \
   --preserve-hosts onfail \


### PR DESCRIPTION
 - Typically a bundle is already installed that includes all the gems
   necessary to run Beaker based "integration" and "acceptance" tests.

   So running `bundle install` is mostly unnecessary.

   Furthermore, running this command with a gemset already installed
   will write or alter the local `.bundle/config`, adding the line:

   BUNDLE_WITHOUT: "build:test:development"

   This prevents the ability to run `bundle exec rake spec` since the
   Rake gem is loaded in the development group, resulting in an error:

```
bundler: failed to load command: rake (/Users/Iristyle/source/puppetlabs-dsc_lite/.bundle/gems/ruby/2.4.0/bin/rake)
Gem::Exception: can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile?
  /usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/rubygems_integration.rb:432:in `block in replace_bin_path'
  /usr/local/opt/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/rubygems_integration.rb:452:in `block in replace_bin_path'
  /Users/Iristyle/source/puppetlabs-dsc_lite/.bundle/gems/ruby/2.4.0/bin/rake:22:in `<top (required)>'
```

 - There isn't a `test` gem group anymore, so remove both it and
   `development` from the `--without` clause