### PR TITLE
(MODULES-7055) Fix DSC Module Version Parsing

### DIFF
--- a/build/dsc/psmodule.rb
+++ b/build/dsc/psmodule.rb
@@ -10,8 +10,8 @@ module Dsc
     end
 
     def version
-      raise "ModuleVersion not found for module #{@name} / #{@module_manifest_path}" if !attributes.key?('ModuleVersion') || attributes['ModuleVersion'].empty?
-      attributes['ModuleVersion']
+      raise "ModuleVersion not found for module #{@name} / #{@module_manifest_path}" if !attributes.key?('moduleversion') || attributes['moduleversion'].empty?
+      attributes['moduleversion']
     end
 
     def attributes
@@ -25,7 +25,7 @@ module Dsc
             utf8_encoded_content.lines.each do |line|
               dos2unix(line)
               matches = regex.match(line)
-              attrs[matches[1].strip] = matches[2] if matches
+              attrs[matches[1].strip.downcase] = matches[2] if matches
             end
             @attributes = attrs
           end

--- a/build/dsc/psmodule.rb
+++ b/build/dsc/psmodule.rb
@@ -14,6 +14,8 @@ module Dsc
       attributes['moduleversion']
     end
 
+    private
+
     def attributes
       begin
         unless @attributes
@@ -35,8 +37,6 @@ module Dsc
         raise "could not read psd1 manifest file for #{@name} / #{@module_manifest_path}: #{e}"
       end
     end
-
-    private
 
     def utf8_encode_content(content)
       detection = CharlockHolmes::EncodingDetector.detect(content)

--- a/spec/unit/psmodule_spec.rb
+++ b/spec/unit/psmodule_spec.rb
@@ -13,39 +13,39 @@ describe Dsc::Psmodule, :if => charlock_holmes_available do
   describe "when parsing a psd1 manifest" do
 
     describe "with single quotes" do
-      let (:psmodule){ 
+      let (:psmodule){
         module_name = 'foo'
         module_manifest_path = File.join(File.dirname(__FILE__), '../fixtures/singlequotes.psd1')
         Dsc::Psmodule.new(module_name, module_manifest_path)
       }
 
       it "should parse" do
-        attributes = psmodule.attributes
-        expect(attributes).not_to eq(nil)
+        data = psmodule.version
+        expect(data).not_to eq(nil)
       end
     end
 
     describe "with double quotes" do
-      let (:psmodule){ 
+      let (:psmodule){
         module_name = 'foo'
         module_manifest_path = File.join(File.dirname(__FILE__), '../fixtures/doublequotes.psd1')
         Dsc::Psmodule.new(module_name, module_manifest_path)
       }
       it "should parse" do
-        attributes = psmodule.attributes
-        expect(attributes).not_to eq(nil)
+        data = psmodule.version
+        expect(data).not_to eq(nil)
       end
     end
 
     describe "that is invlaid" do
-      let (:psmodule){ 
+      let (:psmodule){
         module_name = 'foo'
         module_manifest_path = File.join(File.dirname(__FILE__), '../fixtures/bad.psd1')
         Dsc::Psmodule.new(module_name, module_manifest_path)
       }
 
       it "should fail" do
-        expect{psmodule.attributes}.to raise_error(RuntimeError,/could not read psd1 manifest file for foo/)
+        expect{psmodule.version}.to raise_error(RuntimeError,/could not read psd1 manifest file for foo/)
       end
     end
 


### PR DESCRIPTION
This commit fixes parsing the moduleversion part of the psd1 manifest
file for a DSC Resource by lowercasing each attribute before adding it
to the attribute hash. This avoids any casing differences introduced by
a DSC Resource author that differs from the string 'ModuleVersion'.