### PR TITLE
(MAINT) Fix Powershell Manager Short Timeout Test

### DIFF
--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -66,6 +66,12 @@ describe PuppetX::Dsc::PowerShellManager,
           expected_error = /Failure waiting for PowerShell process (\d+) to start pipe server/
           expect(e.message).to match expected_error
           pid = expected_error.match(e.message)[1].to_i
+
+          # We want to make sure that enough time has elapsed since the manager called kill
+          # for the OS to finish killing the process and doing all of it's cleanup.
+          # We have found that without an appropriate wait period, the kill call below
+          # can return unexpected results and fail the test.
+          sleep(1)
           expect{Process.kill(0, pid)}.to raise_error(Errno::ESRCH)
         end
       end


### PR DESCRIPTION
This change fixes a race condition in the spec tests that causes
frequent transient errors and CI failures.