### PR TITLE
(MODULES-8389) Ensure Build Works if DSC Module Not Tagged

### DIFF
--- a/dsc_resource_release_tags.yml
+++ b/dsc_resource_release_tags.yml
@@ -53,3 +53,14 @@ xWindowsRestore: 1.0.0-PSGallery
 xWindowsUpdate: 2.7.0.0-PSGallery
 xWinEventLog: 1.1.0.0-PSGallery
 xWordPress: 1.1.0.0-PSGallery
+xDisk: 1.0-PSGallery
+WmiNamespaceSecurityDsc: d49daa4c18f12aabf32fd60631d927c6d276a453
+iSCSIDsc: 2208ad24a0cc0a85ce19fb377e72fbc21d366587
+FSRMDsc: 8945f610fa9a6f7f920260abf4e50d91db25bac0
+FileContentDsc: 272086660b16874a400800a76b85ee47e26421e2
+WSManDsc: 1aa6400e7ffa1932505bf9904a7ce9e147af9c45
+CertificateDsc: 4.2.0.0-PSGallery
+NetworkingDsc: 6.2.0.0-PSGallery
+ComputerManagementDsc: 6.0.0.0-PSGallery
+DFSDsc: 4.2.0.0-PSGallery
+ActiveDirectoryCSDsc: 3.0.0.0-PSGallery


### PR DESCRIPTION
Prior to this commit the build task would fail out on any PowerShell
DSC module which did not have a tag in its repository which ended in
`-PSGallery` - since our last release, this is true of multiple
modules included in the DSC Resource module maintained by Microsoft.

Even if a tracked version was specified the build still failed because
it checked for a tag regardless of whether the version was tracked.

This commit updates the rake task for checkout by only searching for
versions in the module repository if no tracked version is declared.

It also updates the list of tracked versions to include those on which
the module build would fail because of missing tags.