### PR TITLE
(MODULES-2310) Support Unicode parameters

### DIFF
--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -197,7 +197,8 @@ EOT
   def self.ps_script_content(mode, resource, provider)
     dsc_invoke_method = mode
     @param_hash = resource
-    template = ERB.new(File.new(template_path + "/invoke_dsc_resource.ps1.erb").read, nil, '-')
+    file = File.new(template_path + "/invoke_dsc_resource.ps1.erb", :encoding => Encoding::UTF_8)
+    template = ERB.new(file.read, nil, '-')
     template.result(binding)
   end
 end


### PR DESCRIPTION
 - Previously templates were renderd in the Default.external_encoding
   which would cause injection of UTF-8 content to create incorrect
   strings.

   For instance, the ERB template would load as IBM437, then Unicode
   content would be coerced to that encoding when rendering an ERB
   template.

   Since manifest content is guaranteed to be UTF-8 and since the ERB
   template is guaranteed to be UTF-8, enforce this in code