### PR TITLE
(MODULES-4748) Prevent zombie procs from timeout

### DIFF
--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -58,6 +58,18 @@ describe PuppetX::Dsc::PowerShellManager,
         expect(first_pid).to eq(second_pid)
       end
 
+      it "should fail if the manger is created with a short timeout" do
+        expect {
+          PuppetX::Dsc::PowerShellManager.new(manager_args, false, 0.01)
+        }.to raise_error do |e|
+          expect(e).to be_a(RuntimeError)
+          expected_error = /Failure waiting for PowerShell process (\d+) to start pipe server/
+          expect(e.message).to match expected_error
+          pid = expected_error.match(e.message)[1].to_i
+          expect{Process.kill(0, pid)}.to raise_error(Errno::ESRCH)
+        end
+      end
+
       def bad_file_descriptor_regex
         # Ruby can do something like:
         # <Errno::EBADF: Bad file descriptor>


### PR DESCRIPTION
Prior to this commit if a timeout occurs while waiting for the
connection to a named pipe then a zombie process is left on the
system as the code to close or kill it is never called. This commit
ensures that such zombie processes are removed before the error is
raised.

This commit also adds an RSPEC test to validate that if we try to
create a manager with an unreasonably low timeout value, that the
manager will not have time to open the pipes server and it will
fail to create the manager and further verify that no zombie
processes are left running.

Paired-with: Bill Hurt <william.hurt@puppet.com>