### PR TITLE
(MODULES-8389) Fix build process

### DIFF
--- a/build/dsc.rake
+++ b/build/dsc.rake
@@ -97,10 +97,12 @@ namespace :dsc do
           # similar to what was done in the Chocolatey module
           versions = tags_raw.scan(/(\S+)\-PSGallery/).map { | ver | Gem::Version.new(ver[0]) }
           if versions.empty?
-            raise "#{dsc_resource_name} does not have any '*-PSGallery' tags. Appears it has not been released yet. Tags found #{tags_raw.to_s}"
+            latest_version = %x{ git rev-parse HEAD }.strip
+            puts "WARNING: #{dsc_resource_name} does not have any '*-PSGallery' tags. Falling back to commit hash: #{latest_version}"
+          else
+            latest_version = versions.max.to_s + "-PSGallery"
           end
 
-          latest_version = versions.max.to_s + "-PSGallery"
           tracked_version = resource_tags["#{dsc_resource_name}"]
 
           update_version = tracked_version.nil? ? true : update_versions


### PR DESCRIPTION
Prior to this commit the build task would fail on any PowerShell
DSC module which did not have a tag in its repository which ended
in `-PSGallery`. Since our last release, this is true of multiple
modules included in the PowerShell DSC Resource module maintained
by Microsoft.

Even if a tracked version was specified the build still failed
because it checked for a tag regardless of whether the version
was tracked.

This commit updates the rake task for checkout to instead mark
the latest version as commit hash pinned for the submodule by
Microsoft if no PSGallery tags are found. This ensures that the
module code specified matches the code that Microsoft has pinned.