### PR TITLE
(MODULES-7462) Fix broken type files

### DIFF
--- a/lib/facter/powershell_version.rb
+++ b/lib/facter/powershell_version.rb
@@ -3,9 +3,7 @@ require Pathname.new(__FILE__).dirname + '../' + 'puppet_x/puppetlabs/powershell
 
 Facter.add(:powershell_version) do
   setcode do
-    if Puppet::Util::Platform.windows?
-      version = PuppetX::PuppetLabs::Dsc::PowerShellVersion.version
-      version
-    end
+    platform = Puppet::Util::Platform
+    platform.windows? ? PuppetX::PuppetLabs::Dsc::PowerShellVersion.version : 0
   end
 end


### PR DESCRIPTION
The ruby gems project has changed the behavior of the
Gem::Version.correct? function. Previously when given nil as an argument
it would return true. Returning true from that function meant that a
call like Gem::Version.new(nil) would return an empty string for a
version number. This worked for us because when we compared versions, an
empty string was considered less than the version number we were testing
against and the code would evaluate without error.

Starting with rubygems/rubygems#2203 which
landed in gems 2.7.7, that function now returns false when given nil as
its argument, which causes Gem::Version.new(nil) to throw an error. This
is problematic for us because even though we take efforts to ensure that
only tests that can run on non windows platforms are ever run there, the
code that enforces the platform guards is evaluated after the types
themselves are evaluated. This causes errors to be thrown before test
files can be filtered out.

This change ensures a value that can be compared is generated when
requesting a new version object.