### PR TITLE
(MODULES-6859) Create `dsc` feature for confines

### DIFF
--- a/build/dsc/templates/dsc_type.rb.erb
+++ b/build/dsc/templates/dsc_type.rb.erb
@@ -262,7 +262,7 @@ Puppet::Type.newtype(:dsc_<%= resource.friendlyname.downcase %>) do
 end
 
 Puppet::Type.type(:dsc_<%= resource.friendlyname.downcase %>).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/feature/dsc.rb
+++ b/lib/puppet/feature/dsc.rb
@@ -1,0 +1,20 @@
+require 'puppet/util/feature'
+
+if Puppet.features.microsoft_windows?
+  required_version = Gem::Version.new('5.0.10586.117')
+  installed_version = Gem::Version.new(Facter.value(:powershell_version))
+
+  if (installed_version >= required_version)
+    Puppet.features.add(:dsc)
+  else
+    Puppet.warn_once(
+      'dsc_unavailable',
+      :dsc_unavailable,
+      _("The dsc module requires PowerShell version %{required} - current version %{current}") %
+        { :required => required_version, :current => installed_version},
+      nil,
+      nil,
+      :err
+    )
+  end
+end

--- a/lib/puppet/type/dsc_accountpolicy.rb
+++ b/lib/puppet/type/dsc_accountpolicy.rb
@@ -330,7 +330,7 @@ Puppet::Type.newtype(:dsc_accountpolicy) do
 end
 
 Puppet::Type.type(:dsc_accountpolicy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -180,7 +180,7 @@ Puppet::Type.newtype(:dsc_archive) do
 end
 
 Puppet::Type.type(:dsc_archive).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_auditpolicycsv.rb
+++ b/lib/puppet/type/dsc_auditpolicycsv.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:dsc_auditpolicycsv) do
 end
 
 Puppet::Type.type(:dsc_auditpolicycsv).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_auditpolicyoption.rb
+++ b/lib/puppet/type/dsc_auditpolicyoption.rb
@@ -101,7 +101,7 @@ Puppet::Type.newtype(:dsc_auditpolicyoption) do
 end
 
 Puppet::Type.type(:dsc_auditpolicyoption).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_auditpolicysubcategory.rb
+++ b/lib/puppet/type/dsc_auditpolicysubcategory.rb
@@ -118,7 +118,7 @@ Puppet::Type.newtype(:dsc_auditpolicysubcategory) do
 end
 
 Puppet::Type.type(:dsc_auditpolicysubcategory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_disk.rb
+++ b/lib/puppet/type/dsc_disk.rb
@@ -212,7 +212,7 @@ Puppet::Type.newtype(:dsc_disk) do
 end
 
 Puppet::Type.type(:dsc_disk).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_diskaccesspath.rb
+++ b/lib/puppet/type/dsc_diskaccesspath.rb
@@ -180,7 +180,7 @@ Puppet::Type.newtype(:dsc_diskaccesspath) do
 end
 
 Puppet::Type.type(:dsc_diskaccesspath).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -128,7 +128,7 @@ Puppet::Type.newtype(:dsc_environment) do
 end
 
 Puppet::Type.type(:dsc_environment).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -273,7 +273,7 @@ Puppet::Type.newtype(:dsc_file) do
 end
 
 Puppet::Type.type(:dsc_file).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -182,7 +182,7 @@ Puppet::Type.newtype(:dsc_group) do
 end
 
 Puppet::Type.type(:dsc_group).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -75,7 +75,7 @@ Puppet::Type.newtype(:dsc_log) do
 end
 
 Puppet::Type.type(:dsc_log).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_mountimage.rb
+++ b/lib/puppet/type/dsc_mountimage.rb
@@ -149,7 +149,7 @@ Puppet::Type.newtype(:dsc_mountimage) do
 end
 
 Puppet::Type.type(:dsc_mountimage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_officeonlineserverfarm.rb
+++ b/lib/puppet/type/dsc_officeonlineserverfarm.rb
@@ -884,7 +884,7 @@ Puppet::Type.newtype(:dsc_officeonlineserverfarm) do
 end
 
 Puppet::Type.type(:dsc_officeonlineserverfarm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_officeonlineserverinstall.rb
+++ b/lib/puppet/type/dsc_officeonlineserverinstall.rb
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_officeonlineserverinstall) do
 end
 
 Puppet::Type.type(:dsc_officeonlineserverinstall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_officeonlineserverinstalllanguagepack.rb
+++ b/lib/puppet/type/dsc_officeonlineserverinstalllanguagepack.rb
@@ -115,7 +115,7 @@ Puppet::Type.newtype(:dsc_officeonlineserverinstalllanguagepack) do
 end
 
 Puppet::Type.type(:dsc_officeonlineserverinstalllanguagepack).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_officeonlineservermachine.rb
+++ b/lib/puppet/type/dsc_officeonlineservermachine.rb
@@ -116,7 +116,7 @@ Puppet::Type.newtype(:dsc_officeonlineservermachine) do
 end
 
 Puppet::Type.type(:dsc_officeonlineservermachine).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_opticaldiskdriveletter.rb
+++ b/lib/puppet/type/dsc_opticaldiskdriveletter.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_opticaldiskdriveletter) do
 end
 
 Puppet::Type.type(:dsc_opticaldiskdriveletter).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -288,7 +288,7 @@ Puppet::Type.newtype(:dsc_package) do
 end
 
 Puppet::Type.type(:dsc_package).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -182,7 +182,7 @@ Puppet::Type.newtype(:dsc_registry) do
 end
 
 Puppet::Type.type(:dsc_registry).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_runbookdirectory.rb
+++ b/lib/puppet/type/dsc_runbookdirectory.rb
@@ -150,7 +150,7 @@ Puppet::Type.newtype(:dsc_runbookdirectory) do
 end
 
 Puppet::Type.type(:dsc_runbookdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -142,7 +142,7 @@ Puppet::Type.newtype(:dsc_script) do
 end
 
 Puppet::Type.type(:dsc_script).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_securityoption.rb
+++ b/lib/puppet/type/dsc_securityoption.rb
@@ -1591,7 +1591,7 @@ Puppet::Type.newtype(:dsc_securityoption) do
 end
 
 Puppet::Type.type(:dsc_securityoption).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_securitytemplate.rb
+++ b/lib/puppet/type/dsc_securitytemplate.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:dsc_securitytemplate) do
 end
 
 Puppet::Type.type(:dsc_securitytemplate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -245,7 +245,7 @@ Puppet::Type.newtype(:dsc_service) do
 end
 
 Puppet::Type.type(:dsc_service).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_smavariable.rb
+++ b/lib/puppet/type/dsc_smavariable.rb
@@ -179,7 +179,7 @@ Puppet::Type.newtype(:dsc_smavariable) do
 end
 
 Puppet::Type.type(:dsc_smavariable).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spaccessserviceapp.rb
+++ b/lib/puppet/type/dsc_spaccessserviceapp.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_spaccessserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spaccessserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spaccessservices2010.rb
+++ b/lib/puppet/type/dsc_spaccessservices2010.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_spaccessservices2010) do
 end
 
 Puppet::Type.type(:dsc_spaccessservices2010).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spalternateurl.rb
+++ b/lib/puppet/type/dsc_spalternateurl.rb
@@ -167,7 +167,7 @@ Puppet::Type.newtype(:dsc_spalternateurl) do
 end
 
 Puppet::Type.type(:dsc_spalternateurl).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spantivirussettings.rb
+++ b/lib/puppet/type/dsc_spantivirussettings.rb
@@ -179,7 +179,7 @@ Puppet::Type.newtype(:dsc_spantivirussettings) do
 end
 
 Puppet::Type.type(:dsc_spantivirussettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spappcatalog.rb
+++ b/lib/puppet/type/dsc_spappcatalog.rb
@@ -94,7 +94,7 @@ Puppet::Type.newtype(:dsc_spappcatalog) do
 end
 
 Puppet::Type.type(:dsc_spappcatalog).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spappdomain.rb
+++ b/lib/puppet/type/dsc_spappdomain.rb
@@ -109,7 +109,7 @@ Puppet::Type.newtype(:dsc_spappdomain) do
 end
 
 Puppet::Type.type(:dsc_spappdomain).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spappmanagementserviceapp.rb
+++ b/lib/puppet/type/dsc_spappmanagementserviceapp.rb
@@ -174,7 +174,7 @@ Puppet::Type.newtype(:dsc_spappmanagementserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spappmanagementserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spappstoresettings.rb
+++ b/lib/puppet/type/dsc_spappstoresettings.rb
@@ -126,7 +126,7 @@ Puppet::Type.newtype(:dsc_spappstoresettings) do
 end
 
 Puppet::Type.type(:dsc_spappstoresettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spbcsserviceapp.rb
+++ b/lib/puppet/type/dsc_spbcsserviceapp.rb
@@ -174,7 +174,7 @@ Puppet::Type.newtype(:dsc_spbcsserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spbcsserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spblobcachesettings.rb
+++ b/lib/puppet/type/dsc_spblobcachesettings.rb
@@ -196,7 +196,7 @@ Puppet::Type.newtype(:dsc_spblobcachesettings) do
 end
 
 Puppet::Type.type(:dsc_spblobcachesettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spcacheaccounts.rb
+++ b/lib/puppet/type/dsc_spcacheaccounts.rb
@@ -140,7 +140,7 @@ Puppet::Type.newtype(:dsc_spcacheaccounts) do
 end
 
 Puppet::Type.type(:dsc_spcacheaccounts).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spconfigwizard.rb
+++ b/lib/puppet/type/dsc_spconfigwizard.rb
@@ -142,7 +142,7 @@ Puppet::Type.newtype(:dsc_spconfigwizard) do
 end
 
 Puppet::Type.type(:dsc_spconfigwizard).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spcontentdatabase.rb
+++ b/lib/puppet/type/dsc_spcontentdatabase.rb
@@ -196,7 +196,7 @@ Puppet::Type.newtype(:dsc_spcontentdatabase) do
 end
 
 Puppet::Type.type(:dsc_spcontentdatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spcreatefarm.rb
+++ b/lib/puppet/type/dsc_spcreatefarm.rb
@@ -212,7 +212,7 @@ Puppet::Type.newtype(:dsc_spcreatefarm) do
 end
 
 Puppet::Type.type(:dsc_spcreatefarm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spdatabaseaag.rb
+++ b/lib/puppet/type/dsc_spdatabaseaag.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_spdatabaseaag) do
 end
 
 Puppet::Type.type(:dsc_spdatabaseaag).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spdesignersettings.rb
+++ b/lib/puppet/type/dsc_spdesignersettings.rb
@@ -224,7 +224,7 @@ Puppet::Type.newtype(:dsc_spdesignersettings) do
 end
 
 Puppet::Type.type(:dsc_spdesignersettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spdiagnosticloggingsettings.rb
+++ b/lib/puppet/type/dsc_spdiagnosticloggingsettings.rb
@@ -382,7 +382,7 @@ Puppet::Type.newtype(:dsc_spdiagnosticloggingsettings) do
 end
 
 Puppet::Type.type(:dsc_spdiagnosticloggingsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spdiagnosticsprovider.rb
+++ b/lib/puppet/type/dsc_spdiagnosticsprovider.rb
@@ -166,7 +166,7 @@ Puppet::Type.newtype(:dsc_spdiagnosticsprovider) do
 end
 
 Puppet::Type.type(:dsc_spdiagnosticsprovider).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spdistributedcacheservice.rb
+++ b/lib/puppet/type/dsc_spdistributedcacheservice.rb
@@ -181,7 +181,7 @@ Puppet::Type.newtype(:dsc_spdistributedcacheservice) do
 end
 
 Puppet::Type.type(:dsc_spdistributedcacheservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spexcelserviceapp.rb
+++ b/lib/puppet/type/dsc_spexcelserviceapp.rb
@@ -456,7 +456,7 @@ Puppet::Type.newtype(:dsc_spexcelserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spexcelserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spfarm.rb
+++ b/lib/puppet/type/dsc_spfarm.rb
@@ -246,7 +246,7 @@ Puppet::Type.newtype(:dsc_spfarm) do
 end
 
 Puppet::Type.type(:dsc_spfarm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spfarmadministrators.rb
+++ b/lib/puppet/type/dsc_spfarmadministrators.rb
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_spfarmadministrators) do
 end
 
 Puppet::Type.type(:dsc_spfarmadministrators).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spfarmpropertybag.rb
+++ b/lib/puppet/type/dsc_spfarmpropertybag.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_spfarmpropertybag) do
 end
 
 Puppet::Type.type(:dsc_spfarmpropertybag).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spfarmsolution.rb
+++ b/lib/puppet/type/dsc_spfarmsolution.rb
@@ -196,7 +196,7 @@ Puppet::Type.newtype(:dsc_spfarmsolution) do
 end
 
 Puppet::Type.type(:dsc_spfarmsolution).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spfeature.rb
+++ b/lib/puppet/type/dsc_spfeature.rb
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_spfeature) do
 end
 
 Puppet::Type.type(:dsc_spfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sphealthanalyzerrulestate.rb
+++ b/lib/puppet/type/dsc_sphealthanalyzerrulestate.rb
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_sphealthanalyzerrulestate) do
 end
 
 Puppet::Type.type(:dsc_sphealthanalyzerrulestate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spinfopathformsserviceconfig.rb
+++ b/lib/puppet/type/dsc_spinfopathformsserviceconfig.rb
@@ -321,7 +321,7 @@ Puppet::Type.newtype(:dsc_spinfopathformsserviceconfig) do
 end
 
 Puppet::Type.type(:dsc_spinfopathformsserviceconfig).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spinstall.rb
+++ b/lib/puppet/type/dsc_spinstall.rb
@@ -143,7 +143,7 @@ Puppet::Type.newtype(:dsc_spinstall) do
 end
 
 Puppet::Type.type(:dsc_spinstall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spinstalllanguagepack.rb
+++ b/lib/puppet/type/dsc_spinstalllanguagepack.rb
@@ -157,7 +157,7 @@ Puppet::Type.newtype(:dsc_spinstalllanguagepack) do
 end
 
 Puppet::Type.type(:dsc_spinstalllanguagepack).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spinstallprereqs.rb
+++ b/lib/puppet/type/dsc_spinstallprereqs.rb
@@ -369,7 +369,7 @@ Puppet::Type.newtype(:dsc_spinstallprereqs) do
 end
 
 Puppet::Type.type(:dsc_spinstallprereqs).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spirmsettings.rb
+++ b/lib/puppet/type/dsc_spirmsettings.rb
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:dsc_spirmsettings) do
 end
 
 Puppet::Type.type(:dsc_spirmsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spjoinfarm.rb
+++ b/lib/puppet/type/dsc_spjoinfarm.rb
@@ -145,7 +145,7 @@ Puppet::Type.newtype(:dsc_spjoinfarm) do
 end
 
 Puppet::Type.type(:dsc_spjoinfarm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sploglevel.rb
+++ b/lib/puppet/type/dsc_sploglevel.rb
@@ -145,7 +145,7 @@ Puppet::Type.newtype(:dsc_sploglevel) do
 end
 
 Puppet::Type.type(:dsc_sploglevel).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spmachinetranslationserviceapp.rb
+++ b/lib/puppet/type/dsc_spmachinetranslationserviceapp.rb
@@ -174,7 +174,7 @@ Puppet::Type.newtype(:dsc_spmachinetranslationserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spmachinetranslationserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spmanagedaccount.rb
+++ b/lib/puppet/type/dsc_spmanagedaccount.rb
@@ -181,7 +181,7 @@ Puppet::Type.newtype(:dsc_spmanagedaccount) do
 end
 
 Puppet::Type.type(:dsc_spmanagedaccount).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spmanagedmetadataserviceapp.rb
+++ b/lib/puppet/type/dsc_spmanagedmetadataserviceapp.rb
@@ -244,7 +244,7 @@ Puppet::Type.newtype(:dsc_spmanagedmetadataserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spmanagedmetadataserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spmanagedmetadataserviceappdefault.rb
+++ b/lib/puppet/type/dsc_spmanagedmetadataserviceappdefault.rb
@@ -127,7 +127,7 @@ Puppet::Type.newtype(:dsc_spmanagedmetadataserviceappdefault) do
 end
 
 Puppet::Type.type(:dsc_spmanagedmetadataserviceappdefault).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spmanagedpath.rb
+++ b/lib/puppet/type/dsc_spmanagedpath.rb
@@ -163,7 +163,7 @@ Puppet::Type.newtype(:dsc_spmanagedpath) do
 end
 
 Puppet::Type.type(:dsc_spmanagedpath).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spminrolecompliance.rb
+++ b/lib/puppet/type/dsc_spminrolecompliance.rb
@@ -97,7 +97,7 @@ Puppet::Type.newtype(:dsc_spminrolecompliance) do
 end
 
 Puppet::Type.type(:dsc_spminrolecompliance).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spofficeonlineserverbinding.rb
+++ b/lib/puppet/type/dsc_spofficeonlineserverbinding.rb
@@ -132,7 +132,7 @@ Puppet::Type.newtype(:dsc_spofficeonlineserverbinding) do
 end
 
 Puppet::Type.type(:dsc_spofficeonlineserverbinding).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spoutgoingemailsettings.rb
+++ b/lib/puppet/type/dsc_spoutgoingemailsettings.rb
@@ -188,7 +188,7 @@ Puppet::Type.newtype(:dsc_spoutgoingemailsettings) do
 end
 
 Puppet::Type.type(:dsc_spoutgoingemailsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sppasswordchangesettings.rb
+++ b/lib/puppet/type/dsc_sppasswordchangesettings.rb
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_sppasswordchangesettings) do
 end
 
 Puppet::Type.type(:dsc_sppasswordchangesettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spperformancepointserviceapp.rb
+++ b/lib/puppet/type/dsc_spperformancepointserviceapp.rb
@@ -174,7 +174,7 @@ Puppet::Type.newtype(:dsc_spperformancepointserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spperformancepointserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sppowerpointautomationserviceapp.rb
+++ b/lib/puppet/type/dsc_sppowerpointautomationserviceapp.rb
@@ -234,7 +234,7 @@ Puppet::Type.newtype(:dsc_sppowerpointautomationserviceapp) do
 end
 
 Puppet::Type.type(:dsc_sppowerpointautomationserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spproductupdate.rb
+++ b/lib/puppet/type/dsc_spproductupdate.rb
@@ -173,7 +173,7 @@ Puppet::Type.newtype(:dsc_spproductupdate) do
 end
 
 Puppet::Type.type(:dsc_spproductupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectserveradditionalsettings.rb
+++ b/lib/puppet/type/dsc_spprojectserveradditionalsettings.rb
@@ -140,7 +140,7 @@ Puppet::Type.newtype(:dsc_spprojectserveradditionalsettings) do
 end
 
 Puppet::Type.type(:dsc_spprojectserveradditionalsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectserveradresourcepoolsync.rb
+++ b/lib/puppet/type/dsc_spprojectserveradresourcepoolsync.rb
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_spprojectserveradresourcepoolsync) do
 end
 
 Puppet::Type.type(:dsc_spprojectserveradresourcepoolsync).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectserverglobalpermissions.rb
+++ b/lib/puppet/type/dsc_spprojectserverglobalpermissions.rb
@@ -167,7 +167,7 @@ Puppet::Type.newtype(:dsc_spprojectserverglobalpermissions) do
 end
 
 Puppet::Type.type(:dsc_spprojectserverglobalpermissions).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectservergroup.rb
+++ b/lib/puppet/type/dsc_spprojectservergroup.rb
@@ -215,7 +215,7 @@ Puppet::Type.newtype(:dsc_spprojectservergroup) do
 end
 
 Puppet::Type.type(:dsc_spprojectservergroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectserverlicense.rb
+++ b/lib/puppet/type/dsc_spprojectserverlicense.rb
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:dsc_spprojectserverlicense) do
 end
 
 Puppet::Type.type(:dsc_spprojectserverlicense).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectserverpermissionmode.rb
+++ b/lib/puppet/type/dsc_spprojectserverpermissionmode.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:dsc_spprojectserverpermissionmode) do
 end
 
 Puppet::Type.type(:dsc_spprojectserverpermissionmode).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectserverserviceapp.rb
+++ b/lib/puppet/type/dsc_spprojectserverserviceapp.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_spprojectserverserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spprojectserverserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectservertimesheetsettings.rb
+++ b/lib/puppet/type/dsc_spprojectservertimesheetsettings.rb
@@ -401,7 +401,7 @@ Puppet::Type.newtype(:dsc_spprojectservertimesheetsettings) do
 end
 
 Puppet::Type.type(:dsc_spprojectservertimesheetsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectserverusersyncsettings.rb
+++ b/lib/puppet/type/dsc_spprojectserverusersyncsettings.rb
@@ -142,7 +142,7 @@ Puppet::Type.newtype(:dsc_spprojectserverusersyncsettings) do
 end
 
 Puppet::Type.type(:dsc_spprojectserverusersyncsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spprojectserverwsssettings.rb
+++ b/lib/puppet/type/dsc_spprojectserverwsssettings.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:dsc_spprojectserverwsssettings) do
 end
 
 Puppet::Type.type(:dsc_spprojectserverwsssettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sppublishserviceapplication.rb
+++ b/lib/puppet/type/dsc_sppublishserviceapplication.rb
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:dsc_sppublishserviceapplication) do
 end
 
 Puppet::Type.type(:dsc_sppublishserviceapplication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spquotatemplate.rb
+++ b/lib/puppet/type/dsc_spquotatemplate.rb
@@ -186,7 +186,7 @@ Puppet::Type.newtype(:dsc_spquotatemplate) do
 end
 
 Puppet::Type.type(:dsc_spquotatemplate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spremotefarmtrust.rb
+++ b/lib/puppet/type/dsc_spremotefarmtrust.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_spremotefarmtrust) do
 end
 
 Puppet::Type.type(:dsc_spremotefarmtrust).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchauthoritativepage.rb
+++ b/lib/puppet/type/dsc_spsearchauthoritativepage.rb
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_spsearchauthoritativepage) do
 end
 
 Puppet::Type.type(:dsc_spsearchauthoritativepage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchcontentsource.rb
+++ b/lib/puppet/type/dsc_spsearchcontentsource.rb
@@ -338,7 +338,7 @@ Puppet::Type.newtype(:dsc_spsearchcontentsource) do
 end
 
 Puppet::Type.type(:dsc_spsearchcontentsource).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchcrawlerimpactrule.rb
+++ b/lib/puppet/type/dsc_spsearchcrawlerimpactrule.rb
@@ -182,7 +182,7 @@ Puppet::Type.newtype(:dsc_spsearchcrawlerimpactrule) do
 end
 
 Puppet::Type.type(:dsc_spsearchcrawlerimpactrule).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchcrawlmapping.rb
+++ b/lib/puppet/type/dsc_spsearchcrawlmapping.rb
@@ -146,7 +146,7 @@ Puppet::Type.newtype(:dsc_spsearchcrawlmapping) do
 end
 
 Puppet::Type.type(:dsc_spsearchcrawlmapping).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchcrawlrule.rb
+++ b/lib/puppet/type/dsc_spsearchcrawlrule.rb
@@ -224,7 +224,7 @@ Puppet::Type.newtype(:dsc_spsearchcrawlrule) do
 end
 
 Puppet::Type.type(:dsc_spsearchcrawlrule).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchfiletype.rb
+++ b/lib/puppet/type/dsc_spsearchfiletype.rb
@@ -177,7 +177,7 @@ Puppet::Type.newtype(:dsc_spsearchfiletype) do
 end
 
 Puppet::Type.type(:dsc_spsearchfiletype).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchindexpartition.rb
+++ b/lib/puppet/type/dsc_spsearchindexpartition.rb
@@ -147,7 +147,7 @@ Puppet::Type.newtype(:dsc_spsearchindexpartition) do
 end
 
 Puppet::Type.type(:dsc_spsearchindexpartition).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchresultsource.rb
+++ b/lib/puppet/type/dsc_spsearchresultsource.rb
@@ -177,7 +177,7 @@ Puppet::Type.newtype(:dsc_spsearchresultsource) do
 end
 
 Puppet::Type.type(:dsc_spsearchresultsource).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchserviceapp.rb
+++ b/lib/puppet/type/dsc_spsearchserviceapp.rb
@@ -237,7 +237,7 @@ Puppet::Type.newtype(:dsc_spsearchserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spsearchserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsearchtopology.rb
+++ b/lib/puppet/type/dsc_spsearchtopology.rb
@@ -217,7 +217,7 @@ Puppet::Type.newtype(:dsc_spsearchtopology) do
 end
 
 Puppet::Type.type(:dsc_spsearchtopology).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsecurestoreserviceapp.rb
+++ b/lib/puppet/type/dsc_spsecurestoreserviceapp.rb
@@ -289,7 +289,7 @@ Puppet::Type.newtype(:dsc_spsecurestoreserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spsecurestoreserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsecuritytokenserviceconfig.rb
+++ b/lib/puppet/type/dsc_spsecuritytokenserviceconfig.rb
@@ -177,7 +177,7 @@ Puppet::Type.newtype(:dsc_spsecuritytokenserviceconfig) do
 end
 
 Puppet::Type.type(:dsc_spsecuritytokenserviceconfig).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spserviceapppool.rb
+++ b/lib/puppet/type/dsc_spserviceapppool.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_spserviceapppool) do
 end
 
 Puppet::Type.type(:dsc_spserviceapppool).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spserviceappproxygroup.rb
+++ b/lib/puppet/type/dsc_spserviceappproxygroup.rb
@@ -168,7 +168,7 @@ Puppet::Type.newtype(:dsc_spserviceappproxygroup) do
 end
 
 Puppet::Type.type(:dsc_spserviceappproxygroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spserviceappsecurity.rb
+++ b/lib/puppet/type/dsc_spserviceappsecurity.rb
@@ -211,7 +211,7 @@ Puppet::Type.newtype(:dsc_spserviceappsecurity) do
 end
 
 Puppet::Type.type(:dsc_spserviceappsecurity).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spserviceidentity.rb
+++ b/lib/puppet/type/dsc_spserviceidentity.rb
@@ -109,7 +109,7 @@ Puppet::Type.newtype(:dsc_spserviceidentity) do
 end
 
 Puppet::Type.type(:dsc_spserviceidentity).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spserviceinstance.rb
+++ b/lib/puppet/type/dsc_spserviceinstance.rb
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:dsc_spserviceinstance) do
 end
 
 Puppet::Type.type(:dsc_spserviceinstance).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsessionstateservice.rb
+++ b/lib/puppet/type/dsc_spsessionstateservice.rb
@@ -149,7 +149,7 @@ Puppet::Type.newtype(:dsc_spsessionstateservice) do
 end
 
 Puppet::Type.type(:dsc_spsessionstateservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spshelladmins.rb
+++ b/lib/puppet/type/dsc_spshelladmins.rb
@@ -215,7 +215,7 @@ Puppet::Type.newtype(:dsc_spshelladmins) do
 end
 
 Puppet::Type.type(:dsc_spshelladmins).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsite.rb
+++ b/lib/puppet/type/dsc_spsite.rb
@@ -280,7 +280,7 @@ Puppet::Type.newtype(:dsc_spsite) do
 end
 
 Puppet::Type.type(:dsc_spsite).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spstateserviceapp.rb
+++ b/lib/puppet/type/dsc_spstateserviceapp.rb
@@ -175,7 +175,7 @@ Puppet::Type.newtype(:dsc_spstateserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spstateserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spsubscriptionsettingsserviceapp.rb
+++ b/lib/puppet/type/dsc_spsubscriptionsettingsserviceapp.rb
@@ -159,7 +159,7 @@ Puppet::Type.newtype(:dsc_spsubscriptionsettingsserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spsubscriptionsettingsserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sptimerjobstate.rb
+++ b/lib/puppet/type/dsc_sptimerjobstate.rb
@@ -142,7 +142,7 @@ Puppet::Type.newtype(:dsc_sptimerjobstate) do
 end
 
 Puppet::Type.type(:dsc_sptimerjobstate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sptrustedidentitytokenissuer.rb
+++ b/lib/puppet/type/dsc_sptrustedidentitytokenissuer.rb
@@ -285,7 +285,7 @@ Puppet::Type.newtype(:dsc_sptrustedidentitytokenissuer) do
 end
 
 Puppet::Type.type(:dsc_sptrustedidentitytokenissuer).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sptrustedrootauthority.rb
+++ b/lib/puppet/type/dsc_sptrustedrootauthority.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_sptrustedrootauthority) do
 end
 
 Puppet::Type.type(:dsc_sptrustedrootauthority).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spusageapplication.rb
+++ b/lib/puppet/type/dsc_spusageapplication.rb
@@ -244,7 +244,7 @@ Puppet::Type.newtype(:dsc_spusageapplication) do
 end
 
 Puppet::Type.type(:dsc_spusageapplication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spuserprofileproperty.rb
+++ b/lib/puppet/type/dsc_spuserprofileproperty.rb
@@ -451,7 +451,7 @@ Puppet::Type.newtype(:dsc_spuserprofileproperty) do
 end
 
 Puppet::Type.type(:dsc_spuserprofileproperty).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spuserprofilesection.rb
+++ b/lib/puppet/type/dsc_spuserprofilesection.rb
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_spuserprofilesection) do
 end
 
 Puppet::Type.type(:dsc_spuserprofilesection).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spuserprofileserviceapp.rb
+++ b/lib/puppet/type/dsc_spuserprofileserviceapp.rb
@@ -281,7 +281,7 @@ Puppet::Type.newtype(:dsc_spuserprofileserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spuserprofileserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spuserprofileserviceapppermissions.rb
+++ b/lib/puppet/type/dsc_spuserprofileserviceapppermissions.rb
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_spuserprofileserviceapppermissions) do
 end
 
 Puppet::Type.type(:dsc_spuserprofileserviceapppermissions).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spuserprofilesyncconnection.rb
+++ b/lib/puppet/type/dsc_spuserprofilesyncconnection.rb
@@ -241,7 +241,7 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncconnection) do
 end
 
 Puppet::Type.type(:dsc_spuserprofilesyncconnection).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spuserprofilesyncservice.rb
+++ b/lib/puppet/type/dsc_spuserprofilesyncservice.rb
@@ -146,7 +146,7 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncservice) do
 end
 
 Puppet::Type.type(:dsc_spuserprofilesyncservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spvisioserviceapp.rb
+++ b/lib/puppet/type/dsc_spvisioserviceapp.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_spvisioserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spvisioserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spweb.rb
+++ b/lib/puppet/type/dsc_spweb.rb
@@ -256,7 +256,7 @@ Puppet::Type.newtype(:dsc_spweb) do
 end
 
 Puppet::Type.type(:dsc_spweb).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebappauthentication.rb
+++ b/lib/puppet/type/dsc_spwebappauthentication.rb
@@ -257,7 +257,7 @@ Puppet::Type.newtype(:dsc_spwebappauthentication) do
 end
 
 Puppet::Type.type(:dsc_spwebappauthentication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebappblockedfiletypes.rb
+++ b/lib/puppet/type/dsc_spwebappblockedfiletypes.rb
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_spwebappblockedfiletypes) do
 end
 
 Puppet::Type.type(:dsc_spwebappblockedfiletypes).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebappgeneralsettings.rb
+++ b/lib/puppet/type/dsc_spwebappgeneralsettings.rb
@@ -427,7 +427,7 @@ Puppet::Type.newtype(:dsc_spwebappgeneralsettings) do
 end
 
 Puppet::Type.type(:dsc_spwebappgeneralsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebapplication.rb
+++ b/lib/puppet/type/dsc_spwebapplication.rb
@@ -266,7 +266,7 @@ Puppet::Type.newtype(:dsc_spwebapplication) do
 end
 
 Puppet::Type.type(:dsc_spwebapplication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebapplicationappdomain.rb
+++ b/lib/puppet/type/dsc_spwebapplicationappdomain.rb
@@ -160,7 +160,7 @@ Puppet::Type.newtype(:dsc_spwebapplicationappdomain) do
 end
 
 Puppet::Type.type(:dsc_spwebapplicationappdomain).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebapplicationextension.rb
+++ b/lib/puppet/type/dsc_spwebapplicationextension.rb
@@ -241,7 +241,7 @@ Puppet::Type.newtype(:dsc_spwebapplicationextension) do
 end
 
 Puppet::Type.type(:dsc_spwebapplicationextension).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebapppeoplepickersettings.rb
+++ b/lib/puppet/type/dsc_spwebapppeoplepickersettings.rb
@@ -209,7 +209,7 @@ Puppet::Type.newtype(:dsc_spwebapppeoplepickersettings) do
 end
 
 Puppet::Type.type(:dsc_spwebapppeoplepickersettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebapppermissions.rb
+++ b/lib/puppet/type/dsc_spwebapppermissions.rb
@@ -194,7 +194,7 @@ Puppet::Type.newtype(:dsc_spwebapppermissions) do
 end
 
 Puppet::Type.type(:dsc_spwebapppermissions).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebapppolicy.rb
+++ b/lib/puppet/type/dsc_spwebapppolicy.rb
@@ -217,7 +217,7 @@ Puppet::Type.newtype(:dsc_spwebapppolicy) do
 end
 
 Puppet::Type.type(:dsc_spwebapppolicy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebappproxygroup.rb
+++ b/lib/puppet/type/dsc_spwebappproxygroup.rb
@@ -109,7 +109,7 @@ Puppet::Type.newtype(:dsc_spwebappproxygroup) do
 end
 
 Puppet::Type.type(:dsc_spwebappproxygroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebappsiteuseanddeletion.rb
+++ b/lib/puppet/type/dsc_spwebappsiteuseanddeletion.rb
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_spwebappsiteuseanddeletion) do
 end
 
 Puppet::Type.type(:dsc_spwebappsiteuseanddeletion).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebappsuitebar.rb
+++ b/lib/puppet/type/dsc_spwebappsuitebar.rb
@@ -169,7 +169,7 @@ Puppet::Type.newtype(:dsc_spwebappsuitebar) do
 end
 
 Puppet::Type.type(:dsc_spwebappsuitebar).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebappthrottlingsettings.rb
+++ b/lib/puppet/type/dsc_spwebappthrottlingsettings.rb
@@ -309,7 +309,7 @@ Puppet::Type.newtype(:dsc_spwebappthrottlingsettings) do
 end
 
 Puppet::Type.type(:dsc_spwebappthrottlingsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwebappworkflowsettings.rb
+++ b/lib/puppet/type/dsc_spwebappworkflowsettings.rb
@@ -142,7 +142,7 @@ Puppet::Type.newtype(:dsc_spwebappworkflowsettings) do
 end
 
 Puppet::Type.type(:dsc_spwebappworkflowsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spwordautomationserviceapp.rb
+++ b/lib/puppet/type/dsc_spwordautomationserviceapp.rb
@@ -399,7 +399,7 @@ Puppet::Type.newtype(:dsc_spwordautomationserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spwordautomationserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spworkflowservice.rb
+++ b/lib/puppet/type/dsc_spworkflowservice.rb
@@ -127,7 +127,7 @@ Puppet::Type.newtype(:dsc_spworkflowservice) do
 end
 
 Puppet::Type.type(:dsc_spworkflowservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_spworkmanagementserviceapp.rb
+++ b/lib/puppet/type/dsc_spworkmanagementserviceapp.rb
@@ -252,7 +252,7 @@ Puppet::Type.newtype(:dsc_spworkmanagementserviceapp) do
 end
 
 Puppet::Type.type(:dsc_spworkmanagementserviceapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlag.rb
+++ b/lib/puppet/type/dsc_sqlag.rb
@@ -420,7 +420,7 @@ Puppet::Type.newtype(:dsc_sqlag) do
 end
 
 Puppet::Type.type(:dsc_sqlag).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlagdatabase.rb
+++ b/lib/puppet/type/dsc_sqlagdatabase.rb
@@ -229,7 +229,7 @@ Puppet::Type.newtype(:dsc_sqlagdatabase) do
 end
 
 Puppet::Type.type(:dsc_sqlagdatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlaglistener.rb
+++ b/lib/puppet/type/dsc_sqlaglistener.rb
@@ -197,7 +197,7 @@ Puppet::Type.newtype(:dsc_sqlaglistener) do
 end
 
 Puppet::Type.type(:dsc_sqlaglistener).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlagreplica.rb
+++ b/lib/puppet/type/dsc_sqlagreplica.rb
@@ -380,7 +380,7 @@ Puppet::Type.newtype(:dsc_sqlagreplica) do
 end
 
 Puppet::Type.type(:dsc_sqlagreplica).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlalias.rb
+++ b/lib/puppet/type/dsc_sqlalias.rb
@@ -182,7 +182,7 @@ Puppet::Type.newtype(:dsc_sqlalias) do
 end
 
 Puppet::Type.type(:dsc_sqlalias).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlalwaysonservice.rb
+++ b/lib/puppet/type/dsc_sqlalwaysonservice.rb
@@ -149,7 +149,7 @@ Puppet::Type.newtype(:dsc_sqlalwaysonservice) do
 end
 
 Puppet::Type.type(:dsc_sqlalwaysonservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqldatabase.rb
+++ b/lib/puppet/type/dsc_sqldatabase.rb
@@ -147,7 +147,7 @@ Puppet::Type.newtype(:dsc_sqldatabase) do
 end
 
 Puppet::Type.type(:dsc_sqldatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqldatabasedefaultlocation.rb
+++ b/lib/puppet/type/dsc_sqldatabasedefaultlocation.rb
@@ -178,7 +178,7 @@ Puppet::Type.newtype(:dsc_sqldatabasedefaultlocation) do
 end
 
 Puppet::Type.type(:dsc_sqldatabasedefaultlocation).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqldatabaseowner.rb
+++ b/lib/puppet/type/dsc_sqldatabaseowner.rb
@@ -123,7 +123,7 @@ Puppet::Type.newtype(:dsc_sqldatabaseowner) do
 end
 
 Puppet::Type.type(:dsc_sqldatabaseowner).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqldatabasepermission.rb
+++ b/lib/puppet/type/dsc_sqldatabasepermission.rb
@@ -187,7 +187,7 @@ Puppet::Type.newtype(:dsc_sqldatabasepermission) do
 end
 
 Puppet::Type.type(:dsc_sqldatabasepermission).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqldatabaserecoverymodel.rb
+++ b/lib/puppet/type/dsc_sqldatabaserecoverymodel.rb
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:dsc_sqldatabaserecoverymodel) do
 end
 
 Puppet::Type.type(:dsc_sqldatabaserecoverymodel).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqldatabaserole.rb
+++ b/lib/puppet/type/dsc_sqldatabaserole.rb
@@ -167,7 +167,7 @@ Puppet::Type.newtype(:dsc_sqldatabaserole) do
 end
 
 Puppet::Type.type(:dsc_sqldatabaserole).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlrs.rb
+++ b/lib/puppet/type/dsc_sqlrs.rb
@@ -206,7 +206,7 @@ Puppet::Type.newtype(:dsc_sqlrs) do
 end
 
 Puppet::Type.type(:dsc_sqlrs).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlscript.rb
+++ b/lib/puppet/type/dsc_sqlscript.rb
@@ -199,7 +199,7 @@ Puppet::Type.newtype(:dsc_sqlscript) do
 end
 
 Puppet::Type.type(:dsc_sqlscript).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverconfiguration.rb
+++ b/lib/puppet/type/dsc_sqlserverconfiguration.rb
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_sqlserverconfiguration) do
 end
 
 Puppet::Type.type(:dsc_sqlserverconfiguration).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverdatabasemail.rb
+++ b/lib/puppet/type/dsc_sqlserverdatabasemail.rb
@@ -256,7 +256,7 @@ Puppet::Type.newtype(:dsc_sqlserverdatabasemail) do
 end
 
 Puppet::Type.type(:dsc_sqlserverdatabasemail).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverendpoint.rb
+++ b/lib/puppet/type/dsc_sqlserverendpoint.rb
@@ -163,7 +163,7 @@ Puppet::Type.newtype(:dsc_sqlserverendpoint) do
 end
 
 Puppet::Type.type(:dsc_sqlserverendpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverendpointpermission.rb
+++ b/lib/puppet/type/dsc_sqlserverendpointpermission.rb
@@ -163,7 +163,7 @@ Puppet::Type.newtype(:dsc_sqlserverendpointpermission) do
 end
 
 Puppet::Type.type(:dsc_sqlserverendpointpermission).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverendpointstate.rb
+++ b/lib/puppet/type/dsc_sqlserverendpointstate.rb
@@ -128,7 +128,7 @@ Puppet::Type.newtype(:dsc_sqlserverendpointstate) do
 end
 
 Puppet::Type.type(:dsc_sqlserverendpointstate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverlogin.rb
+++ b/lib/puppet/type/dsc_sqlserverlogin.rb
@@ -230,7 +230,7 @@ Puppet::Type.newtype(:dsc_sqlserverlogin) do
 end
 
 Puppet::Type.type(:dsc_sqlserverlogin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlservermaxdop.rb
+++ b/lib/puppet/type/dsc_sqlservermaxdop.rb
@@ -179,7 +179,7 @@ Puppet::Type.newtype(:dsc_sqlservermaxdop) do
 end
 
 Puppet::Type.type(:dsc_sqlservermaxdop).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlservermemory.rb
+++ b/lib/puppet/type/dsc_sqlservermemory.rb
@@ -197,7 +197,7 @@ Puppet::Type.newtype(:dsc_sqlservermemory) do
 end
 
 Puppet::Type.type(:dsc_sqlservermemory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlservernetwork.rb
+++ b/lib/puppet/type/dsc_sqlservernetwork.rb
@@ -192,7 +192,7 @@ Puppet::Type.newtype(:dsc_sqlservernetwork) do
 end
 
 Puppet::Type.type(:dsc_sqlservernetwork).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverpermission.rb
+++ b/lib/puppet/type/dsc_sqlserverpermission.rb
@@ -158,7 +158,7 @@ Puppet::Type.newtype(:dsc_sqlserverpermission) do
 end
 
 Puppet::Type.type(:dsc_sqlserverpermission).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverreplication.rb
+++ b/lib/puppet/type/dsc_sqlserverreplication.rb
@@ -209,7 +209,7 @@ Puppet::Type.newtype(:dsc_sqlserverreplication) do
 end
 
 Puppet::Type.type(:dsc_sqlserverreplication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserverrole.rb
+++ b/lib/puppet/type/dsc_sqlserverrole.rb
@@ -186,7 +186,7 @@ Puppet::Type.newtype(:dsc_sqlserverrole) do
 end
 
 Puppet::Type.type(:dsc_sqlserverrole).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlserviceaccount.rb
+++ b/lib/puppet/type/dsc_sqlserviceaccount.rb
@@ -178,7 +178,7 @@ Puppet::Type.newtype(:dsc_sqlserviceaccount) do
 end
 
 Puppet::Type.type(:dsc_sqlserviceaccount).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlsetup.rb
+++ b/lib/puppet/type/dsc_sqlsetup.rb
@@ -859,7 +859,7 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
 end
 
 Puppet::Type.type(:dsc_sqlsetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlwaitforag.rb
+++ b/lib/puppet/type/dsc_sqlwaitforag.rb
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:dsc_sqlwaitforag) do
 end
 
 Puppet::Type.type(:dsc_sqlwaitforag).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_sqlwindowsfirewall.rb
+++ b/lib/puppet/type/dsc_sqlwindowsfirewall.rb
@@ -226,7 +226,7 @@ Puppet::Type.newtype(:dsc_sqlwindowsfirewall) do
 end
 
 Puppet::Type.type(:dsc_sqlwindowsfirewall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_systemlocale.rb
+++ b/lib/puppet/type/dsc_systemlocale.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:dsc_systemlocale) do
 end
 
 Puppet::Type.type(:dsc_systemlocale).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -207,7 +207,7 @@ Puppet::Type.newtype(:dsc_user) do
 end
 
 Puppet::Type.type(:dsc_user).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_userrightsassignment.rb
+++ b/lib/puppet/type/dsc_userrightsassignment.rb
@@ -135,7 +135,7 @@ Puppet::Type.newtype(:dsc_userrightsassignment) do
 end
 
 Puppet::Type.type(:dsc_userrightsassignment).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_waitfordisk.rb
+++ b/lib/puppet/type/dsc_waitfordisk.rb
@@ -132,7 +132,7 @@ Puppet::Type.newtype(:dsc_waitfordisk) do
 end
 
 Puppet::Type.type(:dsc_waitfordisk).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_waitforvolume.rb
+++ b/lib/puppet/type/dsc_waitforvolume.rb
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:dsc_waitforvolume) do
 end
 
 Puppet::Type.type(:dsc_waitforvolume).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -174,7 +174,7 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
 end
 
 Puppet::Type.type(:dsc_windowsfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_windowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_windowsoptionalfeature.rb
@@ -228,7 +228,7 @@ Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
 end
 
 Puppet::Type.type(:dsc_windowsoptionalfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -280,7 +280,7 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
 end
 
 Puppet::Type.type(:dsc_windowsprocess).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xadcomputer.rb
+++ b/lib/puppet/type/dsc_xadcomputer.rb
@@ -313,7 +313,7 @@ Puppet::Type.newtype(:dsc_xadcomputer) do
 end
 
 Puppet::Type.type(:dsc_xadcomputer).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xadcscertificationauthority.rb
+++ b/lib/puppet/type/dsc_xadcscertificationauthority.rb
@@ -416,7 +416,7 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
 end
 
 Puppet::Type.type(:dsc_xadcscertificationauthority).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xadcsonlineresponder.rb
+++ b/lib/puppet/type/dsc_xadcsonlineresponder.rb
@@ -117,7 +117,7 @@ Puppet::Type.newtype(:dsc_xadcsonlineresponder) do
 end
 
 Puppet::Type.type(:dsc_xadcsonlineresponder).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xadcswebenrollment.rb
+++ b/lib/puppet/type/dsc_xadcswebenrollment.rb
@@ -132,7 +132,7 @@ Puppet::Type.newtype(:dsc_xadcswebenrollment) do
 end
 
 Puppet::Type.type(:dsc_xadcswebenrollment).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -201,7 +201,7 @@ Puppet::Type.newtype(:dsc_xaddomain) do
 end
 
 Puppet::Type.type(:dsc_xaddomain).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -170,7 +170,7 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
 end
 
 Puppet::Type.type(:dsc_xaddomaincontroller).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xaddomaindefaultpasswordpolicy.rb
+++ b/lib/puppet/type/dsc_xaddomaindefaultpasswordpolicy.rb
@@ -267,7 +267,7 @@ Puppet::Type.newtype(:dsc_xaddomaindefaultpasswordpolicy) do
 end
 
 Puppet::Type.type(:dsc_xaddomaindefaultpasswordpolicy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -167,7 +167,7 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
 end
 
 Puppet::Type.type(:dsc_xaddomaintrust).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xadgroup.rb
+++ b/lib/puppet/type/dsc_xadgroup.rb
@@ -312,7 +312,7 @@ Puppet::Type.newtype(:dsc_xadgroup) do
 end
 
 Puppet::Type.type(:dsc_xadgroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xadorganizationalunit.rb
+++ b/lib/puppet/type/dsc_xadorganizationalunit.rb
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_xadorganizationalunit) do
 end
 
 Puppet::Type.type(:dsc_xadorganizationalunit).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xadrecyclebin.rb
+++ b/lib/puppet/type/dsc_xadrecyclebin.rb
@@ -124,7 +124,7 @@ Puppet::Type.newtype(:dsc_xadrecyclebin) do
 end
 
 Puppet::Type.type(:dsc_xadrecyclebin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xadserviceprincipalname.rb
+++ b/lib/puppet/type/dsc_xadserviceprincipalname.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xadserviceprincipalname) do
 end
 
 Puppet::Type.type(:dsc_xadserviceprincipalname).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -768,7 +768,7 @@ Puppet::Type.newtype(:dsc_xaduser) do
 end
 
 Puppet::Type.type(:dsc_xaduser).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -181,7 +181,7 @@ Puppet::Type.newtype(:dsc_xarchive) do
 end
 
 Puppet::Type.type(:dsc_xarchive).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -143,7 +143,7 @@ Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
 end
 
 Puppet::Type.type(:dsc_xazureaffinitygroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurepackadmin.rb
+++ b/lib/puppet/type/dsc_xazurepackadmin.rb
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_xazurepackadmin) do
 end
 
 Puppet::Type.type(:dsc_xazurepackadmin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
+++ b/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
@@ -177,7 +177,7 @@ Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
 end
 
 Puppet::Type.type(:dsc_xazurepackdatabasesetting).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurepackfqdn.rb
+++ b/lib/puppet/type/dsc_xazurepackfqdn.rb
@@ -176,7 +176,7 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
 end
 
 Puppet::Type.type(:dsc_xazurepackfqdn).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurepackidentityprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackidentityprovider.rb
@@ -176,7 +176,7 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
 end
 
 Puppet::Type.type(:dsc_xazurepackidentityprovider).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurepackrelyingparty.rb
+++ b/lib/puppet/type/dsc_xazurepackrelyingparty.rb
@@ -178,7 +178,7 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
 end
 
 Puppet::Type.type(:dsc_xazurepackrelyingparty).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurepackresourceprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackresourceprovider.rb
@@ -631,7 +631,7 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
 end
 
 Puppet::Type.type(:dsc_xazurepackresourceprovider).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurepacksetup.rb
+++ b/lib/puppet/type/dsc_xazurepacksetup.rb
@@ -224,7 +224,7 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
 end
 
 Puppet::Type.type(:dsc_xazurepacksetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurepackupdate.rb
+++ b/lib/puppet/type/dsc_xazurepackupdate.rb
@@ -127,7 +127,7 @@ Puppet::Type.newtype(:dsc_xazurepackupdate) do
 end
 
 Puppet::Type.type(:dsc_xazurepackupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -220,7 +220,7 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
 end
 
 Puppet::Type.type(:dsc_xazurequickvm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -143,7 +143,7 @@ Puppet::Type.newtype(:dsc_xazureservice) do
 end
 
 Puppet::Type.type(:dsc_xazureservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -207,7 +207,7 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
 end
 
 Puppet::Type.type(:dsc_xazuresqldatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -175,7 +175,7 @@ Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
 end
 
 Puppet::Type.type(:dsc_xazuresqldatabaseserverfirewallrule).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -158,7 +158,7 @@ Puppet::Type.newtype(:dsc_xazurestorageaccount) do
 end
 
 Puppet::Type.type(:dsc_xazurestorageaccount).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xazuresubscription) do
 end
 
 Puppet::Type.type(:dsc_xazuresubscription).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -251,7 +251,7 @@ Puppet::Type.newtype(:dsc_xazurevm) do
 end
 
 Puppet::Type.type(:dsc_xazurevm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -173,7 +173,7 @@ Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
 end
 
 Puppet::Type.type(:dsc_xazurevmdscconfiguration).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xazurevmdscextension.rb
+++ b/lib/puppet/type/dsc_xazurevmdscextension.rb
@@ -305,7 +305,7 @@ Puppet::Type.newtype(:dsc_xazurevmdscextension) do
 end
 
 Puppet::Type.type(:dsc_xazurevmdscextension).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xblautobitlocker.rb
+++ b/lib/puppet/type/dsc_xblautobitlocker.rb
@@ -388,7 +388,7 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
 end
 
 Puppet::Type.type(:dsc_xblautobitlocker).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xblbitlocker.rb
+++ b/lib/puppet/type/dsc_xblbitlocker.rb
@@ -383,7 +383,7 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
 end
 
 Puppet::Type.type(:dsc_xblbitlocker).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xbltpm.rb
+++ b/lib/puppet/type/dsc_xbltpm.rb
@@ -126,7 +126,7 @@ Puppet::Type.newtype(:dsc_xbltpm) do
 end
 
 Puppet::Type.type(:dsc_xbltpm).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xcertificateexport.rb
+++ b/lib/puppet/type/dsc_xcertificateexport.rb
@@ -325,7 +325,7 @@ Puppet::Type.newtype(:dsc_xcertificateexport) do
 end
 
 Puppet::Type.type(:dsc_xcertificateexport).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xcertificateimport.rb
+++ b/lib/puppet/type/dsc_xcertificateimport.rb
@@ -150,7 +150,7 @@ Puppet::Type.newtype(:dsc_xcertificateimport) do
 end
 
 Puppet::Type.type(:dsc_xcertificateimport).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xcertreq.rb
+++ b/lib/puppet/type/dsc_xcertreq.rb
@@ -325,7 +325,7 @@ Puppet::Type.newtype(:dsc_xcertreq) do
 end
 
 Puppet::Type.type(:dsc_xcertreq).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -127,7 +127,7 @@ Puppet::Type.newtype(:dsc_xcluster) do
 end
 
 Puppet::Type.type(:dsc_xcluster).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xclusterdisk.rb
+++ b/lib/puppet/type/dsc_xclusterdisk.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xclusterdisk) do
 end
 
 Puppet::Type.type(:dsc_xclusterdisk).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xclusternetwork.rb
+++ b/lib/puppet/type/dsc_xclusternetwork.rb
@@ -143,7 +143,7 @@ Puppet::Type.newtype(:dsc_xclusternetwork) do
 end
 
 Puppet::Type.type(:dsc_xclusternetwork).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xclusterpreferredowner.rb
+++ b/lib/puppet/type/dsc_xclusterpreferredowner.rb
@@ -151,7 +151,7 @@ Puppet::Type.newtype(:dsc_xclusterpreferredowner) do
 end
 
 Puppet::Type.type(:dsc_xclusterpreferredowner).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xclusterquorum.rb
+++ b/lib/puppet/type/dsc_xclusterquorum.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_xclusterquorum) do
 end
 
 Puppet::Type.type(:dsc_xclusterquorum).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -185,7 +185,7 @@ Puppet::Type.newtype(:dsc_xcomputer) do
 end
 
 Puppet::Type.type(:dsc_xcomputer).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xcredssp.rb
+++ b/lib/puppet/type/dsc_xcredssp.rb
@@ -135,7 +135,7 @@ Puppet::Type.newtype(:dsc_xcredssp) do
 end
 
 Puppet::Type.type(:dsc_xcredssp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -207,7 +207,7 @@ Puppet::Type.newtype(:dsc_xdatabase) do
 end
 
 Puppet::Type.type(:dsc_xdatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdatabaselogin.rb
+++ b/lib/puppet/type/dsc_xdatabaselogin.rb
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_xdatabaselogin) do
 end
 
 Puppet::Type.type(:dsc_xdatabaselogin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdatabaseserver.rb
+++ b/lib/puppet/type/dsc_xdatabaseserver.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:dsc_xdatabaseserver) do
 end
 
 Puppet::Type.type(:dsc_xdatabaseserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -160,7 +160,7 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
 end
 
 Puppet::Type.type(:dsc_xdbpackage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
+++ b/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xdefaultgatewayaddress) do
 end
 
 Puppet::Type.type(:dsc_xdefaultgatewayaddress).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdfsnamespacefolder.rb
+++ b/lib/puppet/type/dsc_xdfsnamespacefolder.rb
@@ -231,7 +231,7 @@ Puppet::Type.newtype(:dsc_xdfsnamespacefolder) do
 end
 
 Puppet::Type.type(:dsc_xdfsnamespacefolder).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdfsnamespaceroot.rb
+++ b/lib/puppet/type/dsc_xdfsnamespaceroot.rb
@@ -297,7 +297,7 @@ Puppet::Type.newtype(:dsc_xdfsnamespaceroot) do
 end
 
 Puppet::Type.type(:dsc_xdfsnamespaceroot).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdfsnamespaceserverconfiguration.rb
+++ b/lib/puppet/type/dsc_xdfsnamespaceserverconfiguration.rb
@@ -133,7 +133,7 @@ Puppet::Type.newtype(:dsc_xdfsnamespaceserverconfiguration) do
 end
 
 Puppet::Type.type(:dsc_xdfsnamespaceserverconfiguration).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdfsreplicationgroup.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroup.rb
@@ -200,7 +200,7 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroup) do
 end
 
 Puppet::Type.type(:dsc_xdfsreplicationgroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdfsreplicationgroupconnection.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupconnection.rb
@@ -198,7 +198,7 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupconnection) do
 end
 
 Puppet::Type.type(:dsc_xdfsreplicationgroupconnection).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdfsreplicationgroupfolder.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupfolder.rb
@@ -176,7 +176,7 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupfolder) do
 end
 
 Puppet::Type.type(:dsc_xdfsreplicationgroupfolder).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdfsreplicationgroupmembership.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupmembership.rb
@@ -204,7 +204,7 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupmembership) do
 end
 
 Puppet::Type.type(:dsc_xdfsreplicationgroupmembership).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdhcpclient.rb
+++ b/lib/puppet/type/dsc_xdhcpclient.rb
@@ -116,7 +116,7 @@ Puppet::Type.newtype(:dsc_xdhcpclient) do
 end
 
 Puppet::Type.type(:dsc_xdhcpclient).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdhcpserverauthorization.rb
+++ b/lib/puppet/type/dsc_xdhcpserverauthorization.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xdhcpserverauthorization) do
 end
 
 Puppet::Type.type(:dsc_xdhcpserverauthorization).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdhcpserverclass.rb
+++ b/lib/puppet/type/dsc_xdhcpserverclass.rb
@@ -172,7 +172,7 @@ Puppet::Type.newtype(:dsc_xdhcpserverclass) do
 end
 
 Puppet::Type.type(:dsc_xdhcpserverclass).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -167,7 +167,7 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
 end
 
 Puppet::Type.type(:dsc_xdhcpserveroption).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -163,7 +163,7 @@ Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
 end
 
 Puppet::Type.type(:dsc_xdhcpserverreservation).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -211,7 +211,7 @@ Puppet::Type.newtype(:dsc_xdhcpserverscope) do
 end
 
 Puppet::Type.type(:dsc_xdhcpserverscope).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdismfeature.rb
+++ b/lib/puppet/type/dsc_xdismfeature.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xdismfeature) do
 end
 
 Puppet::Type.type(:dsc_xdismfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsarecord.rb
+++ b/lib/puppet/type/dsc_xdnsarecord.rb
@@ -130,7 +130,7 @@ Puppet::Type.newtype(:dsc_xdnsarecord) do
 end
 
 Puppet::Type.type(:dsc_xdnsarecord).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsclientglobalsetting.rb
+++ b/lib/puppet/type/dsc_xdnsclientglobalsetting.rb
@@ -133,7 +133,7 @@ Puppet::Type.newtype(:dsc_xdnsclientglobalsetting) do
 end
 
 Puppet::Type.type(:dsc_xdnsclientglobalsetting).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsconnectionsuffix.rb
+++ b/lib/puppet/type/dsc_xdnsconnectionsuffix.rb
@@ -145,7 +145,7 @@ Puppet::Type.newtype(:dsc_xdnsconnectionsuffix) do
 end
 
 Puppet::Type.type(:dsc_xdnsconnectionsuffix).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsrecord.rb
+++ b/lib/puppet/type/dsc_xdnsrecord.rb
@@ -165,7 +165,7 @@ Puppet::Type.newtype(:dsc_xdnsrecord) do
 end
 
 Puppet::Type.type(:dsc_xdnsrecord).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -132,7 +132,7 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
 end
 
 Puppet::Type.type(:dsc_xdnsserveraddress).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsserveradzone.rb
+++ b/lib/puppet/type/dsc_xdnsserveradzone.rb
@@ -180,7 +180,7 @@ Puppet::Type.newtype(:dsc_xdnsserveradzone) do
 end
 
 Puppet::Type.type(:dsc_xdnsserveradzone).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsserverforwarder.rb
+++ b/lib/puppet/type/dsc_xdnsserverforwarder.rb
@@ -99,7 +99,7 @@ Puppet::Type.newtype(:dsc_xdnsserverforwarder) do
 end
 
 Puppet::Type.type(:dsc_xdnsserverforwarder).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsserverprimaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserverprimaryzone.rb
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_xdnsserverprimaryzone) do
 end
 
 Puppet::Type.type(:dsc_xdnsserverprimaryzone).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
 end
 
 Puppet::Type.type(:dsc_xdnsserversecondaryzone).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsserversetting.rb
+++ b/lib/puppet/type/dsc_xdnsserversetting.rb
@@ -837,7 +837,7 @@ Puppet::Type.newtype(:dsc_xdnsserversetting) do
 end
 
 Puppet::Type.type(:dsc_xdnsserversetting).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
 end
 
 Puppet::Type.type(:dsc_xdnsserverzonetransfer).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -315,7 +315,7 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
 end
 
 Puppet::Type.type(:dsc_xdscwebservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xenvironment.rb
+++ b/lib/puppet/type/dsc_xenvironment.rb
@@ -157,7 +157,7 @@ Puppet::Type.newtype(:dsc_xenvironment) do
 end
 
 Puppet::Type.type(:dsc_xenvironment).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
@@ -566,7 +566,7 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xexchactivesyncvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchantimalwarescanning.rb
+++ b/lib/puppet/type/dsc_xexchantimalwarescanning.rb
@@ -111,7 +111,7 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
 end
 
 Puppet::Type.type(:dsc_xexchantimalwarescanning).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
@@ -269,7 +269,7 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xexchautodiscovervirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchautomountpoint.rb
+++ b/lib/puppet/type/dsc_xexchautomountpoint.rb
@@ -257,7 +257,7 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
 end
 
 Puppet::Type.type(:dsc_xexchautomountpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchclientaccessserver.rb
+++ b/lib/puppet/type/dsc_xexchclientaccessserver.rb
@@ -190,7 +190,7 @@ Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
 end
 
 Puppet::Type.type(:dsc_xexchclientaccessserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
@@ -490,7 +490,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
 end
 
 Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
@@ -140,7 +140,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
 end
 
 Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroupmember).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
@@ -194,7 +194,7 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
 end
 
 Puppet::Type.type(:dsc_xexchdatabaseavailabilitygroupnetwork).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
@@ -253,7 +253,7 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xexchecpvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexcheventloglevel.rb
+++ b/lib/puppet/type/dsc_xexcheventloglevel.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:dsc_xexcheventloglevel) do
 end
 
 Puppet::Type.type(:dsc_xexcheventloglevel).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchexchangecertificate.rb
+++ b/lib/puppet/type/dsc_xexchexchangecertificate.rb
@@ -194,7 +194,7 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
 end
 
 Puppet::Type.type(:dsc_xexchexchangecertificate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchexchangeserver.rb
+++ b/lib/puppet/type/dsc_xexchexchangeserver.rb
@@ -201,7 +201,7 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
 end
 
 Puppet::Type.type(:dsc_xexchexchangeserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchimapsettings.rb
+++ b/lib/puppet/type/dsc_xexchimapsettings.rb
@@ -176,7 +176,7 @@ Puppet::Type.newtype(:dsc_xexchimapsettings) do
 end
 
 Puppet::Type.type(:dsc_xexchimapsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchinstall.rb
+++ b/lib/puppet/type/dsc_xexchinstall.rb
@@ -111,7 +111,7 @@ Puppet::Type.newtype(:dsc_xexchinstall) do
 end
 
 Puppet::Type.type(:dsc_xexchinstall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchjetstress.rb
+++ b/lib/puppet/type/dsc_xexchjetstress.rb
@@ -147,7 +147,7 @@ Puppet::Type.newtype(:dsc_xexchjetstress) do
 end
 
 Puppet::Type.type(:dsc_xexchjetstress).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchjetstresscleanup.rb
+++ b/lib/puppet/type/dsc_xexchjetstresscleanup.rb
@@ -176,7 +176,7 @@ Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
 end
 
 Puppet::Type.type(:dsc_xexchjetstresscleanup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchmailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabase.rb
@@ -545,7 +545,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
 end
 
 Puppet::Type.type(:dsc_xexchmailboxdatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
@@ -219,7 +219,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
 end
 
 Puppet::Type.type(:dsc_xexchmailboxdatabasecopy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchmailboxserver.rb
+++ b/lib/puppet/type/dsc_xexchmailboxserver.rb
@@ -846,7 +846,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxserver) do
 end
 
 Puppet::Type.type(:dsc_xexchmailboxserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchmailboxtransportservice.rb
+++ b/lib/puppet/type/dsc_xexchmailboxtransportservice.rb
@@ -449,7 +449,7 @@ Puppet::Type.newtype(:dsc_xexchmailboxtransportservice) do
 end
 
 Puppet::Type.type(:dsc_xexchmailboxtransportservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchmaintenancemode.rb
+++ b/lib/puppet/type/dsc_xexchmaintenancemode.rb
@@ -175,7 +175,7 @@ Puppet::Type.newtype(:dsc_xexchmaintenancemode) do
 end
 
 Puppet::Type.type(:dsc_xexchmaintenancemode).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
@@ -173,7 +173,7 @@ Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xexchmapivirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
@@ -293,7 +293,7 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xexchoabvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchoutlookanywhere.rb
+++ b/lib/puppet/type/dsc_xexchoutlookanywhere.rb
@@ -311,7 +311,7 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
 end
 
 Puppet::Type.type(:dsc_xexchoutlookanywhere).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
@@ -398,7 +398,7 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xexchowavirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchpopsettings.rb
+++ b/lib/puppet/type/dsc_xexchpopsettings.rb
@@ -176,7 +176,7 @@ Puppet::Type.newtype(:dsc_xexchpopsettings) do
 end
 
 Puppet::Type.type(:dsc_xexchpopsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
@@ -219,7 +219,7 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xexchpowershellvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchreceiveconnector.rb
+++ b/lib/puppet/type/dsc_xexchreceiveconnector.rb
@@ -943,7 +943,7 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
 end
 
 Puppet::Type.type(:dsc_xexchreceiveconnector).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchtransportservice.rb
+++ b/lib/puppet/type/dsc_xexchtransportservice.rb
@@ -1452,7 +1452,7 @@ Puppet::Type.newtype(:dsc_xexchtransportservice) do
 end
 
 Puppet::Type.type(:dsc_xexchtransportservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchumcallroutersettings.rb
+++ b/lib/puppet/type/dsc_xexchumcallroutersettings.rb
@@ -127,7 +127,7 @@ Puppet::Type.newtype(:dsc_xexchumcallroutersettings) do
 end
 
 Puppet::Type.type(:dsc_xexchumcallroutersettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchumservice.rb
+++ b/lib/puppet/type/dsc_xexchumservice.rb
@@ -145,7 +145,7 @@ Puppet::Type.newtype(:dsc_xexchumservice) do
 end
 
 Puppet::Type.type(:dsc_xexchumservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchwaitforadprep.rb
+++ b/lib/puppet/type/dsc_xexchwaitforadprep.rb
@@ -202,7 +202,7 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
 end
 
 Puppet::Type.type(:dsc_xexchwaitforadprep).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchwaitfordag.rb
+++ b/lib/puppet/type/dsc_xexchwaitfordag.rb
@@ -145,7 +145,7 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
 end
 
 Puppet::Type.type(:dsc_xexchwaitfordag).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
@@ -160,7 +160,7 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
 end
 
 Puppet::Type.type(:dsc_xexchwaitformailboxdatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
@@ -364,7 +364,7 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xexchwebservicesvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -614,7 +614,7 @@ Puppet::Type.newtype(:dsc_xfirewall) do
 end
 
 Puppet::Type.type(:dsc_xfirewall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xfirewallprofile.rb
+++ b/lib/puppet/type/dsc_xfirewallprofile.rb
@@ -384,7 +384,7 @@ Puppet::Type.newtype(:dsc_xfirewallprofile) do
 end
 
 Puppet::Type.type(:dsc_xfirewallprofile).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -183,7 +183,7 @@ Puppet::Type.newtype(:dsc_xgroup) do
 end
 
 Puppet::Type.type(:dsc_xgroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xhostsfile.rb
+++ b/lib/puppet/type/dsc_xhostsfile.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xhostsfile) do
 end
 
 Puppet::Type.type(:dsc_xhostsfile).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xhotfix.rb
+++ b/lib/puppet/type/dsc_xhotfix.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xhotfix) do
 end
 
 Puppet::Type.type(:dsc_xhotfix).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xiisfeaturedelegation.rb
+++ b/lib/puppet/type/dsc_xiisfeaturedelegation.rb
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_xiisfeaturedelegation) do
 end
 
 Puppet::Type.type(:dsc_xiisfeaturedelegation).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xiishandler.rb
+++ b/lib/puppet/type/dsc_xiishandler.rb
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_xiishandler) do
 end
 
 Puppet::Type.type(:dsc_xiishandler).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xiislogging.rb
+++ b/lib/puppet/type/dsc_xiislogging.rb
@@ -173,7 +173,7 @@ Puppet::Type.newtype(:dsc_xiislogging) do
 end
 
 Puppet::Type.type(:dsc_xiislogging).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xiismimetypemapping.rb
+++ b/lib/puppet/type/dsc_xiismimetypemapping.rb
@@ -115,7 +115,7 @@ Puppet::Type.newtype(:dsc_xiismimetypemapping) do
 end
 
 Puppet::Type.type(:dsc_xiismimetypemapping).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -195,7 +195,7 @@ Puppet::Type.newtype(:dsc_xiismodule) do
 end
 
 Puppet::Type.type(:dsc_xiismodule).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
+++ b/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xinternetexplorerhomepage) do
 end
 
 Puppet::Type.type(:dsc_xinternetexplorerhomepage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -116,7 +116,7 @@ Puppet::Type.newtype(:dsc_xipaddress) do
 end
 
 Puppet::Type.type(:dsc_xipaddress).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xipaddressoption.rb
+++ b/lib/puppet/type/dsc_xipaddressoption.rb
@@ -94,7 +94,7 @@ Puppet::Type.newtype(:dsc_xipaddressoption) do
 end
 
 Puppet::Type.type(:dsc_xipaddressoption).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -165,7 +165,7 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
 end
 
 Puppet::Type.type(:dsc_xjeaendpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -149,7 +149,7 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
 end
 
 Puppet::Type.type(:dsc_xjeatoolkit).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xmicrosoftupdate.rb
+++ b/lib/puppet/type/dsc_xmicrosoftupdate.rb
@@ -83,7 +83,7 @@ Puppet::Type.newtype(:dsc_xmicrosoftupdate) do
 end
 
 Puppet::Type.type(:dsc_xmicrosoftupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xmppreference.rb
+++ b/lib/puppet/type/dsc_xmppreference.rb
@@ -974,7 +974,7 @@ Puppet::Type.newtype(:dsc_xmppreference) do
 end
 
 Puppet::Type.type(:dsc_xmppreference).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xmsipackage.rb
+++ b/lib/puppet/type/dsc_xmsipackage.rb
@@ -361,7 +361,7 @@ Puppet::Type.newtype(:dsc_xmsipackage) do
 end
 
 Puppet::Type.type(:dsc_xmsipackage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
 end
 
 Puppet::Type.type(:dsc_xmysqldatabase).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -166,7 +166,7 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
 end
 
 Puppet::Type.type(:dsc_xmysqlgrant).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
 end
 
 Puppet::Type.type(:dsc_xmysqlserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -145,7 +145,7 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
 end
 
 Puppet::Type.type(:dsc_xmysqluser).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetadapteradvancedproperty.rb
+++ b/lib/puppet/type/dsc_xnetadapteradvancedproperty.rb
@@ -126,7 +126,7 @@ Puppet::Type.newtype(:dsc_xnetadapteradvancedproperty) do
 end
 
 Puppet::Type.type(:dsc_xnetadapteradvancedproperty).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetadapterbinding.rb
+++ b/lib/puppet/type/dsc_xnetadapterbinding.rb
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_xnetadapterbinding) do
 end
 
 Puppet::Type.type(:dsc_xnetadapterbinding).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetadapterlso.rb
+++ b/lib/puppet/type/dsc_xnetadapterlso.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:dsc_xnetadapterlso) do
 end
 
 Puppet::Type.type(:dsc_xnetadapterlso).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetadaptername.rb
+++ b/lib/puppet/type/dsc_xnetadaptername.rb
@@ -238,7 +238,7 @@ Puppet::Type.newtype(:dsc_xnetadaptername) do
 end
 
 Puppet::Type.type(:dsc_xnetadaptername).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetadapterrdma.rb
+++ b/lib/puppet/type/dsc_xnetadapterrdma.rb
@@ -94,7 +94,7 @@ Puppet::Type.newtype(:dsc_xnetadapterrdma) do
 end
 
 Puppet::Type.type(:dsc_xnetadapterrdma).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetadapterrsc.rb
+++ b/lib/puppet/type/dsc_xnetadapterrsc.rb
@@ -142,7 +142,7 @@ Puppet::Type.newtype(:dsc_xnetadapterrsc) do
 end
 
 Puppet::Type.type(:dsc_xnetadapterrsc).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetadapterrss.rb
+++ b/lib/puppet/type/dsc_xnetadapterrss.rb
@@ -94,7 +94,7 @@ Puppet::Type.newtype(:dsc_xnetadapterrss) do
 end
 
 Puppet::Type.type(:dsc_xnetadapterrss).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetbios.rb
+++ b/lib/puppet/type/dsc_xnetbios.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:dsc_xnetbios) do
 end
 
 Puppet::Type.type(:dsc_xnetbios).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetconnectionprofile.rb
+++ b/lib/puppet/type/dsc_xnetconnectionprofile.rb
@@ -132,7 +132,7 @@ Puppet::Type.newtype(:dsc_xnetconnectionprofile) do
 end
 
 Puppet::Type.type(:dsc_xnetconnectionprofile).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetworkteam.rb
+++ b/lib/puppet/type/dsc_xnetworkteam.rb
@@ -152,7 +152,7 @@ Puppet::Type.newtype(:dsc_xnetworkteam) do
 end
 
 Puppet::Type.type(:dsc_xnetworkteam).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xnetworkteaminterface.rb
+++ b/lib/puppet/type/dsc_xnetworkteaminterface.rb
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_xnetworkteaminterface) do
 end
 
 Puppet::Type.type(:dsc_xnetworkteaminterface).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xofflinedomainjoin.rb
+++ b/lib/puppet/type/dsc_xofflinedomainjoin.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:dsc_xofflinedomainjoin) do
 end
 
 Puppet::Type.type(:dsc_xofflinedomainjoin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -462,7 +462,7 @@ Puppet::Type.newtype(:dsc_xpackage) do
 end
 
 Puppet::Type.type(:dsc_xpackage).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xpendingreboot.rb
+++ b/lib/puppet/type/dsc_xpendingreboot.rb
@@ -238,7 +238,7 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
 end
 
 Puppet::Type.type(:dsc_xpendingreboot).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xpfximport.rb
+++ b/lib/puppet/type/dsc_xpfximport.rb
@@ -182,7 +182,7 @@ Puppet::Type.newtype(:dsc_xpfximport) do
 end
 
 Puppet::Type.type(:dsc_xpfximport).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xpowerplan.rb
+++ b/lib/puppet/type/dsc_xpowerplan.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:dsc_xpowerplan) do
 end
 
 Puppet::Type.type(:dsc_xpowerplan).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
+++ b/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
@@ -81,7 +81,7 @@ Puppet::Type.newtype(:dsc_xpowershellexecutionpolicy) do
 end
 
 Puppet::Type.type(:dsc_xpowershellexecutionpolicy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xproxysettings.rb
+++ b/lib/puppet/type/dsc_xproxysettings.rb
@@ -231,7 +231,7 @@ Puppet::Type.newtype(:dsc_xproxysettings) do
 end
 
 Puppet::Type.type(:dsc_xproxysettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
 end
 
 Puppet::Type.type(:dsc_xpsendpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xrdremoteapp.rb
+++ b/lib/puppet/type/dsc_xrdremoteapp.rb
@@ -253,7 +253,7 @@ Puppet::Type.newtype(:dsc_xrdremoteapp) do
 end
 
 Puppet::Type.type(:dsc_xrdremoteapp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -125,7 +125,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollection) do
 end
 
 Puppet::Type.type(:dsc_xrdsessioncollection).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -366,7 +366,7 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
 end
 
 Puppet::Type.type(:dsc_xrdsessioncollectionconfiguration).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -112,7 +112,7 @@ Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
 end
 
 Puppet::Type.type(:dsc_xrdsessiondeployment).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xregistry.rb
+++ b/lib/puppet/type/dsc_xregistry.rb
@@ -183,7 +183,7 @@ Puppet::Type.newtype(:dsc_xregistry) do
 end
 
 Puppet::Type.type(:dsc_xregistry).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -101,7 +101,7 @@ Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
 end
 
 Puppet::Type.type(:dsc_xremotedesktopadmin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -224,7 +224,7 @@ Puppet::Type.newtype(:dsc_xremotefile) do
 end
 
 Puppet::Type.type(:dsc_xremotefile).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xrobocopy.rb
+++ b/lib/puppet/type/dsc_xrobocopy.rb
@@ -278,7 +278,7 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
 end
 
 Puppet::Type.type(:dsc_xrobocopy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xroute.rb
+++ b/lib/puppet/type/dsc_xroute.rb
@@ -203,7 +203,7 @@ Puppet::Type.newtype(:dsc_xroute) do
 end
 
 Puppet::Type.type(:dsc_xroute).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscdpmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscdpmconsolesetup.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_xscdpmconsolesetup) do
 end
 
 Puppet::Type.type(:dsc_xscdpmconsolesetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_xscdpmdatabaseserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscdpmdatabaseserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscdpmserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmserversetup.rb
@@ -281,7 +281,7 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscdpmserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscheduledtask.rb
+++ b/lib/puppet/type/dsc_xscheduledtask.rb
@@ -727,7 +727,7 @@ Puppet::Type.newtype(:dsc_xscheduledtask) do
 end
 
 Puppet::Type.type(:dsc_xscheduledtask).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscomadmin.rb
+++ b/lib/puppet/type/dsc_xscomadmin.rb
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_xscomadmin) do
 end
 
 Puppet::Type.type(:dsc_xscomadmin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscomconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscomconsolesetup.rb
@@ -216,7 +216,7 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
 end
 
 Puppet::Type.type(:dsc_xscomconsolesetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscomconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscomconsoleupdate.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xscomconsoleupdate) do
 end
 
 Puppet::Type.type(:dsc_xscomconsoleupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscommanagementpack.rb
+++ b/lib/puppet/type/dsc_xscommanagementpack.rb
@@ -169,7 +169,7 @@ Puppet::Type.newtype(:dsc_xscommanagementpack) do
 end
 
 Puppet::Type.type(:dsc_xscommanagementpack).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscommanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscommanagementserversetup.rb
@@ -500,7 +500,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscommanagementserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscommanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscommanagementserverupdate.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xscommanagementserverupdate) do
 end
 
 Puppet::Type.type(:dsc_xscommanagementserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscomreportingserversetup.rb
+++ b/lib/puppet/type/dsc_xscomreportingserversetup.rb
@@ -277,7 +277,7 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscomreportingserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
@@ -280,7 +280,7 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscomwebconsoleserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserverupdate) do
 end
 
 Puppet::Type.type(:dsc_xscomwebconsoleserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscript.rb
+++ b/lib/puppet/type/dsc_xscript.rb
@@ -143,7 +143,7 @@ Puppet::Type.newtype(:dsc_xscript) do
 end
 
 Puppet::Type.type(:dsc_xscript).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscsmapowershellsetup.rb
+++ b/lib/puppet/type/dsc_xscsmapowershellsetup.rb
@@ -129,7 +129,7 @@ Puppet::Type.newtype(:dsc_xscsmapowershellsetup) do
 end
 
 Puppet::Type.type(:dsc_xscsmapowershellsetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
@@ -280,7 +280,7 @@ Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscsmarunbookworkerserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
@@ -407,7 +407,7 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscsmawebserviceserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscspfserver.rb
+++ b/lib/puppet/type/dsc_xscspfserver.rb
@@ -132,7 +132,7 @@ Puppet::Type.newtype(:dsc_xscspfserver) do
 end
 
 Puppet::Type.type(:dsc_xscspfserver).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscspfserversetup.rb
+++ b/lib/puppet/type/dsc_xscspfserversetup.rb
@@ -440,7 +440,7 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscspfserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscspfserverupdate.rb
+++ b/lib/puppet/type/dsc_xscspfserverupdate.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xscspfserverupdate) do
 end
 
 Puppet::Type.type(:dsc_xscspfserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscspfsetting.rb
+++ b/lib/puppet/type/dsc_xscspfsetting.rb
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_xscspfsetting) do
 end
 
 Puppet::Type.type(:dsc_xscspfsetting).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscspfstamp.rb
+++ b/lib/puppet/type/dsc_xscspfstamp.rb
@@ -132,7 +132,7 @@ Puppet::Type.newtype(:dsc_xscspfstamp) do
 end
 
 Puppet::Type.type(:dsc_xscspfstamp).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscsrserversetup.rb
+++ b/lib/puppet/type/dsc_xscsrserversetup.rb
@@ -300,7 +300,7 @@ Puppet::Type.newtype(:dsc_xscsrserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscsrserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscsrserverupdate.rb
+++ b/lib/puppet/type/dsc_xscsrserverupdate.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xscsrserverupdate) do
 end
 
 Puppet::Type.type(:dsc_xscsrserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscvmmadmin.rb
+++ b/lib/puppet/type/dsc_xscvmmadmin.rb
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_xscvmmadmin) do
 end
 
 Puppet::Type.type(:dsc_xscvmmadmin).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscvmmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscvmmconsolesetup.rb
@@ -180,7 +180,7 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
 end
 
 Puppet::Type.type(:dsc_xscvmmconsolesetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xscvmmconsoleupdate) do
 end
 
 Puppet::Type.type(:dsc_xscvmmconsoleupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
@@ -597,7 +597,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
 end
 
 Puppet::Type.type(:dsc_xscvmmmanagementserversetup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserverupdate) do
 end
 
 Puppet::Type.type(:dsc_xscvmmmanagementserverupdate).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -283,7 +283,7 @@ Puppet::Type.newtype(:dsc_xservice) do
 end
 
 Puppet::Type.type(:dsc_xservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsmacredential.rb
+++ b/lib/puppet/type/dsc_xsmacredential.rb
@@ -157,7 +157,7 @@ Puppet::Type.newtype(:dsc_xsmacredential) do
 end
 
 Puppet::Type.type(:dsc_xsmacredential).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -312,7 +312,7 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
 end
 
 Puppet::Type.type(:dsc_xsmbshare).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsqlalias.rb
+++ b/lib/puppet/type/dsc_xsqlalias.rb
@@ -164,7 +164,7 @@ Puppet::Type.newtype(:dsc_xsqlalias) do
 end
 
 Puppet::Type.type(:dsc_xsqlalias).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -128,7 +128,7 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
 end
 
 Puppet::Type.type(:dsc_xsqlhaendpoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -188,7 +188,7 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
 end
 
 Puppet::Type.type(:dsc_xsqlhagroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -110,7 +110,7 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
 end
 
 Puppet::Type.type(:dsc_xsqlhaservice).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -306,7 +306,7 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
 end
 
 Puppet::Type.type(:dsc_xsqlserverinstall).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsslsettings.rb
+++ b/lib/puppet/type/dsc_xsslsettings.rb
@@ -126,7 +126,7 @@ Puppet::Type.newtype(:dsc_xsslsettings) do
 end
 
 Puppet::Type.type(:dsc_xsslsettings).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsystemrestore.rb
+++ b/lib/puppet/type/dsc_xsystemrestore.rb
@@ -101,7 +101,7 @@ Puppet::Type.newtype(:dsc_xsystemrestore) do
 end
 
 Puppet::Type.type(:dsc_xsystemrestore).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xsystemrestorepoint.rb
+++ b/lib/puppet/type/dsc_xsystemrestorepoint.rb
@@ -116,7 +116,7 @@ Puppet::Type.newtype(:dsc_xsystemrestorepoint) do
 end
 
 Puppet::Type.type(:dsc_xsystemrestorepoint).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xtimezone.rb
+++ b/lib/puppet/type/dsc_xtimezone.rb
@@ -96,7 +96,7 @@ Puppet::Type.newtype(:dsc_xtimezone) do
 end
 
 Puppet::Type.type(:dsc_xtimezone).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xuser.rb
+++ b/lib/puppet/type/dsc_xuser.rb
@@ -208,7 +208,7 @@ Puppet::Type.newtype(:dsc_xuser) do
 end
 
 Puppet::Type.type(:dsc_xuser).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -233,7 +233,7 @@ Puppet::Type.newtype(:dsc_xvhd) do
 end
 
 Puppet::Type.type(:dsc_xvhd).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -147,7 +147,7 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
 end
 
 Puppet::Type.type(:dsc_xvhdfile).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvirtualmemory.rb
+++ b/lib/puppet/type/dsc_xvirtualmemory.rb
@@ -134,7 +134,7 @@ Puppet::Type.newtype(:dsc_xvirtualmemory) do
 end
 
 Puppet::Type.type(:dsc_xvirtualmemory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvmdvddrive.rb
+++ b/lib/puppet/type/dsc_xvmdvddrive.rb
@@ -153,7 +153,7 @@ Puppet::Type.newtype(:dsc_xvmdvddrive) do
 end
 
 Puppet::Type.type(:dsc_xvmdvddrive).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvmharddiskdrive.rb
+++ b/lib/puppet/type/dsc_xvmharddiskdrive.rb
@@ -172,7 +172,7 @@ Puppet::Type.newtype(:dsc_xvmharddiskdrive) do
 end
 
 Puppet::Type.type(:dsc_xvmharddiskdrive).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvmhost.rb
+++ b/lib/puppet/type/dsc_xvmhost.rb
@@ -324,7 +324,7 @@ Puppet::Type.newtype(:dsc_xvmhost) do
 end
 
 Puppet::Type.type(:dsc_xvmhost).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -497,7 +497,7 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
 end
 
 Puppet::Type.type(:dsc_xvmhyperv).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvmnetworkadapter.rb
+++ b/lib/puppet/type/dsc_xvmnetworkadapter.rb
@@ -174,7 +174,7 @@ Puppet::Type.newtype(:dsc_xvmnetworkadapter) do
 end
 
 Puppet::Type.type(:dsc_xvmnetworkadapter).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvmprocessor.rb
+++ b/lib/puppet/type/dsc_xvmprocessor.rb
@@ -281,7 +281,7 @@ Puppet::Type.newtype(:dsc_xvmprocessor) do
 end
 
 Puppet::Type.type(:dsc_xvmprocessor).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvmscsicontroller.rb
+++ b/lib/puppet/type/dsc_xvmscsicontroller.rb
@@ -137,7 +137,7 @@ Puppet::Type.newtype(:dsc_xvmscsicontroller) do
 end
 
 Puppet::Type.type(:dsc_xvmscsicontroller).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -234,7 +234,7 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
 end
 
 Puppet::Type.type(:dsc_xvmswitch).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -148,7 +148,7 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
 end
 
 Puppet::Type.type(:dsc_xwaitforaddomain).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwaitforcertificateservices.rb
+++ b/lib/puppet/type/dsc_xwaitforcertificateservices.rb
@@ -131,7 +131,7 @@ Puppet::Type.newtype(:dsc_xwaitforcertificateservices) do
 end
 
 Puppet::Type.type(:dsc_xwaitforcertificateservices).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -114,7 +114,7 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
 end
 
 Puppet::Type.type(:dsc_xwaitforcluster).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -176,7 +176,7 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
 end
 
 Puppet::Type.type(:dsc_xwaitforsqlhagroup).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xweakhostreceive.rb
+++ b/lib/puppet/type/dsc_xweakhostreceive.rb
@@ -116,7 +116,7 @@ Puppet::Type.newtype(:dsc_xweakhostreceive) do
 end
 
 Puppet::Type.type(:dsc_xweakhostreceive).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xweakhostsend.rb
+++ b/lib/puppet/type/dsc_xweakhostsend.rb
@@ -116,7 +116,7 @@ Puppet::Type.newtype(:dsc_xweakhostsend) do
 end
 
 Puppet::Type.type(:dsc_xweakhostsend).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -308,7 +308,7 @@ Puppet::Type.newtype(:dsc_xwebapplication) do
 end
 
 Puppet::Type.type(:dsc_xwebapplication).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -904,7 +904,7 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
 end
 
 Puppet::Type.type(:dsc_xwebapppool).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwebapppooldefaults.rb
+++ b/lib/puppet/type/dsc_xwebapppooldefaults.rb
@@ -117,7 +117,7 @@ Puppet::Type.newtype(:dsc_xwebapppooldefaults) do
 end
 
 Puppet::Type.type(:dsc_xwebapppooldefaults).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -166,7 +166,7 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
 end
 
 Puppet::Type.type(:dsc_xwebconfigkeyvalue).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwebpackagedeploy.rb
+++ b/lib/puppet/type/dsc_xwebpackagedeploy.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xwebpackagedeploy) do
 end
 
 Puppet::Type.type(:dsc_xwebpackagedeploy).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -447,7 +447,7 @@ Puppet::Type.newtype(:dsc_xwebsite) do
 end
 
 Puppet::Type.type(:dsc_xwebsite).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwebsitedefaults.rb
+++ b/lib/puppet/type/dsc_xwebsitedefaults.rb
@@ -162,7 +162,7 @@ Puppet::Type.newtype(:dsc_xwebsitedefaults) do
 end
 
 Puppet::Type.type(:dsc_xwebsitedefaults).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -147,7 +147,7 @@ Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
 end
 
 Puppet::Type.type(:dsc_xwebvirtualdirectory).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwefcollector.rb
+++ b/lib/puppet/type/dsc_xwefcollector.rb
@@ -98,7 +98,7 @@ Puppet::Type.newtype(:dsc_xwefcollector) do
 end
 
 Puppet::Type.type(:dsc_xwefcollector).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwefsubscription.rb
+++ b/lib/puppet/type/dsc_xwefsubscription.rb
@@ -404,7 +404,7 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
 end
 
 Puppet::Type.type(:dsc_xwefsubscription).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwindowsfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsfeature.rb
@@ -160,7 +160,7 @@ Puppet::Type.newtype(:dsc_xwindowsfeature) do
 end
 
 Puppet::Type.type(:dsc_xwindowsfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -211,7 +211,7 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
 end
 
 Puppet::Type.type(:dsc_xwindowsoptionalfeature).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwindowspackagecab.rb
+++ b/lib/puppet/type/dsc_xwindowspackagecab.rb
@@ -128,7 +128,7 @@ Puppet::Type.newtype(:dsc_xwindowspackagecab) do
 end
 
 Puppet::Type.type(:dsc_xwindowspackagecab).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -299,7 +299,7 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
 end
 
 Puppet::Type.type(:dsc_xwindowsprocess).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwindowsupdateagent.rb
+++ b/lib/puppet/type/dsc_xwindowsupdateagent.rb
@@ -210,7 +210,7 @@ Puppet::Type.newtype(:dsc_xwindowsupdateagent) do
 end
 
 Puppet::Type.type(:dsc_xwindowsupdateagent).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -160,7 +160,7 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
 end
 
 Puppet::Type.type(:dsc_xwineventlog).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwinssetting.rb
+++ b/lib/puppet/type/dsc_xwinssetting.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:dsc_xwinssetting) do
 end
 
 Puppet::Type.type(:dsc_xwinssetting).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -144,7 +144,7 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
 end
 
 Puppet::Type.type(:dsc_xwordpresssite).provide :powershell, :parent => Puppet::Type.type(:base_dsc).provider(:powershell) do
-  confine :true => (Gem::Version.new(Facter.value(:powershell_version)) >= Gem::Version.new('5.0.10586.117'))
+  confine :feature => :dsc
   defaultfor :operatingsystem => :windows
 
   mk_resource_methods


### PR DESCRIPTION
NOTE: This is a bit of a "hot take" on how to fix this. I think it should also clean up what happens with `DSC_MODULE_POWERSHELL_UPGRADE_MSG`, and I'm not sure if the feature name should be something other than `dsc`. It may make sense to remove the confine on the provider altogether given there are other checks performed later - i.e. we're checking in two separate places for the same thing.


 - Previously when a version of PowerShell older than 5.0.10586.117
   was installed, Puppet would return an error message like:

   Error: Could not find a suitable provider for dsc_file

   Unfortunately this message did not yield any useful information,
   even with --debug and --verbose turned on, because of the way the
   existing confine check was performed with a confine :true

   To produce a more useful message that is meaningful to users,
   introduce a new feature that performs the same check as the
   confine, but that also will issue an error message (only once)
   that indicates the installed version / required version constraints
   for the module, changing the output to:.

   Error: The dsc module requires PowerShell version 5.0.10586.117 - current version 5.0.10514.6\n   (file & line not available)
   Error: Could not find a suitable provider for dsc_file

 - Note that DSC_MODULE_POWERSHELL_UPGRADE_MSG is never actually shown
   when the PowerShell version is < 5.0.10586.117 because the check
   occurs too late in the lifecycle of loading providers. The confine
   code has already evaluated, preventing the other messsages from
   being shown.