### PR TITLE
(WIP)(maint) Make build tasks work on windows

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,7 +6,6 @@ Gemfile:
       - gem: mof
         git: 'https://github.com/puppetlabs/mof.git'
         ref: 'f50581901c53ff6a40c54b72ef5f4fcaed9679a1'
-      - gem: charlock_holmes
       - gem: iconv
         version: '~> 1.0.4'
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0')"

--- a/Gemfile
+++ b/Gemfile
@@ -55,18 +55,17 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')                  
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
   gem "beaker-pe",                                                               :require => false
-  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
 end
 
 group :build do
   gem "cim",               :require => false
-  gem "mof",               :require => false, :git => 'https://github.com/puppetlabs/mof.git', :ref => 'f50581901c53ff6a40c54b72ef5f4fcaed9679a1'
-  gem "charlock_holmes",   :require => false
+  gem "mof",               :require => false,:git => 'https://github.com/jpogran/mof.git', :ref => '73221aca1b412795a9de0a62848f7788809ec30c'
   gem "iconv", '~> 1.0.4', :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0')
 end
 

--- a/build/dsc.rb
+++ b/build/dsc.rb
@@ -11,7 +11,6 @@ require 'logger'
 if Bundler.rubygems.find_name('mof').any?
   require 'mof'
   require 'cim'
-  require 'charlock_holmes/string'
 end
 
 # Debug

--- a/build/dsc/manager.rb
+++ b/build/dsc/manager.rb
@@ -183,7 +183,7 @@ module Dsc
         if resource.friendlyname
           puppet_type_path = "#{@target_module_path}/#{@puppet_type_subpath}"
           FileUtils.mkdir_p(puppet_type_path) unless File.exists?(puppet_type_path)
-          File.open("#{puppet_type_path}/dsc_#{resource.friendlyname.downcase}.rb", 'w+') do |file|
+          File.open("#{puppet_type_path}/dsc_#{resource.friendlyname.downcase}.rb", 'w+b') do |file|
             file.write(type_erb.result(binding))
             pn = Pathname.new(file.path).expand_path.relative_path_from(@module_path)
             type_pathes << "Add type - #{pn.to_s}"
@@ -191,7 +191,7 @@ module Dsc
           puppet_type_spec_path = "#{@target_module_path}/#{@puppet_type_spec_subpath}"
           FileUtils.mkdir_p(puppet_type_spec_path) unless File.exists?(puppet_type_spec_path)
           if whitelist.include?(resource.friendlyname.downcase)
-            File.open("#{puppet_type_spec_path}/dsc_#{resource.friendlyname.downcase}_spec.rb", 'w+') do |file|
+            File.open("#{puppet_type_spec_path}/dsc_#{resource.friendlyname.downcase}_spec.rb", 'w+b') do |file|
               file.write(type_spec_erb.result(binding))
               pn = Pathname.new(file.path).expand_path.relative_path_from(@module_path)
               type_pathes << "Add type spec - #{pn.to_s}"

--- a/build/dsc/mof.rb
+++ b/build/dsc/mof.rb
@@ -68,7 +68,7 @@ module Dsc
     private
 
     def create_index_mof(index_mof_file_name, mofs)
-      File.open(index_mof_file_name, 'w') do |file|
+      File.open(index_mof_file_name, 'wb') do |file|
         mofs.each{|mof_path| file.write("#pragma include (\"#{mof_path}\")\n") }
       end
     end

--- a/build/dsc/property.rb
+++ b/build/dsc/property.rb
@@ -21,6 +21,7 @@ module Dsc
       begin
         if @description.nil? && @cim_feature.description
           content = @cim_feature.description
+          content.force_encoding(Encoding::UTF_8)
           content.gsub!(/\xe2\x80\x9c/u, "'") # usage of single quotes as this string will be injected in a double bracket "#{content}"
           content.gsub!(/\xe2\x80\x9d/u, "'") # usage of single quotes as this string will be injected in a double bracket "#{content}"
           content.gsub!(/\xe2\x80\x98/u, "'")

--- a/spec/unit/psmodule_spec.rb
+++ b/spec/unit/psmodule_spec.rb
@@ -1,15 +1,7 @@
 require 'spec_helper'
 require File.join(File.dirname(__FILE__), '../../build/dsc/psmodule')
 
-charlock_holmes_available = false
-begin
-  require 'charlock_holmes'
-  charlock_holmes_available = true
-rescue LoadError
-  # If any LoadErrors are thrown then charlock_holmes is not available as a gem
-end
-
-describe Dsc::Psmodule, :if => charlock_holmes_available do
+describe Dsc::Psmodule do
   describe "when parsing a psd1 manifest" do
 
     describe "with single quotes" do


### PR DESCRIPTION
This commit enables building this module on windows platforms by
removing the charlock_holmes dependency and updating all file read/write
methods to use binary methods.

The charlock_holmes gem is only used to parse psd1 manifest files, so
the removal is constrained to one location. The gem is replaced with
inline encoding enforcement to UTF8. We don't need to worry about all
the variances that charlock_holmes worries about, we only read the psd1
file to get the version number. This is also less important as we move
to PSGallery imports and deprecate git imports.

All relevant file methods were updated to use binary reads and writes to
avoid CRLF differences when writing and reading files on windows. This
setting will 'do the right thing' regardless on windows or on linux/mac.

Note, this is dependent on PR https://github.com/puppetlabs/mof/pull/5
which updates the MOF parser to handle absolute paths on windows.