### PR TITLE
(MODULES-4748) Increase timeout for opening PowerShell

### DIFF
--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -54,8 +54,8 @@ module PuppetX
         pipe_path = "\\\\.\\pipe\\#{named_pipe_name}"
         # wait for the pipe server to signal ready, and fail if no response in 10 seconds
 
-        # wait up to 10 seconds in 0.2 second intervals to be able to open the pipe
-        50.times do
+        # wait up to 30 seconds in 0.2 second intervals to be able to open the pipe
+        150.times do
           begin
             # pipe is opened in binary mode and must always
             @pipe = File.open(pipe_path, 'r+b')


### PR DESCRIPTION
Prior to this commit, the timeout waiting for PowerShell to start
was only 10 seconds; this was not, in practice, a long enough
period of time for multiple customers, especially when a node is
under heavy load. This commit increases the timeout to 30 seconds.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-dsc/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=13413&summary=%5BDSC%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
