### PR TITLE
(IMAGES-795) 2008r2 Failing PowerShell Tests

### DIFF
--- a/lib/puppet_x/templates/dsc/init_ps.ps1
+++ b/lib/puppet_x/templates/dsc/init_ps.ps1
@@ -736,6 +736,8 @@ function Start-PipeServer
     $Encoding
   )
 
+  Add-Type -AssemblyName "System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+
   # this does not require versioning in the payload as client / server are tightly coupled
   $server = New-Object System.IO.Pipes.NamedPipeServerStream($CommandChannelPipeName,
     [System.IO.Pipes.PipeDirection]::InOut)


### PR DESCRIPTION
The newest image for Windows 2008r2 is exhibiting different behavior
for loading .NET assemblies than we have seen in the past. The
System.Core assembly is not loaded into the PowerShell host process by
default any longer. This causes the init.ps1 script in the module to
to fail to start a Pipe Server to receive PowerShell scripts to be
executed. This change always attempts to load the System.Core
assembly prior to creating the pipe server object. Explicity loading the
assembly fixes the issue and the newest image becomes usable again. This
fix is also require to fix any moduels that depend on the PowerShell
exec provider working properly.