### PR TITLE
(MODULES-8856) Redact debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Fixed
+- Ensure sensitive values are redacted in debug output ([MODULES-8856](https://tickets.puppetlabs.com/browse/MODULES-8856))
+
 ## [1.9.0] - 2019-04-02
 
 ### Added

--- a/spec/unit/puppet/provider/powershell_spec.rb
+++ b/spec/unit/puppet/provider/powershell_spec.rb
@@ -35,4 +35,21 @@ describe Puppet::Type.type(:dsc_file).provider(:powershell) do
       expect(subject.class.format_dsc_value("This should show \$foo variable")).to match(/'This should show \$foo variable'/)
     end
   end
+
+  describe "when secrets are present" do
+    it "should unwrap secrets for passing to PowerShell" do
+      sensitive_pass = Puppet::Pops::Types::PSensitiveType::Sensitive.new('password')
+      expect(subject.class.format_dsc_value(sensitive_pass)).to match(/'password' # PuppetSensitive/)
+    end
+    it "should redact secrets for displaying in debug" do
+      # Note that here we're passing a full string as it shows up in the script_content to be executed
+      # This is because we built a matcher to redact the value being passed, but not the key.
+      # This means a redaction of a string not including '= ' before the string value will not redact.
+      # Every secret unwrapped in this module will unwrap as "'secret' # PuppetSensitive" and, currently,
+      # always inside a hash table to be passed along. This means we can (currently) expect the value to
+      # always come after an equals sign.
+      expect(subject.class.redact_content(" 'password' = 'password' # PuppetSensitive\n")).not_to match(/# PuppetSensitive/)
+      expect(subject.class.redact_content(" 'password' = 'password' # PuppetSensitive\n")).to match(/'password' = '\[REDACTED\]'/)
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit the provider would output the full Powershell log to be executed during debug runs. This is to ensure that we can verify exactly what will be executed. However, this also meant that credentials and other secrets could leak into the debug output, and thus also into PuppetDB logs.

This commit modifies the provider and  ERB template to ensure that methods for formatting Puppet data to be PowerShell compliant are able to take a new parameter, `redact`.

Passing this parameter will cause the script builder to redact any sensitive data it is passed. This flag is forwarded along through a helper method. This implementation allows us to reuse the code for interpolating the correct values into the PowerShell script for the actual execution and for the debug messaging.

There is possibly a better implementation for this change.

This commit also includes updated spec tests to verify the behavior when choosing to redact sensitive values.