### PR TITLE
(MAINT) Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: false
 language: ruby
 cache: bundler
 script: "bundle exec rake release_checks"
-#Inserting below due to the following issue: https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203
-before_install:
-  - gem update bundler
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
This commit updates the Travis config to remove the erroneous
`before_install` setting which is causing CI to fail. This
should be captured in the near future in a modsync update.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-dsc/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=13413&summary=%5BDSC%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
