### PR TITLE
(MODULES-8071) Fix UTF-8 acceptance tests for Puppet 6

### DIFF
--- a/spec/acceptance/basic_dsc_resources/file/file_valid_spec.rb
+++ b/spec/acceptance/basic_dsc_resources/file/file_valid_spec.rb
@@ -72,9 +72,9 @@ describe 'Apply DSC "File" resource' do
     windows_agents.each do |agent|
       it "creates a destination file from the source file on #{agent.name}" do
         dsc_props = {
-          :dsc_ensure => 'Present',
-          :dsc_destinationpath => "C:\\#{@work_dir}\\#{@destinationpath}",
-          :dsc_sourcepath => "C:\\#{@work_dir}\\#{@sourcepath}"
+            :dsc_ensure => 'Present',
+            :dsc_destinationpath => "C:\\#{@work_dir}\\#{@destinationpath}",
+            :dsc_sourcepath => "C:\\#{@work_dir}\\#{@sourcepath}"
         }
         dsc_manifest = single_dsc_resource_manifest(dsc_type, dsc_props)
 
@@ -117,8 +117,13 @@ describe 'Apply DSC "File" resource' do
 
           md5_result = on(agent, "md5sum /cygdrive/c/#{@work_dir}/#{@test_file_name}", :acceptable_exit_codes => 0)
           test_file_md5_sum_regex = /60d964865c387e3dde467eff47d6bbf1/
-          # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode content
-          expect(md5_result.output).to_not match(test_file_md5_sum_regex)
+
+          if puppet_version(agent) >= '6'
+            expect(md5_result.output).to match(test_file_md5_sum_regex)
+          else
+            # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode content in puppet versions less than 6
+            expect(md5_result.output).to_not match(test_file_md5_sum_regex)
+          end
         end
       end
     end
@@ -145,12 +150,13 @@ describe 'Apply DSC "File" resource' do
 
       windows_agents.each do |agent|
         it "should create a file with Unicode characters in the name on #{agent.name}" do
-          on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2]) do |result|
-            expect(result.stderr).to_not match(/Error:/)
+          on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2])
+          if puppet_version(agent) >= '6'
+            on(agent, "test -f /cygdrive/c/#{@work_dir}/#{@test_file_name}", :acceptable_exit_codes => 0)
+          else
+            # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode content in puppet versions less than 6
+            expect {on(agent, "test -f /cygdrive/c/#{@work_dir}/#{@test_file_name}", :acceptable_exit_codes => 0)}.to raise_error(Beaker::Host::CommandFailure)
           end
-
-          # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode names
-          expect { on(agent, "test -f /cygdrive/c/#{@work_dir}/#{@test_file_name}", :acceptable_exit_codes => 0) }.to raise_error(Beaker::Host::CommandFailure)
         end
       end
     end
@@ -181,12 +187,17 @@ describe 'Apply DSC "File" resource' do
 
       windows_agents.each do |agent|
         it "should create a file with Unicode characters in the SourcePath on #{agent.name}" do
-          # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode names
           on(agent, puppet("apply C:\\\\#{@work_dir}\\\\#{@test_manifest_name}"), :acceptable_exit_codes => [0, 2]) do |result|
-            expect(result.stderr).to match(/Error:/)
+            if puppet_version(agent) >= '6'
+              expect(result.stderr).to_not match(/Error:/)
+            else
+              # Due to UTF-8 bug found in MODULES-2310, DSC File resource doesn't handle Unicode content in puppet versions less than 6
+              expect(result.stderr).to match(/Error:/)
+            end
           end
         end
       end
     end
   end
 end
+

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -69,3 +69,7 @@ def create_remote_windows_file(hosts, windows_path, content)
   windows_path = windows_path.gsub('\\','\\\\\\')
   on(hosts, "cmd.exe /c echo #{content} > #{windows_path}", :accept_all_exit_codes => true)
 end
+
+def puppet_version(agent)
+  on(agent, puppet('--version', :acceptable_exit_codes => 0)).stdout
+end


### PR DESCRIPTION
Somewhere between Puppet versions 5.5.6 and 6.0.0 UTF-8 characters became properly encoded.
Our previous tests were expecting those tests to fail. This patch branches the tests based
on Puppet version 6 and expects failures on any version less than 6 and expects the UTF-8
encoding to work properly on any puppet version greater than or equal to 6.