### PR TITLE
(MAINT) refactor dsc tests to include --detailed-exitcodes

### DIFF
--- a/spec/acceptance/basic_dsc_resources/file/file_valid_spec.rb
+++ b/spec/acceptance/basic_dsc_resources/file/file_valid_spec.rb
@@ -111,14 +111,12 @@ describe 'Apply DSC "File" resource' do
 
       windows_agents.each do |agent|
         it 'should not scramble UTF8 content in the destination file' do
-          on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2]) do |result|
-            expect(result.stderr).to_not match(/Error:/)
-          end
+          on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2])
 
           md5_result = on(agent, "md5sum /cygdrive/c/#{@work_dir}/#{@test_file_name}", :acceptable_exit_codes => 0)
           test_file_md5_sum_regex = /60d964865c387e3dde467eff47d6bbf1/
-          # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode content
-          expect(md5_result.output).to_not match(test_file_md5_sum_regex)
+
+          expect(md5_result.output).to match(test_file_md5_sum_regex)
         end
       end
     end
@@ -145,12 +143,8 @@ describe 'Apply DSC "File" resource' do
 
       windows_agents.each do |agent|
         it "should create a file with Unicode characters in the name on #{agent.name}" do
-          on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2]) do |result|
-            expect(result.stderr).to_not match(/Error:/)
-          end
-
-          # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode names
-          expect { on(agent, "test -f /cygdrive/c/#{@work_dir}/#{@test_file_name}", :acceptable_exit_codes => 0) }.to raise_error(Beaker::Host::CommandFailure)
+          on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2])
+          on(agent, "test -f /cygdrive/c/#{@work_dir}/#{@test_file_name}", :acceptable_exit_codes => 0)
         end
       end
     end
@@ -181,10 +175,7 @@ describe 'Apply DSC "File" resource' do
 
       windows_agents.each do |agent|
         it "should create a file with Unicode characters in the SourcePath on #{agent.name}" do
-          # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode names
-          on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2]) do |result|
-            expect(result.stderr).to match(/Error:/)
-          end
+          on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2])
         end
       end
     end


### PR DESCRIPTION
Refactor unicode tests into their own .rb file

Removed unneeded helper methods.

Changed variable scope to be more sane.