### PR TITLE
(MODULES-6694) Fix rake checkout task

### DIFF
--- a/build/dsc.rake
+++ b/build/dsc.rake
@@ -77,6 +77,7 @@ eod
 
         Rake::Task['dsc:resources:checkout'].invoke(
           community_dsc_resources_root, update_versions, composite_resources)
+        Rake::Task['dsc:resources:checkout'].reenable
         Rake::Task['dsc:resources:checkout'].invoke(
           official_dsc_resources_root, update_versions, composite_resources)
 


### PR DESCRIPTION
This commit fixes the rake checkout task by reenabling it after the
first invocation so that it will process both xDscResource and
DscResource folders.

The rake checkout task will use the dsc_resource_tags.yml file to
checkout the correct git tag. This works the first time it's called when
processing the xDscResource folder. However since rake by default will
only run a task once, when the DscResource folder is processed next it
just skips it without error or warning. This has not popped up before
because before commit 08c8fc0705b6c7cc789f0e55cfb4463afa27fc02 we
weren't correctly updating dsc_resource_tags.yml with any HQ Dsc
Resources, so we couldn't have ever tried to pin a version.