### PR TITLE
(MODULES-5623) Handle DateTime values correctly

### DIFF
--- a/lib/puppet/provider/templates/dsc/invoke_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/templates/dsc/invoke_dsc_resource.ps1.erb
@@ -35,6 +35,8 @@ $invokeParams = @{
     <%- name = p.name.to_s.gsub(/^dsc_/,'')
     if name == 'ensure' && dsc_invoke_method == 'test'
       value = "\'#{resource.parameters[:ensure].default.to_s}\'"
+    elsif p.mof_type == 'datetime'
+      value = "[System.DateTime]#{format_dsc_value(p.value)}"
     elsif p.mof_type == 'MSFT_Credential'
       value = "[PSCustomObject]#{format_dsc_value(p.value)} | new-pscredential"
     elsif p.mof_is_embedded? && p.mof_type != 'MSFT_KeyValuePair'


### PR DESCRIPTION
DateTime values should be passed along as System.DateTime objects and not pure strings, this fixes issues with `starttime` property not being handled correctly.