### PR TITLE
(Maint) Bump reboot dep

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/reboot",
-      "version_requirement": ">= 1.2.1 < 2.0.0"
+      "version_requirement": ">= 1.2.1 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
We released puppetlabs/reboot 2.0, which causes problems with modules
that have a dependancy set to < 2.0.0. This fix ensures the module will
resolve the dependency properly.