### PR TITLE
(MODULES-8172) Sensitive fixes across versions

### DIFF
--- a/lib/puppet/type/dsc_accountpolicy.rb
+++ b/lib/puppet/type/dsc_accountpolicy.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_accountpolicy) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_archive.rb
+++ b/lib/puppet/type/dsc_archive.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_archive) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -169,6 +172,9 @@ Puppet::Type.newtype(:dsc_archive) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_auditpolicycsv.rb
+++ b/lib/puppet/type/dsc_auditpolicycsv.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_auditpolicycsv) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_auditpolicyoption.rb
+++ b/lib/puppet/type/dsc_auditpolicyoption.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_auditpolicyoption) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_auditpolicysubcategory.rb
+++ b/lib/puppet/type/dsc_auditpolicysubcategory.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_auditpolicysubcategory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_disk.rb
+++ b/lib/puppet/type/dsc_disk.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_disk) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DriveLetter

--- a/lib/puppet/type/dsc_diskaccesspath.rb
+++ b/lib/puppet/type/dsc_diskaccesspath.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_diskaccesspath) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         AccessPath

--- a/lib/puppet/type/dsc_environment.rb
+++ b/lib/puppet/type/dsc_environment.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_environment) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_file.rb
+++ b/lib/puppet/type/dsc_file.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_file) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DestinationPath
@@ -200,6 +203,9 @@ Puppet::Type.newtype(:dsc_file) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_group.rb
+++ b/lib/puppet/type/dsc_group.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_group) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GroupName
@@ -171,6 +174,9 @@ Puppet::Type.newtype(:dsc_group) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_log.rb
+++ b/lib/puppet/type/dsc_log.rb
@@ -50,6 +50,9 @@ Puppet::Type.newtype(:dsc_log) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Message

--- a/lib/puppet/type/dsc_mountimage.rb
+++ b/lib/puppet/type/dsc_mountimage.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_mountimage) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ImagePath

--- a/lib/puppet/type/dsc_officeonlineserverfarm.rb
+++ b/lib/puppet/type/dsc_officeonlineserverfarm.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_officeonlineserverfarm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         AllowCEIP

--- a/lib/puppet/type/dsc_officeonlineserverinstall.rb
+++ b/lib/puppet/type/dsc_officeonlineserverinstall.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_officeonlineserverinstall) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_officeonlineserverinstalllanguagepack.rb
+++ b/lib/puppet/type/dsc_officeonlineserverinstalllanguagepack.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_officeonlineserverinstalllanguagepack) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_officeonlineservermachine.rb
+++ b/lib/puppet/type/dsc_officeonlineservermachine.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_officeonlineservermachine) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_opticaldiskdriveletter.rb
+++ b/lib/puppet/type/dsc_opticaldiskdriveletter.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_opticaldiskdriveletter) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DiskId

--- a/lib/puppet/type/dsc_package.rb
+++ b/lib/puppet/type/dsc_package.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_package) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -149,6 +152,9 @@ Puppet::Type.newtype(:dsc_package) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_registry.rb
+++ b/lib/puppet/type/dsc_registry.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_registry) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Key

--- a/lib/puppet/type/dsc_runbookdirectory.rb
+++ b/lib/puppet/type/dsc_runbookdirectory.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_runbookdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_script.rb
+++ b/lib/puppet/type/dsc_script.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_script) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GetScript
@@ -116,6 +119,9 @@ Puppet::Type.newtype(:dsc_script) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_securityoption.rb
+++ b/lib/puppet/type/dsc_securityoption.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_securityoption) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_securitytemplate.rb
+++ b/lib/puppet/type/dsc_securitytemplate.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_securitytemplate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_service.rb
+++ b/lib/puppet/type/dsc_service.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_service) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -137,6 +140,9 @@ Puppet::Type.newtype(:dsc_service) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_smavariable.rb
+++ b/lib/puppet/type/dsc_smavariable.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_smavariable) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_spaccessserviceapp.rb
+++ b/lib/puppet/type/dsc_spaccessserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spaccessserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -133,6 +136,9 @@ Puppet::Type.newtype(:dsc_spaccessserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spaccessservices2010.rb
+++ b/lib/puppet/type/dsc_spaccessservices2010.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spaccessservices2010) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_spaccessservices2010) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spalternateurl.rb
+++ b/lib/puppet/type/dsc_spalternateurl.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_spalternateurl) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppName
@@ -156,6 +159,9 @@ Puppet::Type.newtype(:dsc_spalternateurl) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spantivirussettings.rb
+++ b/lib/puppet/type/dsc_spantivirussettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spantivirussettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ScanOnDownload
@@ -168,6 +171,9 @@ Puppet::Type.newtype(:dsc_spantivirussettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spappcatalog.rb
+++ b/lib/puppet/type/dsc_spappcatalog.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spappcatalog) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SiteUrl
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_spappcatalog) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spappdomain.rb
+++ b/lib/puppet/type/dsc_spappdomain.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spappdomain) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         AppDomain
@@ -98,6 +101,9 @@ Puppet::Type.newtype(:dsc_spappdomain) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spappmanagementserviceapp.rb
+++ b/lib/puppet/type/dsc_spappmanagementserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spappmanagementserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -163,6 +166,9 @@ Puppet::Type.newtype(:dsc_spappmanagementserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spappstoresettings.rb
+++ b/lib/puppet/type/dsc_spappstoresettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spappstoresettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -115,6 +118,9 @@ Puppet::Type.newtype(:dsc_spappstoresettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spbcsserviceapp.rb
+++ b/lib/puppet/type/dsc_spbcsserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spbcsserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -163,6 +166,9 @@ Puppet::Type.newtype(:dsc_spbcsserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spblobcachesettings.rb
+++ b/lib/puppet/type/dsc_spblobcachesettings.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spblobcachesettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -185,6 +188,9 @@ Puppet::Type.newtype(:dsc_spblobcachesettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spcacheaccounts.rb
+++ b/lib/puppet/type/dsc_spcacheaccounts.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spcacheaccounts) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -129,6 +132,9 @@ Puppet::Type.newtype(:dsc_spcacheaccounts) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spconfigwizard.rb
+++ b/lib/puppet/type/dsc_spconfigwizard.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spconfigwizard) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -131,6 +134,9 @@ Puppet::Type.newtype(:dsc_spconfigwizard) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spcontentdatabase.rb
+++ b/lib/puppet/type/dsc_spcontentdatabase.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spcontentdatabase) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -185,6 +188,9 @@ Puppet::Type.newtype(:dsc_spcontentdatabase) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spcreatefarm.rb
+++ b/lib/puppet/type/dsc_spcreatefarm.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spcreatefarm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         FarmConfigDatabaseName
@@ -101,6 +104,9 @@ Puppet::Type.newtype(:dsc_spcreatefarm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("FarmAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Passphrase
@@ -116,6 +122,9 @@ Puppet::Type.newtype(:dsc_spcreatefarm) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Passphrase", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -201,6 +210,9 @@ Puppet::Type.newtype(:dsc_spcreatefarm) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spdatabaseaag.rb
+++ b/lib/puppet/type/dsc_spdatabaseaag.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spdatabaseaag) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DatabaseName
@@ -133,6 +136,9 @@ Puppet::Type.newtype(:dsc_spdatabaseaag) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spdesignersettings.rb
+++ b/lib/puppet/type/dsc_spdesignersettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spdesignersettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -213,6 +216,9 @@ Puppet::Type.newtype(:dsc_spdesignersettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spdiagnosticloggingsettings.rb
+++ b/lib/puppet/type/dsc_spdiagnosticloggingsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spdiagnosticloggingsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         LogPath
@@ -371,6 +374,9 @@ Puppet::Type.newtype(:dsc_spdiagnosticloggingsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spdiagnosticsprovider.rb
+++ b/lib/puppet/type/dsc_spdiagnosticsprovider.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spdiagnosticsprovider) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -155,6 +158,9 @@ Puppet::Type.newtype(:dsc_spdiagnosticsprovider) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spdistributedcacheclientsettings.rb
+++ b/lib/puppet/type/dsc_spdistributedcacheclientsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spdistributedcacheclientsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance
@@ -626,6 +629,9 @@ Puppet::Type.newtype(:dsc_spdistributedcacheclientsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spdistributedcacheservice.rb
+++ b/lib/puppet/type/dsc_spdistributedcacheservice.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spdistributedcacheservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -170,6 +173,9 @@ Puppet::Type.newtype(:dsc_spdistributedcacheservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spexcelserviceapp.rb
+++ b/lib/puppet/type/dsc_spexcelserviceapp.rb
@@ -76,6 +76,9 @@ Puppet::Type.newtype(:dsc_spexcelserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -445,6 +448,9 @@ Puppet::Type.newtype(:dsc_spexcelserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spfarm.rb
+++ b/lib/puppet/type/dsc_spfarm.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spfarm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -119,6 +122,9 @@ Puppet::Type.newtype(:dsc_spfarm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("FarmAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Passphrase
@@ -134,6 +140,9 @@ Puppet::Type.newtype(:dsc_spfarm) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Passphrase", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -235,6 +244,9 @@ Puppet::Type.newtype(:dsc_spfarm) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spfarmadministrators.rb
+++ b/lib/puppet/type/dsc_spfarmadministrators.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spfarmadministrators) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -137,6 +140,9 @@ Puppet::Type.newtype(:dsc_spfarmadministrators) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spfarmpropertybag.rb
+++ b/lib/puppet/type/dsc_spfarmpropertybag.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spfarmpropertybag) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Key
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_spfarmpropertybag) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spfarmsolution.rb
+++ b/lib/puppet/type/dsc_spfarmsolution.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spfarmsolution) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -185,6 +188,9 @@ Puppet::Type.newtype(:dsc_spfarmsolution) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spfeature.rb
+++ b/lib/puppet/type/dsc_spfeature.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spfeature) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -153,6 +156,9 @@ Puppet::Type.newtype(:dsc_spfeature) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sphealthanalyzerrulestate.rb
+++ b/lib/puppet/type/dsc_sphealthanalyzerrulestate.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_sphealthanalyzerrulestate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -151,6 +154,9 @@ Puppet::Type.newtype(:dsc_sphealthanalyzerrulestate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spinfopathformsserviceconfig.rb
+++ b/lib/puppet/type/dsc_spinfopathformsserviceconfig.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spinfopathformsserviceconfig) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -310,6 +313,9 @@ Puppet::Type.newtype(:dsc_spinfopathformsserviceconfig) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spinstall.rb
+++ b/lib/puppet/type/dsc_spinstall.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spinstall) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         BinaryDir

--- a/lib/puppet/type/dsc_spinstalllanguagepack.rb
+++ b/lib/puppet/type/dsc_spinstalllanguagepack.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spinstalllanguagepack) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         BinaryDir
@@ -146,6 +149,9 @@ Puppet::Type.newtype(:dsc_spinstalllanguagepack) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spinstallprereqs.rb
+++ b/lib/puppet/type/dsc_spinstallprereqs.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spinstallprereqs) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstallerPath

--- a/lib/puppet/type/dsc_spirmsettings.rb
+++ b/lib/puppet/type/dsc_spirmsettings.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spirmsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -119,6 +122,9 @@ Puppet::Type.newtype(:dsc_spirmsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spjoinfarm.rb
+++ b/lib/puppet/type/dsc_spjoinfarm.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spjoinfarm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         FarmConfigDatabaseName
@@ -101,6 +104,9 @@ Puppet::Type.newtype(:dsc_spjoinfarm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Passphrase", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServerRole
@@ -134,6 +140,9 @@ Puppet::Type.newtype(:dsc_spjoinfarm) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sploglevel.rb
+++ b/lib/puppet/type/dsc_sploglevel.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_sploglevel) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -134,6 +137,9 @@ Puppet::Type.newtype(:dsc_sploglevel) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spmachinetranslationserviceapp.rb
+++ b/lib/puppet/type/dsc_spmachinetranslationserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spmachinetranslationserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -163,6 +166,9 @@ Puppet::Type.newtype(:dsc_spmachinetranslationserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spmanagedaccount.rb
+++ b/lib/puppet/type/dsc_spmanagedaccount.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spmanagedaccount) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         AccountName
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_spmanagedaccount) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Account", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -170,6 +176,9 @@ Puppet::Type.newtype(:dsc_spmanagedaccount) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spmanagedmetadataserviceapp.rb
+++ b/lib/puppet/type/dsc_spmanagedmetadataserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spmanagedmetadataserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -233,6 +236,9 @@ Puppet::Type.newtype(:dsc_spmanagedmetadataserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spmanagedmetadataserviceappdefault.rb
+++ b/lib/puppet/type/dsc_spmanagedmetadataserviceappdefault.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spmanagedmetadataserviceappdefault) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance
@@ -116,6 +119,9 @@ Puppet::Type.newtype(:dsc_spmanagedmetadataserviceappdefault) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spmanagedpath.rb
+++ b/lib/puppet/type/dsc_spmanagedpath.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spmanagedpath) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -152,6 +155,9 @@ Puppet::Type.newtype(:dsc_spmanagedpath) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spminrolecompliance.rb
+++ b/lib/puppet/type/dsc_spminrolecompliance.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spminrolecompliance) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         State
@@ -86,6 +89,9 @@ Puppet::Type.newtype(:dsc_spminrolecompliance) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spofficeonlineserverbinding.rb
+++ b/lib/puppet/type/dsc_spofficeonlineserverbinding.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spofficeonlineserverbinding) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Zone
@@ -121,6 +124,9 @@ Puppet::Type.newtype(:dsc_spofficeonlineserverbinding) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spoutgoingemailsettings.rb
+++ b/lib/puppet/type/dsc_spoutgoingemailsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spoutgoingemailsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -177,6 +180,9 @@ Puppet::Type.newtype(:dsc_spoutgoingemailsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sppasswordchangesettings.rb
+++ b/lib/puppet/type/dsc_sppasswordchangesettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_sppasswordchangesettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         MailAddress
@@ -137,6 +140,9 @@ Puppet::Type.newtype(:dsc_sppasswordchangesettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spperformancepointserviceapp.rb
+++ b/lib/puppet/type/dsc_spperformancepointserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spperformancepointserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -163,6 +166,9 @@ Puppet::Type.newtype(:dsc_spperformancepointserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sppowerpointautomationserviceapp.rb
+++ b/lib/puppet/type/dsc_sppowerpointautomationserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_sppowerpointautomationserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -223,6 +226,9 @@ Puppet::Type.newtype(:dsc_sppowerpointautomationserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spproductupdate.rb
+++ b/lib/puppet/type/dsc_spproductupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spproductupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SetupFile
@@ -162,6 +165,9 @@ Puppet::Type.newtype(:dsc_spproductupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectserveradditionalsettings.rb
+++ b/lib/puppet/type/dsc_spprojectserveradditionalsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spprojectserveradditionalsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -129,6 +132,9 @@ Puppet::Type.newtype(:dsc_spprojectserveradditionalsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectserveradresourcepoolsync.rb
+++ b/lib/puppet/type/dsc_spprojectserveradresourcepoolsync.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spprojectserveradresourcepoolsync) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -137,6 +140,9 @@ Puppet::Type.newtype(:dsc_spprojectserveradresourcepoolsync) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectserverglobalpermissions.rb
+++ b/lib/puppet/type/dsc_spprojectserverglobalpermissions.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spprojectserverglobalpermissions) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -156,6 +159,9 @@ Puppet::Type.newtype(:dsc_spprojectserverglobalpermissions) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectservergroup.rb
+++ b/lib/puppet/type/dsc_spprojectservergroup.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spprojectservergroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -204,6 +207,9 @@ Puppet::Type.newtype(:dsc_spprojectservergroup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectserverlicense.rb
+++ b/lib/puppet/type/dsc_spprojectserverlicense.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spprojectserverlicense) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -103,6 +106,9 @@ Puppet::Type.newtype(:dsc_spprojectserverlicense) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectserverpermissionmode.rb
+++ b/lib/puppet/type/dsc_spprojectserverpermissionmode.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spprojectserverpermissionmode) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -101,6 +104,9 @@ Puppet::Type.newtype(:dsc_spprojectserverpermissionmode) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectserverserviceapp.rb
+++ b/lib/puppet/type/dsc_spprojectserverserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spprojectserverserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -133,6 +136,9 @@ Puppet::Type.newtype(:dsc_spprojectserverserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectservertimesheetsettings.rb
+++ b/lib/puppet/type/dsc_spprojectservertimesheetsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spprojectservertimesheetsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -390,6 +393,9 @@ Puppet::Type.newtype(:dsc_spprojectservertimesheetsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectserverusersyncsettings.rb
+++ b/lib/puppet/type/dsc_spprojectserverusersyncsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spprojectserverusersyncsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -131,6 +134,9 @@ Puppet::Type.newtype(:dsc_spprojectserverusersyncsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spprojectserverwsssettings.rb
+++ b/lib/puppet/type/dsc_spprojectserverwsssettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spprojectserverwsssettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -101,6 +104,9 @@ Puppet::Type.newtype(:dsc_spprojectserverwsssettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sppublishserviceapplication.rb
+++ b/lib/puppet/type/dsc_sppublishserviceapplication.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_sppublishserviceapplication) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -103,6 +106,9 @@ Puppet::Type.newtype(:dsc_sppublishserviceapplication) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spquotatemplate.rb
+++ b/lib/puppet/type/dsc_spquotatemplate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spquotatemplate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -175,6 +178,9 @@ Puppet::Type.newtype(:dsc_spquotatemplate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spremotefarmtrust.rb
+++ b/lib/puppet/type/dsc_spremotefarmtrust.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spremotefarmtrust) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -133,6 +136,9 @@ Puppet::Type.newtype(:dsc_spremotefarmtrust) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchauthoritativepage.rb
+++ b/lib/puppet/type/dsc_spsearchauthoritativepage.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spsearchauthoritativepage) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServiceAppName
@@ -153,6 +156,9 @@ Puppet::Type.newtype(:dsc_spsearchauthoritativepage) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchcontentsource.rb
+++ b/lib/puppet/type/dsc_spsearchcontentsource.rb
@@ -77,6 +77,9 @@ Puppet::Type.newtype(:dsc_spsearchcontentsource) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -327,6 +330,9 @@ Puppet::Type.newtype(:dsc_spsearchcontentsource) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchcrawlerimpactrule.rb
+++ b/lib/puppet/type/dsc_spsearchcrawlerimpactrule.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spsearchcrawlerimpactrule) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServiceAppName
@@ -171,6 +174,9 @@ Puppet::Type.newtype(:dsc_spsearchcrawlerimpactrule) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchcrawlmapping.rb
+++ b/lib/puppet/type/dsc_spsearchcrawlmapping.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spsearchcrawlmapping) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServiceAppName
@@ -135,6 +138,9 @@ Puppet::Type.newtype(:dsc_spsearchcrawlmapping) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchcrawlrule.rb
+++ b/lib/puppet/type/dsc_spsearchcrawlrule.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spsearchcrawlrule) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path
@@ -164,6 +167,9 @@ Puppet::Type.newtype(:dsc_spsearchcrawlrule) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AuthenticationCredentials", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         CertificateName
@@ -213,6 +219,9 @@ Puppet::Type.newtype(:dsc_spsearchcrawlrule) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchfiletype.rb
+++ b/lib/puppet/type/dsc_spsearchfiletype.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spsearchfiletype) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         FileType
@@ -166,6 +169,9 @@ Puppet::Type.newtype(:dsc_spsearchfiletype) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchindexpartition.rb
+++ b/lib/puppet/type/dsc_spsearchindexpartition.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spsearchindexpartition) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Index
@@ -136,6 +139,9 @@ Puppet::Type.newtype(:dsc_spsearchindexpartition) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchresultsource.rb
+++ b/lib/puppet/type/dsc_spsearchresultsource.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spsearchresultsource) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -166,6 +169,9 @@ Puppet::Type.newtype(:dsc_spsearchresultsource) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchserviceapp.rb
+++ b/lib/puppet/type/dsc_spsearchserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spsearchserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -160,6 +163,9 @@ Puppet::Type.newtype(:dsc_spsearchserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DefaultContentAccessAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         CloudIndex
@@ -211,6 +217,9 @@ Puppet::Type.newtype(:dsc_spsearchserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("WindowsServiceAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstallAccount
@@ -226,6 +235,9 @@ Puppet::Type.newtype(:dsc_spsearchserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsearchtopology.rb
+++ b/lib/puppet/type/dsc_spsearchtopology.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spsearchtopology) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServiceAppName
@@ -206,6 +209,9 @@ Puppet::Type.newtype(:dsc_spsearchtopology) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsecurestoreserviceapp.rb
+++ b/lib/puppet/type/dsc_spsecurestoreserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spsecurestoreserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -148,6 +151,9 @@ Puppet::Type.newtype(:dsc_spsecurestoreserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DatabaseCredentials", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -278,6 +284,9 @@ Puppet::Type.newtype(:dsc_spsecurestoreserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsecuritytokenserviceconfig.rb
+++ b/lib/puppet/type/dsc_spsecuritytokenserviceconfig.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spsecuritytokenserviceconfig) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -166,6 +169,9 @@ Puppet::Type.newtype(:dsc_spsecuritytokenserviceconfig) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spserviceapppool.rb
+++ b/lib/puppet/type/dsc_spserviceapppool.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spserviceapppool) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_spserviceapppool) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spserviceappproxygroup.rb
+++ b/lib/puppet/type/dsc_spserviceappproxygroup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spserviceappproxygroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -157,6 +160,9 @@ Puppet::Type.newtype(:dsc_spserviceappproxygroup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spserviceappsecurity.rb
+++ b/lib/puppet/type/dsc_spserviceappsecurity.rb
@@ -76,6 +76,9 @@ Puppet::Type.newtype(:dsc_spserviceappsecurity) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServiceAppName
@@ -200,6 +203,9 @@ Puppet::Type.newtype(:dsc_spserviceappsecurity) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spserviceidentity.rb
+++ b/lib/puppet/type/dsc_spserviceidentity.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spserviceidentity) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -98,6 +101,9 @@ Puppet::Type.newtype(:dsc_spserviceidentity) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spserviceinstance.rb
+++ b/lib/puppet/type/dsc_spserviceinstance.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spserviceinstance) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -103,6 +106,9 @@ Puppet::Type.newtype(:dsc_spserviceinstance) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsessionstateservice.rb
+++ b/lib/puppet/type/dsc_spsessionstateservice.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spsessionstateservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DatabaseName
@@ -138,6 +141,9 @@ Puppet::Type.newtype(:dsc_spsessionstateservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spshelladmins.rb
+++ b/lib/puppet/type/dsc_spshelladmins.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_spshelladmins) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -204,6 +207,9 @@ Puppet::Type.newtype(:dsc_spshelladmins) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsite.rb
+++ b/lib/puppet/type/dsc_spsite.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spsite) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -269,6 +272,9 @@ Puppet::Type.newtype(:dsc_spsite) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spstateserviceapp.rb
+++ b/lib/puppet/type/dsc_spstateserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spstateserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -99,6 +102,9 @@ Puppet::Type.newtype(:dsc_spstateserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DatabaseCredentials", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -164,6 +170,9 @@ Puppet::Type.newtype(:dsc_spstateserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spsubscriptionsettingsserviceapp.rb
+++ b/lib/puppet/type/dsc_spsubscriptionsettingsserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spsubscriptionsettingsserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -148,6 +151,9 @@ Puppet::Type.newtype(:dsc_spsubscriptionsettingsserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sptimerjobstate.rb
+++ b/lib/puppet/type/dsc_sptimerjobstate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_sptimerjobstate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         TypeName
@@ -131,6 +134,9 @@ Puppet::Type.newtype(:dsc_sptimerjobstate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sptrustedidentitytokenissuer.rb
+++ b/lib/puppet/type/dsc_sptrustedidentitytokenissuer.rb
@@ -76,6 +76,9 @@ Puppet::Type.newtype(:dsc_sptrustedidentitytokenissuer) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -274,6 +277,9 @@ Puppet::Type.newtype(:dsc_sptrustedidentitytokenissuer) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sptrustedrootauthority.rb
+++ b/lib/puppet/type/dsc_sptrustedrootauthority.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_sptrustedrootauthority) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_sptrustedrootauthority) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spusageapplication.rb
+++ b/lib/puppet/type/dsc_spusageapplication.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spusageapplication) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -114,6 +117,9 @@ Puppet::Type.newtype(:dsc_spusageapplication) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DatabaseCredentials", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -233,6 +239,9 @@ Puppet::Type.newtype(:dsc_spusageapplication) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spuserprofileproperty.rb
+++ b/lib/puppet/type/dsc_spuserprofileproperty.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spuserprofileproperty) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -440,6 +443,9 @@ Puppet::Type.newtype(:dsc_spuserprofileproperty) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spuserprofilesection.rb
+++ b/lib/puppet/type/dsc_spuserprofilesection.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spuserprofilesection) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -151,6 +154,9 @@ Puppet::Type.newtype(:dsc_spuserprofilesection) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spuserprofileserviceapp.rb
+++ b/lib/puppet/type/dsc_spuserprofileserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spuserprofileserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -270,6 +273,9 @@ Puppet::Type.newtype(:dsc_spuserprofileserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spuserprofileserviceapppermissions.rb
+++ b/lib/puppet/type/dsc_spuserprofileserviceapppermissions.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spuserprofileserviceapppermissions) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ProxyName
@@ -137,6 +140,9 @@ Puppet::Type.newtype(:dsc_spuserprofileserviceapppermissions) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spuserprofilesyncconnection.rb
+++ b/lib/puppet/type/dsc_spuserprofilesyncconnection.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncconnection) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -113,6 +116,9 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncconnection) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ConnectionCredentials", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -230,6 +236,9 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncconnection) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spuserprofilesyncservice.rb
+++ b/lib/puppet/type/dsc_spuserprofilesyncservice.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         UserProfileServiceAppName
@@ -104,6 +107,9 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("FarmAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         RunOnlyWhenWriteable
@@ -135,6 +141,9 @@ Puppet::Type.newtype(:dsc_spuserprofilesyncservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spvisioserviceapp.rb
+++ b/lib/puppet/type/dsc_spvisioserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spvisioserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -133,6 +136,9 @@ Puppet::Type.newtype(:dsc_spvisioserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spweb.rb
+++ b/lib/puppet/type/dsc_spweb.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spweb) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -245,6 +248,9 @@ Puppet::Type.newtype(:dsc_spweb) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebappauthentication.rb
+++ b/lib/puppet/type/dsc_spwebappauthentication.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_spwebappauthentication) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -246,6 +249,9 @@ Puppet::Type.newtype(:dsc_spwebappauthentication) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebappblockedfiletypes.rb
+++ b/lib/puppet/type/dsc_spwebappblockedfiletypes.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spwebappblockedfiletypes) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -137,6 +140,9 @@ Puppet::Type.newtype(:dsc_spwebappblockedfiletypes) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebappgeneralsettings.rb
+++ b/lib/puppet/type/dsc_spwebappgeneralsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spwebappgeneralsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -416,6 +419,9 @@ Puppet::Type.newtype(:dsc_spwebappgeneralsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebapplication.rb
+++ b/lib/puppet/type/dsc_spwebapplication.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spwebapplication) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -255,6 +258,9 @@ Puppet::Type.newtype(:dsc_spwebapplication) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebapplicationappdomain.rb
+++ b/lib/puppet/type/dsc_spwebapplicationappdomain.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spwebapplicationappdomain) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebApplication
@@ -149,6 +152,9 @@ Puppet::Type.newtype(:dsc_spwebapplicationappdomain) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebapplicationextension.rb
+++ b/lib/puppet/type/dsc_spwebapplicationextension.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_spwebapplicationextension) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -230,6 +233,9 @@ Puppet::Type.newtype(:dsc_spwebapplicationextension) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebapppeoplepickersettings.rb
+++ b/lib/puppet/type/dsc_spwebapppeoplepickersettings.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_spwebapppeoplepickersettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -198,6 +201,9 @@ Puppet::Type.newtype(:dsc_spwebapppeoplepickersettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebapppermissions.rb
+++ b/lib/puppet/type/dsc_spwebapppermissions.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spwebapppermissions) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -183,6 +186,9 @@ Puppet::Type.newtype(:dsc_spwebapppermissions) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebapppolicy.rb
+++ b/lib/puppet/type/dsc_spwebapppolicy.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_spwebapppolicy) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -206,6 +209,9 @@ Puppet::Type.newtype(:dsc_spwebapppolicy) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebappproxygroup.rb
+++ b/lib/puppet/type/dsc_spwebappproxygroup.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spwebappproxygroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -98,6 +101,9 @@ Puppet::Type.newtype(:dsc_spwebappproxygroup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebappsiteuseanddeletion.rb
+++ b/lib/puppet/type/dsc_spwebappsiteuseanddeletion.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spwebappsiteuseanddeletion) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -151,6 +154,9 @@ Puppet::Type.newtype(:dsc_spwebappsiteuseanddeletion) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebappsuitebar.rb
+++ b/lib/puppet/type/dsc_spwebappsuitebar.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spwebappsuitebar) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebAppUrl
@@ -158,6 +161,9 @@ Puppet::Type.newtype(:dsc_spwebappsuitebar) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebappthrottlingsettings.rb
+++ b/lib/puppet/type/dsc_spwebappthrottlingsettings.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_spwebappthrottlingsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -298,6 +301,9 @@ Puppet::Type.newtype(:dsc_spwebappthrottlingsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwebappworkflowsettings.rb
+++ b/lib/puppet/type/dsc_spwebappworkflowsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_spwebappworkflowsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Url
@@ -131,6 +134,9 @@ Puppet::Type.newtype(:dsc_spwebappworkflowsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spwordautomationserviceapp.rb
+++ b/lib/puppet/type/dsc_spwordautomationserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spwordautomationserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -388,6 +391,9 @@ Puppet::Type.newtype(:dsc_spwordautomationserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spworkflowservice.rb
+++ b/lib/puppet/type/dsc_spworkflowservice.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spworkflowservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WorkflowHostUri
@@ -116,6 +119,9 @@ Puppet::Type.newtype(:dsc_spworkflowservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_spworkmanagementserviceapp.rb
+++ b/lib/puppet/type/dsc_spworkmanagementserviceapp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_spworkmanagementserviceapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -241,6 +244,9 @@ Puppet::Type.newtype(:dsc_spworkmanagementserviceapp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("InstallAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sqlag.rb
+++ b/lib/puppet/type/dsc_sqlag.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlag) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_sqlagdatabase.rb
+++ b/lib/puppet/type/dsc_sqlagdatabase.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_sqlagdatabase) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DatabaseName

--- a/lib/puppet/type/dsc_sqlaglistener.rb
+++ b/lib/puppet/type/dsc_sqlaglistener.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlaglistener) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName

--- a/lib/puppet/type/dsc_sqlagreplica.rb
+++ b/lib/puppet/type/dsc_sqlagreplica.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_sqlagreplica) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_sqlalias.rb
+++ b/lib/puppet/type/dsc_sqlalias.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlalias) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_sqlalwaysonservice.rb
+++ b/lib/puppet/type/dsc_sqlalwaysonservice.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlalwaysonservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_sqldatabase.rb
+++ b/lib/puppet/type/dsc_sqldatabase.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_sqldatabase) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_sqldatabasedefaultlocation.rb
+++ b/lib/puppet/type/dsc_sqldatabasedefaultlocation.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqldatabasedefaultlocation) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServerName

--- a/lib/puppet/type/dsc_sqldatabaseowner.rb
+++ b/lib/puppet/type/dsc_sqldatabaseowner.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_sqldatabaseowner) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Database

--- a/lib/puppet/type/dsc_sqldatabasepermission.rb
+++ b/lib/puppet/type/dsc_sqldatabasepermission.rb
@@ -57,6 +57,9 @@ Puppet::Type.newtype(:dsc_sqldatabasepermission) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_sqldatabaserecoverymodel.rb
+++ b/lib/puppet/type/dsc_sqldatabaserecoverymodel.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqldatabaserecoverymodel) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_sqldatabaserole.rb
+++ b/lib/puppet/type/dsc_sqldatabaserole.rb
@@ -56,6 +56,9 @@ Puppet::Type.newtype(:dsc_sqldatabaserole) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_sqlrs.rb
+++ b/lib/puppet/type/dsc_sqlrs.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_sqlrs) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName

--- a/lib/puppet/type/dsc_sqlscript.rb
+++ b/lib/puppet/type/dsc_sqlscript.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_sqlscript) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServerInstance
@@ -134,6 +137,9 @@ Puppet::Type.newtype(:dsc_sqlscript) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sqlserverconfiguration.rb
+++ b/lib/puppet/type/dsc_sqlserverconfiguration.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlserverconfiguration) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServerName

--- a/lib/puppet/type/dsc_sqlserverdatabasemail.rb
+++ b/lib/puppet/type/dsc_sqlserverdatabasemail.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlserverdatabasemail) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         AccountName

--- a/lib/puppet/type/dsc_sqlserverendpoint.rb
+++ b/lib/puppet/type/dsc_sqlserverendpoint.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlserverendpoint) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         EndpointName

--- a/lib/puppet/type/dsc_sqlserverendpointpermission.rb
+++ b/lib/puppet/type/dsc_sqlserverendpointpermission.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlserverendpointpermission) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName

--- a/lib/puppet/type/dsc_sqlserverendpointstate.rb
+++ b/lib/puppet/type/dsc_sqlserverendpointstate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_sqlserverendpointstate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName

--- a/lib/puppet/type/dsc_sqlserverlogin.rb
+++ b/lib/puppet/type/dsc_sqlserverlogin.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_sqlserverlogin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -155,6 +158,9 @@ Puppet::Type.newtype(:dsc_sqlserverlogin) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("LoginCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sqlservermaxdop.rb
+++ b/lib/puppet/type/dsc_sqlservermaxdop.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_sqlservermaxdop) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_sqlservermemory.rb
+++ b/lib/puppet/type/dsc_sqlservermemory.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_sqlservermemory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName

--- a/lib/puppet/type/dsc_sqlservernetwork.rb
+++ b/lib/puppet/type/dsc_sqlservernetwork.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_sqlservernetwork) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName

--- a/lib/puppet/type/dsc_sqlserverpermission.rb
+++ b/lib/puppet/type/dsc_sqlserverpermission.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlserverpermission) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName

--- a/lib/puppet/type/dsc_sqlserverreplication.rb
+++ b/lib/puppet/type/dsc_sqlserverreplication.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_sqlserverreplication) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName
@@ -121,6 +124,9 @@ Puppet::Type.newtype(:dsc_sqlserverreplication) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AdminLinkCredentials", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sqlserverrole.rb
+++ b/lib/puppet/type/dsc_sqlserverrole.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_sqlserverrole) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServerRoleName

--- a/lib/puppet/type/dsc_sqlserviceaccount.rb
+++ b/lib/puppet/type/dsc_sqlserviceaccount.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlserviceaccount) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServerName
@@ -120,6 +123,9 @@ Puppet::Type.newtype(:dsc_sqlserviceaccount) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ServiceAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sqlsetup.rb
+++ b/lib/puppet/type/dsc_sqlsetup.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Action
@@ -100,6 +103,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SourceCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -315,6 +321,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SQLSvcAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SQLSvcAccountUsername
@@ -345,6 +354,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AgtSvcAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -427,6 +439,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SAPwd", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -534,6 +549,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("FTSvcAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         FTSvcAccountUsername
@@ -565,6 +583,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("RSSvcAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         RSSvcAccountUsername
@@ -595,6 +616,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ASSvcAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -752,6 +776,9 @@ Puppet::Type.newtype(:dsc_sqlsetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ISSvcAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_sqlwaitforag.rb
+++ b/lib/puppet/type/dsc_sqlwaitforag.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_sqlwaitforag) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_sqlwindowsfirewall.rb
+++ b/lib/puppet/type/dsc_sqlwindowsfirewall.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_sqlwindowsfirewall) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -215,6 +218,9 @@ Puppet::Type.newtype(:dsc_sqlwindowsfirewall) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SourceCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_systemlocale.rb
+++ b/lib/puppet/type/dsc_systemlocale.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_systemlocale) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_user.rb
+++ b/lib/puppet/type/dsc_user.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_user) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         UserName
@@ -132,6 +135,9 @@ Puppet::Type.newtype(:dsc_user) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Password", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_userrightsassignment.rb
+++ b/lib/puppet/type/dsc_userrightsassignment.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_userrightsassignment) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Policy

--- a/lib/puppet/type/dsc_waitfordisk.rb
+++ b/lib/puppet/type/dsc_waitfordisk.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_waitfordisk) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DiskId

--- a/lib/puppet/type/dsc_waitforvolume.rb
+++ b/lib/puppet/type/dsc_waitforvolume.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_waitforvolume) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DriveLetter

--- a/lib/puppet/type/dsc_windowsfeature.rb
+++ b/lib/puppet/type/dsc_windowsfeature.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -163,6 +166,9 @@ Puppet::Type.newtype(:dsc_windowsfeature) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_windowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_windowsoptionalfeature.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_windowsoptionalfeature) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_windowsprocess.rb
+++ b/lib/puppet/type/dsc_windowsprocess.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path
@@ -100,6 +103,9 @@ Puppet::Type.newtype(:dsc_windowsprocess) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadcomputer.rb
+++ b/lib/puppet/type/dsc_xadcomputer.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xadcomputer) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ComputerName
@@ -238,6 +241,9 @@ Puppet::Type.newtype(:dsc_xadcomputer) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DomainAdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadcscertificationauthority.rb
+++ b/lib/puppet/type/dsc_xadcscertificationauthority.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         CAType
@@ -87,6 +90,9 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -167,6 +173,9 @@ Puppet::Type.newtype(:dsc_xadcscertificationauthority) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("CertFilePassword", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadcsonlineresponder.rb
+++ b/lib/puppet/type/dsc_xadcsonlineresponder.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xadcsonlineresponder) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance
@@ -87,6 +90,9 @@ Puppet::Type.newtype(:dsc_xadcsonlineresponder) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadcswebenrollment.rb
+++ b/lib/puppet/type/dsc_xadcswebenrollment.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xadcswebenrollment) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance
@@ -102,6 +105,9 @@ Puppet::Type.newtype(:dsc_xadcswebenrollment) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xaddomain.rb
+++ b/lib/puppet/type/dsc_xaddomain.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xaddomain) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DomainName
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_xaddomain) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DomainAdministratorCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SafemodeAdministratorPassword
@@ -99,6 +105,9 @@ Puppet::Type.newtype(:dsc_xaddomain) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SafemodeAdministratorPassword", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -145,6 +154,9 @@ Puppet::Type.newtype(:dsc_xaddomain) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DnsDelegationCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xaddomaincontroller.rb
+++ b/lib/puppet/type/dsc_xaddomaincontroller.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DomainName
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DomainAdministratorCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SafemodeAdministratorPassword
@@ -99,6 +105,9 @@ Puppet::Type.newtype(:dsc_xaddomaincontroller) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SafemodeAdministratorPassword", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xaddomaindefaultpasswordpolicy.rb
+++ b/lib/puppet/type/dsc_xaddomaindefaultpasswordpolicy.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xaddomaindefaultpasswordpolicy) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DomainName
@@ -256,6 +259,9 @@ Puppet::Type.newtype(:dsc_xaddomaindefaultpasswordpolicy) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xaddomaintrust.rb
+++ b/lib/puppet/type/dsc_xaddomaintrust.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -88,6 +91,9 @@ Puppet::Type.newtype(:dsc_xaddomaintrust) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("TargetDomainAdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadgroup.rb
+++ b/lib/puppet/type/dsc_xadgroup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xadgroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GroupName
@@ -184,6 +187,9 @@ Puppet::Type.newtype(:dsc_xadgroup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadorganizationalunit.rb
+++ b/lib/puppet/type/dsc_xadorganizationalunit.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xadorganizationalunit) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -120,6 +123,9 @@ Puppet::Type.newtype(:dsc_xadorganizationalunit) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadrecyclebin.rb
+++ b/lib/puppet/type/dsc_xadrecyclebin.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xadrecyclebin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ForestFQDN
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xadrecyclebin) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("EnterpriseAdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xadreplicationsite.rb
+++ b/lib/puppet/type/dsc_xadreplicationsite.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xadreplicationsite) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xadreplicationsubnet.rb
+++ b/lib/puppet/type/dsc_xadreplicationsubnet.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xadreplicationsubnet) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xadserviceprincipalname.rb
+++ b/lib/puppet/type/dsc_xadserviceprincipalname.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xadserviceprincipalname) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xaduser.rb
+++ b/lib/puppet/type/dsc_xaduser.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xaduser) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DomainName
@@ -101,6 +104,9 @@ Puppet::Type.newtype(:dsc_xaduser) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Password", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -724,6 +730,9 @@ Puppet::Type.newtype(:dsc_xaduser) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DomainAdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xarchive.rb
+++ b/lib/puppet/type/dsc_xarchive.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xarchive) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path
@@ -154,6 +157,9 @@ Puppet::Type.newtype(:dsc_xarchive) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazureaffinitygroup.rb
+++ b/lib/puppet/type/dsc_xazureaffinitygroup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazureaffinitygroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xazurepackadmin.rb
+++ b/lib/puppet/type/dsc_xazurepackadmin.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xazurepackadmin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -105,6 +108,9 @@ Puppet::Type.newtype(:dsc_xazurepackadmin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AzurePackAdminCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SQLServer
@@ -151,6 +157,9 @@ Puppet::Type.newtype(:dsc_xazurepackadmin) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("dbUser", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
+++ b/lib/puppet/type/dsc_xazurepackdatabasesetting.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Namespace
@@ -120,6 +123,9 @@ Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AzurePackAdminCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SQLServer
@@ -166,6 +172,9 @@ Puppet::Type.newtype(:dsc_xazurepackdatabasesetting) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("dbUser", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackfqdn.rb
+++ b/lib/puppet/type/dsc_xazurepackfqdn.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Namespace
@@ -120,6 +123,9 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AzurePackAdminCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SQLServer
@@ -165,6 +171,9 @@ Puppet::Type.newtype(:dsc_xazurepackfqdn) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("dbUser", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackidentityprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackidentityprovider.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Target
@@ -120,6 +123,9 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AzurePackAdminCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SQLServer
@@ -165,6 +171,9 @@ Puppet::Type.newtype(:dsc_xazurepackidentityprovider) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("dbUser", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackrelyingparty.rb
+++ b/lib/puppet/type/dsc_xazurepackrelyingparty.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Target
@@ -122,6 +125,9 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AzurePackAdminCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SQLServer
@@ -167,6 +173,9 @@ Puppet::Type.newtype(:dsc_xazurepackrelyingparty) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("dbUser", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackresourceprovider.rb
+++ b/lib/puppet/type/dsc_xazurepackresourceprovider.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         AuthenticationSite
@@ -113,6 +116,9 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AzurePackAdminCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -242,6 +248,9 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AdminAuthenticationUser", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         AdminAuthenticationUsername
@@ -305,6 +314,9 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("TenantAuthenticationUser", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -400,6 +412,9 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("UsageAuthenticationUser", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         UsageAuthenticationUsername
@@ -464,6 +479,9 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("HealthCheckAuthenticationUser", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         HealthCheckAuthenticationUsername
@@ -527,6 +545,9 @@ Puppet::Type.newtype(:dsc_xazurepackresourceprovider) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("NotificationAuthenticationUser", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepacksetup.rb
+++ b/lib/puppet/type/dsc_xazurepacksetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Role
@@ -137,6 +140,9 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Passphrase
@@ -152,6 +158,9 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Passphrase", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -198,6 +207,9 @@ Puppet::Type.newtype(:dsc_xazurepacksetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("dbUser", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurepackupdate.rb
+++ b/lib/puppet/type/dsc_xazurepackupdate.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xazurepackupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Role
@@ -116,6 +119,9 @@ Puppet::Type.newtype(:dsc_xazurepackupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurequickvm.rb
+++ b/lib/puppet/type/dsc_xazurequickvm.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazurequickvm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xazureservice.rb
+++ b/lib/puppet/type/dsc_xazureservice.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazureservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServiceName

--- a/lib/puppet/type/dsc_xazuresqldatabase.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabase.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -132,6 +135,9 @@ Puppet::Type.newtype(:dsc_xazuresqldatabase) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ServerCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
+++ b/lib/puppet/type/dsc_xazuresqldatabaseserverfirewallrule.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xazuresqldatabaseserverfirewallrule) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         RuleName

--- a/lib/puppet/type/dsc_xazurestorageaccount.rb
+++ b/lib/puppet/type/dsc_xazurestorageaccount.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazurestorageaccount) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         StorageAccountName

--- a/lib/puppet/type/dsc_xazuresubscription.rb
+++ b/lib/puppet/type/dsc_xazuresubscription.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazuresubscription) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xazurevm.rb
+++ b/lib/puppet/type/dsc_xazurevm.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazurevm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -195,6 +198,9 @@ Puppet::Type.newtype(:dsc_xazurevm) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
+++ b/lib/puppet/type/dsc_xazurevmdscconfiguration.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xazurevmdscconfiguration) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         StorageAccountName

--- a/lib/puppet/type/dsc_xazurevmdscextension.rb
+++ b/lib/puppet/type/dsc_xazurevmdscextension.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xazurevmdscextension) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         VMName

--- a/lib/puppet/type/dsc_xblautobitlocker.rb
+++ b/lib/puppet/type/dsc_xblautobitlocker.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DriveType
@@ -204,6 +207,9 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Password", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         PasswordProtector
@@ -235,6 +241,9 @@ Puppet::Type.newtype(:dsc_xblautobitlocker) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Pin", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xblbitlocker.rb
+++ b/lib/puppet/type/dsc_xblbitlocker.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         MountPoint
@@ -199,6 +202,9 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Password", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         PasswordProtector
@@ -230,6 +236,9 @@ Puppet::Type.newtype(:dsc_xblbitlocker) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Pin", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xbltpm.rb
+++ b/lib/puppet/type/dsc_xbltpm.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xbltpm) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity

--- a/lib/puppet/type/dsc_xcertificateexport.rb
+++ b/lib/puppet/type/dsc_xcertificateexport.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xcertificateexport) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path
@@ -280,6 +283,9 @@ Puppet::Type.newtype(:dsc_xcertificateexport) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Password", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xcertificateimport.rb
+++ b/lib/puppet/type/dsc_xcertificateimport.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xcertificateimport) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Thumbprint

--- a/lib/puppet/type/dsc_xcertreq.rb
+++ b/lib/puppet/type/dsc_xcertreq.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xcertreq) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Subject
@@ -237,6 +240,9 @@ Puppet::Type.newtype(:dsc_xcertreq) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xcluster.rb
+++ b/lib/puppet/type/dsc_xcluster.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xcluster) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -98,6 +101,9 @@ Puppet::Type.newtype(:dsc_xcluster) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DomainAdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xclusterdisk.rb
+++ b/lib/puppet/type/dsc_xclusterdisk.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xclusterdisk) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Number

--- a/lib/puppet/type/dsc_xclusternetwork.rb
+++ b/lib/puppet/type/dsc_xclusternetwork.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xclusternetwork) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Address

--- a/lib/puppet/type/dsc_xclusterpreferredowner.rb
+++ b/lib/puppet/type/dsc_xclusterpreferredowner.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xclusterpreferredowner) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ClusterGroup

--- a/lib/puppet/type/dsc_xclusterproperty.rb
+++ b/lib/puppet/type/dsc_xclusterproperty.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xclusterproperty) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xclusterquorum.rb
+++ b/lib/puppet/type/dsc_xclusterquorum.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xclusterquorum) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xcomputer.rb
+++ b/lib/puppet/type/dsc_xcomputer.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xcomputer) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -114,6 +117,9 @@ Puppet::Type.newtype(:dsc_xcomputer) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         UnjoinCredential
@@ -129,6 +135,9 @@ Puppet::Type.newtype(:dsc_xcomputer) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("UnjoinCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xcredssp.rb
+++ b/lib/puppet/type/dsc_xcredssp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xcredssp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Role

--- a/lib/puppet/type/dsc_xdatabase.rb
+++ b/lib/puppet/type/dsc_xdatabase.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdatabase) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Credentials
@@ -68,6 +71,9 @@ Puppet::Type.newtype(:dsc_xdatabase) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credentials", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xdatabaselogin.rb
+++ b/lib/puppet/type/dsc_xdatabaselogin.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdatabaselogin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -151,6 +154,9 @@ Puppet::Type.newtype(:dsc_xdatabaselogin) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SqlConnectionCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xdatabaseserver.rb
+++ b/lib/puppet/type/dsc_xdatabaseserver.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xdatabaseserver) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         LoginMode

--- a/lib/puppet/type/dsc_xdbpackage.rb
+++ b/lib/puppet/type/dsc_xdbpackage.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Credentials
@@ -67,6 +70,9 @@ Puppet::Type.newtype(:dsc_xdbpackage) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credentials", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
+++ b/lib/puppet/type/dsc_xdefaultgatewayaddress.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdefaultgatewayaddress) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xdfsnamespacefolder.rb
+++ b/lib/puppet/type/dsc_xdfsnamespacefolder.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xdfsnamespacefolder) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path

--- a/lib/puppet/type/dsc_xdfsnamespaceroot.rb
+++ b/lib/puppet/type/dsc_xdfsnamespaceroot.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xdfsnamespaceroot) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path

--- a/lib/puppet/type/dsc_xdfsnamespaceserverconfiguration.rb
+++ b/lib/puppet/type/dsc_xdfsnamespaceserverconfiguration.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xdfsnamespaceserverconfiguration) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xdfsreplicationgroup.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GroupName

--- a/lib/puppet/type/dsc_xdfsreplicationgroupconnection.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupconnection.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupconnection) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GroupName

--- a/lib/puppet/type/dsc_xdfsreplicationgroupfolder.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupfolder.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupfolder) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GroupName

--- a/lib/puppet/type/dsc_xdfsreplicationgroupmembership.rb
+++ b/lib/puppet/type/dsc_xdfsreplicationgroupmembership.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xdfsreplicationgroupmembership) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GroupName

--- a/lib/puppet/type/dsc_xdhcpclient.rb
+++ b/lib/puppet/type/dsc_xdhcpclient.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdhcpclient) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xdhcpserverauthorization.rb
+++ b/lib/puppet/type/dsc_xdhcpserverauthorization.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdhcpserverauthorization) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DnsName

--- a/lib/puppet/type/dsc_xdhcpserverclass.rb
+++ b/lib/puppet/type/dsc_xdhcpserverclass.rb
@@ -57,6 +57,9 @@ Puppet::Type.newtype(:dsc_xdhcpserverclass) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xdhcpserveroption.rb
+++ b/lib/puppet/type/dsc_xdhcpserveroption.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdhcpserveroption) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ScopeID

--- a/lib/puppet/type/dsc_xdhcpserverreservation.rb
+++ b/lib/puppet/type/dsc_xdhcpserverreservation.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xdhcpserverreservation) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ScopeID

--- a/lib/puppet/type/dsc_xdhcpserverscope.rb
+++ b/lib/puppet/type/dsc_xdhcpserverscope.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xdhcpserverscope) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IPStartRange

--- a/lib/puppet/type/dsc_xdismfeature.rb
+++ b/lib/puppet/type/dsc_xdismfeature.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdismfeature) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xdnsarecord.rb
+++ b/lib/puppet/type/dsc_xdnsarecord.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xdnsarecord) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xdnsclientglobalsetting.rb
+++ b/lib/puppet/type/dsc_xdnsclientglobalsetting.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xdnsclientglobalsetting) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xdnsconnectionsuffix.rb
+++ b/lib/puppet/type/dsc_xdnsconnectionsuffix.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdnsconnectionsuffix) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xdnsrecord.rb
+++ b/lib/puppet/type/dsc_xdnsrecord.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xdnsrecord) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xdnsserveraddress.rb
+++ b/lib/puppet/type/dsc_xdnsserveraddress.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdnsserveraddress) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xdnsserveradzone.rb
+++ b/lib/puppet/type/dsc_xdnsserveradzone.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdnsserveradzone) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -150,6 +153,9 @@ Puppet::Type.newtype(:dsc_xdnsserveradzone) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xdnsserverforwarder.rb
+++ b/lib/puppet/type/dsc_xdnsserverforwarder.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xdnsserverforwarder) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xdnsserverprimaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserverprimaryzone.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdnsserverprimaryzone) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
+++ b/lib/puppet/type/dsc_xdnsserversecondaryzone.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdnsserversecondaryzone) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xdnsserversetting.rb
+++ b/lib/puppet/type/dsc_xdnsserversetting.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xdnsserversetting) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
+++ b/lib/puppet/type/dsc_xdnsserverzonetransfer.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xdnsserverzonetransfer) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xdscwebservice.rb
+++ b/lib/puppet/type/dsc_xdscwebservice.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xdscwebservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         EndpointName

--- a/lib/puppet/type/dsc_xenvironment.rb
+++ b/lib/puppet/type/dsc_xenvironment.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xenvironment) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchactivesyncvirtualdirectory.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchactivesyncvirtualdirectory) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchantimalwarescanning.rb
+++ b/lib/puppet/type/dsc_xexchantimalwarescanning.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Enabled
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_xexchantimalwarescanning) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchautodiscovervirtualdirectory.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchautodiscovervirtualdirectory) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchautomountpoint.rb
+++ b/lib/puppet/type/dsc_xexchautomountpoint.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchautomountpoint) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity

--- a/lib/puppet/type/dsc_xexchclientaccessserver.rb
+++ b/lib/puppet/type/dsc_xexchclientaccessserver.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -147,6 +153,9 @@ Puppet::Type.newtype(:dsc_xexchclientaccessserver) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AlternateServiceAccountCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroup.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupmember.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         MailboxServer
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupmember) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
+++ b/lib/puppet/type/dsc_xexchdatabaseavailabilitygroupnetwork.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_xexchdatabaseavailabilitygroupnetwork) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchecpvirtualdirectory.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchecpvirtualdirectory) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexcheventloglevel.rb
+++ b/lib/puppet/type/dsc_xexcheventloglevel.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexcheventloglevel) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexcheventloglevel) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchexchangecertificate.rb
+++ b/lib/puppet/type/dsc_xexchexchangecertificate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Thumbprint
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -135,6 +141,9 @@ Puppet::Type.newtype(:dsc_xexchexchangecertificate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("CertCreds", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchexchangeserver.rb
+++ b/lib/puppet/type/dsc_xexchexchangeserver.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchexchangeserver) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchimapsettings.rb
+++ b/lib/puppet/type/dsc_xexchimapsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchimapsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Server
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchimapsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchinstall.rb
+++ b/lib/puppet/type/dsc_xexchinstall.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xexchinstall) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path
@@ -100,6 +103,9 @@ Puppet::Type.newtype(:dsc_xexchinstall) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchjetstress.rb
+++ b/lib/puppet/type/dsc_xexchjetstress.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchjetstress) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Type

--- a/lib/puppet/type/dsc_xexchjetstresscleanup.rb
+++ b/lib/puppet/type/dsc_xexchjetstresscleanup.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchjetstresscleanup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         JetstressPath

--- a/lib/puppet/type/dsc_xexchmailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabase.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabase) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
+++ b/lib/puppet/type/dsc_xexchmailboxdatabasecopy.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchmailboxdatabasecopy) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmailboxserver.rb
+++ b/lib/puppet/type/dsc_xexchmailboxserver.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchmailboxserver) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchmailboxserver) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmailboxtransportservice.rb
+++ b/lib/puppet/type/dsc_xexchmailboxtransportservice.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchmailboxtransportservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchmailboxtransportservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmaintenancemode.rb
+++ b/lib/puppet/type/dsc_xexchmaintenancemode.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchmaintenancemode) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Enabled
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_xexchmaintenancemode) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchmapivirtualdirectory.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchmapivirtualdirectory) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchoabvirtualdirectory.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchoabvirtualdirectory) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchoutlookanywhere.rb
+++ b/lib/puppet/type/dsc_xexchoutlookanywhere.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchoutlookanywhere) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchowavirtualdirectory.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchowavirtualdirectory) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchpopsettings.rb
+++ b/lib/puppet/type/dsc_xexchpopsettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchpopsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Server
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchpopsettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchpowershellvirtualdirectory.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchpowershellvirtualdirectory) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchreceiveconnector.rb
+++ b/lib/puppet/type/dsc_xexchreceiveconnector.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_xexchreceiveconnector) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchtransportservice.rb
+++ b/lib/puppet/type/dsc_xexchtransportservice.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchtransportservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchtransportservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchumcallroutersettings.rb
+++ b/lib/puppet/type/dsc_xexchumcallroutersettings.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchumcallroutersettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Server
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchumcallroutersettings) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchumservice.rb
+++ b/lib/puppet/type/dsc_xexchumservice.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchumservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchumservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchwaitforadprep.rb
+++ b/lib/puppet/type/dsc_xexchwaitforadprep.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchwaitforadprep) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchwaitfordag.rb
+++ b/lib/puppet/type/dsc_xexchwaitfordag.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchwaitfordag) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
+++ b/lib/puppet/type/dsc_xexchwaitformailboxdatabase.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchwaitformailboxdatabase) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xexchwebservicesvirtualdirectory.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Identity
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xexchwebservicesvirtualdirectory) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xfirewall.rb
+++ b/lib/puppet/type/dsc_xfirewall.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xfirewall) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xfirewallprofile.rb
+++ b/lib/puppet/type/dsc_xfirewallprofile.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xfirewallprofile) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xgroup.rb
+++ b/lib/puppet/type/dsc_xgroup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xgroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GroupName
@@ -172,6 +175,9 @@ Puppet::Type.newtype(:dsc_xgroup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xhostsfile.rb
+++ b/lib/puppet/type/dsc_xhostsfile.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xhostsfile) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         HostName

--- a/lib/puppet/type/dsc_xhotfix.rb
+++ b/lib/puppet/type/dsc_xhotfix.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xhotfix) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path
@@ -133,6 +136,9 @@ Puppet::Type.newtype(:dsc_xhotfix) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xiisfeaturedelegation.rb
+++ b/lib/puppet/type/dsc_xiisfeaturedelegation.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xiisfeaturedelegation) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SectionName

--- a/lib/puppet/type/dsc_xiishandler.rb
+++ b/lib/puppet/type/dsc_xiishandler.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xiishandler) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xiislogging.rb
+++ b/lib/puppet/type/dsc_xiislogging.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xiislogging) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         LogPath

--- a/lib/puppet/type/dsc_xiismimetypemapping.rb
+++ b/lib/puppet/type/dsc_xiismimetypemapping.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xiismimetypemapping) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Extension

--- a/lib/puppet/type/dsc_xiismodule.rb
+++ b/lib/puppet/type/dsc_xiismodule.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xiismodule) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path

--- a/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
+++ b/lib/puppet/type/dsc_xinternetexplorerhomepage.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xinternetexplorerhomepage) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         StartPage

--- a/lib/puppet/type/dsc_xipaddress.rb
+++ b/lib/puppet/type/dsc_xipaddress.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xipaddress) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IPAddress

--- a/lib/puppet/type/dsc_xipaddressoption.rb
+++ b/lib/puppet/type/dsc_xipaddressoption.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xipaddressoption) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IPAddress

--- a/lib/puppet/type/dsc_xjeaendpoint.rb
+++ b/lib/puppet/type/dsc_xjeaendpoint.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xjeaendpoint) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xjeatoolkit.rb
+++ b/lib/puppet/type/dsc_xjeatoolkit.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xjeatoolkit) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xmicrosoftupdate.rb
+++ b/lib/puppet/type/dsc_xmicrosoftupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xmicrosoftupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xmppreference.rb
+++ b/lib/puppet/type/dsc_xmppreference.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xmppreference) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xmsipackage.rb
+++ b/lib/puppet/type/dsc_xmsipackage.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xmsipackage) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ProductId
@@ -133,6 +136,9 @@ Puppet::Type.newtype(:dsc_xmsipackage) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -242,6 +248,9 @@ Puppet::Type.newtype(:dsc_xmsipackage) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("RunAsCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xmysqldatabase.rb
+++ b/lib/puppet/type/dsc_xmysqldatabase.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DatabaseName
@@ -103,6 +106,9 @@ Puppet::Type.newtype(:dsc_xmysqldatabase) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("RootCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xmysqlgrant.rb
+++ b/lib/puppet/type/dsc_xmysqlgrant.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         UserName
@@ -102,6 +105,9 @@ Puppet::Type.newtype(:dsc_xmysqlgrant) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("RootCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xmysqlserver.rb
+++ b/lib/puppet/type/dsc_xmysqlserver.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         MySqlVersion
@@ -103,6 +106,9 @@ Puppet::Type.newtype(:dsc_xmysqlserver) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("RootPassword", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xmysqluser.rb
+++ b/lib/puppet/type/dsc_xmysqluser.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         UserName
@@ -85,6 +88,9 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("UserCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         RootCredential
@@ -100,6 +106,9 @@ Puppet::Type.newtype(:dsc_xmysqluser) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("RootCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xnetadapteradvancedproperty.rb
+++ b/lib/puppet/type/dsc_xnetadapteradvancedproperty.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xnetadapteradvancedproperty) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         RegistryKeyword

--- a/lib/puppet/type/dsc_xnetadapterbinding.rb
+++ b/lib/puppet/type/dsc_xnetadapterbinding.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xnetadapterbinding) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xnetadapterlso.rb
+++ b/lib/puppet/type/dsc_xnetadapterlso.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xnetadapterlso) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xnetadaptername.rb
+++ b/lib/puppet/type/dsc_xnetadaptername.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xnetadaptername) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         NewName

--- a/lib/puppet/type/dsc_xnetadapterrdma.rb
+++ b/lib/puppet/type/dsc_xnetadapterrdma.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xnetadapterrdma) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xnetadapterrsc.rb
+++ b/lib/puppet/type/dsc_xnetadapterrsc.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xnetadapterrsc) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xnetadapterrss.rb
+++ b/lib/puppet/type/dsc_xnetadapterrss.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xnetadapterrss) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xnetbios.rb
+++ b/lib/puppet/type/dsc_xnetbios.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xnetbios) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xnetconnectionprofile.rb
+++ b/lib/puppet/type/dsc_xnetconnectionprofile.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xnetconnectionprofile) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xnetworkteam.rb
+++ b/lib/puppet/type/dsc_xnetworkteam.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xnetworkteam) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xnetworkteaminterface.rb
+++ b/lib/puppet/type/dsc_xnetworkteaminterface.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xnetworkteaminterface) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xofflinedomainjoin.rb
+++ b/lib/puppet/type/dsc_xofflinedomainjoin.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xofflinedomainjoin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xpackage.rb
+++ b/lib/puppet/type/dsc_xpackage.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xpackage) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -150,6 +153,9 @@ Puppet::Type.newtype(:dsc_xpackage) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -451,6 +457,9 @@ Puppet::Type.newtype(:dsc_xpackage) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("RunAsCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xpendingreboot.rb
+++ b/lib/puppet/type/dsc_xpendingreboot.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xpendingreboot) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xpfximport.rb
+++ b/lib/puppet/type/dsc_xpfximport.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xpfximport) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Thumbprint
@@ -152,6 +155,9 @@ Puppet::Type.newtype(:dsc_xpfximport) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xpowerplan.rb
+++ b/lib/puppet/type/dsc_xpowerplan.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xpowerplan) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
+++ b/lib/puppet/type/dsc_xpowershellexecutionpolicy.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xpowershellexecutionpolicy) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ExecutionPolicy

--- a/lib/puppet/type/dsc_xproxysettings.rb
+++ b/lib/puppet/type/dsc_xproxysettings.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xproxysettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xpsendpoint.rb
+++ b/lib/puppet/type/dsc_xpsendpoint.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xpsendpoint) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("RunAsCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xrdremoteapp.rb
+++ b/lib/puppet/type/dsc_xrdremoteapp.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xrdremoteapp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Alias

--- a/lib/puppet/type/dsc_xrdsessioncollection.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollection.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xrdsessioncollection) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         CollectionName

--- a/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
+++ b/lib/puppet/type/dsc_xrdsessioncollectionconfiguration.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xrdsessioncollectionconfiguration) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         CollectionName

--- a/lib/puppet/type/dsc_xrdsessiondeployment.rb
+++ b/lib/puppet/type/dsc_xrdsessiondeployment.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xrdsessiondeployment) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SessionHost

--- a/lib/puppet/type/dsc_xregistry.rb
+++ b/lib/puppet/type/dsc_xregistry.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xregistry) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Key

--- a/lib/puppet/type/dsc_xremotedesktopadmin.rb
+++ b/lib/puppet/type/dsc_xremotedesktopadmin.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xremotedesktopadmin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xremotefile.rb
+++ b/lib/puppet/type/dsc_xremotefile.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xremotefile) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DestinationPath
@@ -130,6 +133,9 @@ Puppet::Type.newtype(:dsc_xremotefile) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         MatchSource
@@ -194,6 +200,9 @@ Puppet::Type.newtype(:dsc_xremotefile) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ProxyCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xrobocopy.rb
+++ b/lib/puppet/type/dsc_xrobocopy.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xrobocopy) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Source

--- a/lib/puppet/type/dsc_xroute.rb
+++ b/lib/puppet/type/dsc_xroute.rb
@@ -56,6 +56,9 @@ Puppet::Type.newtype(:dsc_xroute) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xscdpmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscdpmconsolesetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscdpmconsolesetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscdpmconsolesetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmdatabaseserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscdpmdatabaseserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscdpmdatabaseserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscdpmserversetup.rb
+++ b/lib/puppet/type/dsc_xscdpmserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -225,6 +231,9 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("YukonMachineCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ReportingMachineName
@@ -270,6 +279,9 @@ Puppet::Type.newtype(:dsc_xscdpmserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ReportingMachineCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscheduledtask.rb
+++ b/lib/puppet/type/dsc_xscheduledtask.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscheduledtask) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         TaskName
@@ -242,6 +245,9 @@ Puppet::Type.newtype(:dsc_xscheduledtask) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ExecuteAsCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomadmin.rb
+++ b/lib/puppet/type/dsc_xscomadmin.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xscomadmin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -120,6 +123,9 @@ Puppet::Type.newtype(:dsc_xscomadmin) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCOMAdminCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscomconsolesetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscomconsolesetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscomconsoleupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscomconsoleupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscomconsoleupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscommanagementpack.rb
+++ b/lib/puppet/type/dsc_xscommanagementpack.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xscommanagementpack) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -113,6 +116,9 @@ Puppet::Type.newtype(:dsc_xscommanagementpack) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCOMAdminCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscommanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscommanagementserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -214,6 +220,9 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ActionAccount", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ActionAccountUsername
@@ -244,6 +253,9 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DASAccount", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -276,6 +288,9 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DataReader", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DataReaderUsername
@@ -306,6 +321,9 @@ Puppet::Type.newtype(:dsc_xscommanagementserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DataWriter", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscommanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscommanagementserverupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscommanagementserverupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscommanagementserverupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomreportingserversetup.rb
+++ b/lib/puppet/type/dsc_xscomreportingserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -119,6 +122,9 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstallPath
@@ -179,6 +185,9 @@ Puppet::Type.newtype(:dsc_xscomreportingserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DataReader", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
+++ b/lib/puppet/type/dsc_xscomwebconsoleserverupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserverupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscomwebconsoleserverupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscript.rb
+++ b/lib/puppet/type/dsc_xscript.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xscript) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         GetScript
@@ -117,6 +120,9 @@ Puppet::Type.newtype(:dsc_xscript) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscsmapowershellsetup.rb
+++ b/lib/puppet/type/dsc_xscsmapowershellsetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscsmapowershellsetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscsmapowershellsetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmarunbookworkerserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -119,6 +122,9 @@ Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Service
@@ -134,6 +140,9 @@ Puppet::Type.newtype(:dsc_xscsmarunbookworkerserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Service", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
+++ b/lib/puppet/type/dsc_xscsmawebserviceserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -119,6 +122,9 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         FirstWebServiceServer
@@ -150,6 +156,9 @@ Puppet::Type.newtype(:dsc_xscsmawebserviceserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ApPool", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscspfserver.rb
+++ b/lib/puppet/type/dsc_xscspfserver.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscspfserver) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -121,6 +124,9 @@ Puppet::Type.newtype(:dsc_xscspfserver) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCSPFAdminCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscspfserversetup.rb
+++ b/lib/puppet/type/dsc_xscspfserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -262,6 +268,9 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCVMM", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SCVMMUsername
@@ -292,6 +301,9 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCAdmin", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 
@@ -324,6 +336,9 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCProvider", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SCProviderUsername
@@ -354,6 +369,9 @@ Puppet::Type.newtype(:dsc_xscspfserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCUsage", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscspfserverupdate.rb
+++ b/lib/puppet/type/dsc_xscspfserverupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscspfserverupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscspfserverupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscspfsetting.rb
+++ b/lib/puppet/type/dsc_xscspfsetting.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xscspfsetting) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -153,6 +156,9 @@ Puppet::Type.newtype(:dsc_xscspfsetting) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCSPFAdminCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscspfstamp.rb
+++ b/lib/puppet/type/dsc_xscspfstamp.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscspfstamp) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -121,6 +124,9 @@ Puppet::Type.newtype(:dsc_xscspfstamp) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCSPFAdminCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscsrserversetup.rb
+++ b/lib/puppet/type/dsc_xscsrserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscsrserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscsrserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscsrserverupdate.rb
+++ b/lib/puppet/type/dsc_xscsrserverupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscsrserverupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscsrserverupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscvmmadmin.rb
+++ b/lib/puppet/type/dsc_xscvmmadmin.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xscvmmadmin) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -120,6 +123,9 @@ Puppet::Type.newtype(:dsc_xscvmmadmin) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SCVMMAdminCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscvmmconsolesetup.rb
+++ b/lib/puppet/type/dsc_xscvmmconsolesetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscvmmconsolesetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmconsoleupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscvmmconsoleupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscvmmconsoleupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserversetup.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -119,6 +122,9 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         vmmService
@@ -134,6 +140,9 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserversetup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("vmmService", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
+++ b/lib/puppet/type/dsc_xscvmmmanagementserverupdate.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserverupdate) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure
@@ -118,6 +121,9 @@ Puppet::Type.newtype(:dsc_xscvmmmanagementserverupdate) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SetupCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xservice.rb
+++ b/lib/puppet/type/dsc_xservice.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -154,6 +157,9 @@ Puppet::Type.newtype(:dsc_xservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsmacredential.rb
+++ b/lib/puppet/type/dsc_xsmacredential.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xsmacredential) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xsmacredential) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsmbshare.rb
+++ b/lib/puppet/type/dsc_xsmbshare.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xsmbshare) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xsqlalias.rb
+++ b/lib/puppet/type/dsc_xsqlalias.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xsqlalias) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xsqlhaendpoint.rb
+++ b/lib/puppet/type/dsc_xsqlhaendpoint.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xsqlhaendpoint) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName

--- a/lib/puppet/type/dsc_xsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xsqlhagroup.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -162,6 +165,9 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DomainCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SqlAdministratorCredential
@@ -177,6 +183,9 @@ Puppet::Type.newtype(:dsc_xsqlhagroup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SqlAdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlhaservice.rb
+++ b/lib/puppet/type/dsc_xsqlhaservice.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName
@@ -84,6 +87,9 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SqlAdministratorCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ServiceCredential
@@ -99,6 +105,9 @@ Puppet::Type.newtype(:dsc_xsqlhaservice) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("ServiceCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsqlserverinstall.rb
+++ b/lib/puppet/type/dsc_xsqlserverinstall.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InstanceName
@@ -114,6 +117,9 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SourcePathCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Features
@@ -144,6 +150,9 @@ Puppet::Type.newtype(:dsc_xsqlserverinstall) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SqlAdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xsslsettings.rb
+++ b/lib/puppet/type/dsc_xsslsettings.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xsslsettings) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xsystemrestore.rb
+++ b/lib/puppet/type/dsc_xsystemrestore.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xsystemrestore) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xsystemrestorepoint.rb
+++ b/lib/puppet/type/dsc_xsystemrestorepoint.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xsystemrestorepoint) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Description

--- a/lib/puppet/type/dsc_xtimezone.rb
+++ b/lib/puppet/type/dsc_xtimezone.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xtimezone) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xuser.rb
+++ b/lib/puppet/type/dsc_xuser.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xuser) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         UserName
@@ -133,6 +136,9 @@ Puppet::Type.newtype(:dsc_xuser) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Password", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xvhd.rb
+++ b/lib/puppet/type/dsc_xvhd.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xvhd) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xvhdfile.rb
+++ b/lib/puppet/type/dsc_xvhdfile.rb
@@ -75,6 +75,9 @@ Puppet::Type.newtype(:dsc_xvhdfile) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         VhdPath

--- a/lib/puppet/type/dsc_xvirtualmemory.rb
+++ b/lib/puppet/type/dsc_xvirtualmemory.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xvirtualmemory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Drive

--- a/lib/puppet/type/dsc_xvmdvddrive.rb
+++ b/lib/puppet/type/dsc_xvmdvddrive.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xvmdvddrive) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         VMName

--- a/lib/puppet/type/dsc_xvmharddiskdrive.rb
+++ b/lib/puppet/type/dsc_xvmharddiskdrive.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xvmharddiskdrive) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         VMName

--- a/lib/puppet/type/dsc_xvmhost.rb
+++ b/lib/puppet/type/dsc_xvmhost.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xvmhost) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xvmhyperv.rb
+++ b/lib/puppet/type/dsc_xvmhyperv.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xvmhyperv) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xvmnetworkadapter.rb
+++ b/lib/puppet/type/dsc_xvmnetworkadapter.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xvmnetworkadapter) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Id

--- a/lib/puppet/type/dsc_xvmprocessor.rb
+++ b/lib/puppet/type/dsc_xvmprocessor.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xvmprocessor) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         VMName

--- a/lib/puppet/type/dsc_xvmscsicontroller.rb
+++ b/lib/puppet/type/dsc_xvmscsicontroller.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xvmscsicontroller) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         VMName

--- a/lib/puppet/type/dsc_xvmswitch.rb
+++ b/lib/puppet/type/dsc_xvmswitch.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xvmswitch) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xwaitforaddomain.rb
+++ b/lib/puppet/type/dsc_xwaitforaddomain.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         DomainName
@@ -83,6 +86,9 @@ Puppet::Type.newtype(:dsc_xwaitforaddomain) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DomainUserCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwaitforcertificateservices.rb
+++ b/lib/puppet/type/dsc_xwaitforcertificateservices.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwaitforcertificateservices) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         CAServerFQDN

--- a/lib/puppet/type/dsc_xwaitforcluster.rb
+++ b/lib/puppet/type/dsc_xwaitforcluster.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xwaitforcluster) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
+++ b/lib/puppet/type/dsc_xwaitforsqlhagroup.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -150,6 +153,9 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("DomainCredential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SqlAdministratorCredential
@@ -165,6 +171,9 @@ Puppet::Type.newtype(:dsc_xwaitforsqlhagroup) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("SqlAdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xweakhostreceive.rb
+++ b/lib/puppet/type/dsc_xweakhostreceive.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xweakhostreceive) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xweakhostsend.rb
+++ b/lib/puppet/type/dsc_xweakhostsend.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xweakhostsend) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         InterfaceAlias

--- a/lib/puppet/type/dsc_xwebapplication.rb
+++ b/lib/puppet/type/dsc_xwebapplication.rb
@@ -77,6 +77,9 @@ Puppet::Type.newtype(:dsc_xwebapplication) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Website

--- a/lib/puppet/type/dsc_xwebapppool.rb
+++ b/lib/puppet/type/dsc_xwebapppool.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -408,6 +411,9 @@ Puppet::Type.newtype(:dsc_xwebapppool) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwebapppooldefaults.rb
+++ b/lib/puppet/type/dsc_xwebapppooldefaults.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xwebapppooldefaults) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ApplyTo

--- a/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
+++ b/lib/puppet/type/dsc_xwebconfigkeyvalue.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xwebconfigkeyvalue) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         WebsitePath

--- a/lib/puppet/type/dsc_xwebpackagedeploy.rb
+++ b/lib/puppet/type/dsc_xwebpackagedeploy.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwebpackagedeploy) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SourcePath

--- a/lib/puppet/type/dsc_xwebsite.rb
+++ b/lib/puppet/type/dsc_xwebsite.rb
@@ -99,6 +99,9 @@ Puppet::Type.newtype(:dsc_xwebsite) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xwebsitedefaults.rb
+++ b/lib/puppet/type/dsc_xwebsitedefaults.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xwebsitedefaults) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         ApplyTo

--- a/lib/puppet/type/dsc_xwebvirtualdirectory.rb
+++ b/lib/puppet/type/dsc_xwebvirtualdirectory.rb
@@ -55,6 +55,9 @@ Puppet::Type.newtype(:dsc_xwebvirtualdirectory) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Website

--- a/lib/puppet/type/dsc_xwefcollector.rb
+++ b/lib/puppet/type/dsc_xwefcollector.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwefcollector) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Ensure

--- a/lib/puppet/type/dsc_xwefsubscription.rb
+++ b/lib/puppet/type/dsc_xwefsubscription.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwefsubscription) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         SubscriptionID

--- a/lib/puppet/type/dsc_xwindowsfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsfeature.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwindowsfeature) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name
@@ -134,6 +137,9 @@ Puppet::Type.newtype(:dsc_xwindowsfeature) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
+++ b/lib/puppet/type/dsc_xwindowsoptionalfeature.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwindowsoptionalfeature) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xwindowspackagecab.rb
+++ b/lib/puppet/type/dsc_xwindowspackagecab.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwindowspackagecab) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Name

--- a/lib/puppet/type/dsc_xwindowsprocess.rb
+++ b/lib/puppet/type/dsc_xwindowsprocess.rb
@@ -54,6 +54,9 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Path
@@ -101,6 +104,9 @@ Puppet::Type.newtype(:dsc_xwindowsprocess) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 

--- a/lib/puppet/type/dsc_xwindowsupdateagent.rb
+++ b/lib/puppet/type/dsc_xwindowsupdateagent.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xwindowsupdateagent) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xwineventlog.rb
+++ b/lib/puppet/type/dsc_xwineventlog.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xwineventlog) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         LogName

--- a/lib/puppet/type/dsc_xwinssetting.rb
+++ b/lib/puppet/type/dsc_xwinssetting.rb
@@ -52,6 +52,9 @@ Puppet::Type.newtype(:dsc_xwinssetting) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         IsSingleInstance

--- a/lib/puppet/type/dsc_xwordpresssite.rb
+++ b/lib/puppet/type/dsc_xwordpresssite.rb
@@ -53,6 +53,9 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("Credential", value)
     end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
+    end
   end
 
   # Name:         Uri
@@ -99,6 +102,9 @@ Puppet::Type.newtype(:dsc_xwordpresssite) do
         fail("Invalid value '#{value}'. Should be a hash")
       end
       PuppetX::Dsc::TypeHelpers.validate_MSFT_Credential("AdministratorCredential", value)
+    end
+    munge do |value|
+      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)
     end
   end
 


### PR DESCRIPTION
Builds on #387  

- Puppet 5 agents connected to Puppet 6 masters and Puppet 6 agents
   connected to Puppet 5 masters don't properly deserialize Sensitive
   values from catalogs.

   The type generation template has been updated with the inclusion
   of support to fix this.

   This commit includes the same fixes in the generated types.

 - Note: Due to issues with the build process, the rake tasks were not
   run over the existing content to produce these files.

   Instead, a regex search replace was performed using the following:

   search pattern:
   (?s)(validate_MSFT_Credential.*?end)

   replacement:
   $1\n    munge do |value|\n      PuppetX::Dsc::TypeHelpers.munge_sensitive_hash!(value)\n    end