### PR TITLE
(MODULES-8856) Fix using the dsc_psdscrunascredential parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure sensitive values are redacted in debug output and `psdscrunascredential` does not break ([MODULES-8856](https://tickets.puppetlabs.com/browse/MODULES-8856)) - thank you, [@Gerben Welter](https://github.com/GerbenWelter)!
+
 ## [1.9.1] - 2019-04-23
 
 ### Fixed

--- a/lib/puppet/provider/base_dsc/powershell.rb
+++ b/lib/puppet/provider/base_dsc/powershell.rb
@@ -180,7 +180,7 @@ EOT
     when dsc_value.class.name == 'Hash'
       "@{" + dsc_value.collect{|k, v| format_dsc_value(k) + ' = ' + format_dsc_value(v)}.join('; ') + "}"
     when dsc_value.class.name == 'Puppet::Pops::Types::PSensitiveType::Sensitive'
-      "'#{escape_quotes(dsc_value.unwrap)}' # PuppetSensitive"
+      "'#{escape_quotes(dsc_value.unwrap)}' <# PuppetSensitive #>"
     else
       fail "unsupported type #{dsc_value.class} of value '#{dsc_value}'"
     end
@@ -192,12 +192,13 @@ EOT
 
   def self.redact_content(content)
     # Note that here we match after an equals to ensure we redact the value being passed, but not the key.
-    # This means a redaction of a string not including '= ' before the string value will not redact.
-    # Every secret unwrapped in this module will unwrap as "'secret' # PuppetSensitive" and, currently,
+    # This means a redaction of a string not including '= ' before the string value will not redact. We
+    # also match everything before the match and backreference it in the replacement string so we don't
+    # lose other key/value pairs on the same line.
+    # Every secret unwrapped in this module will unwrap as "'secret' <# PuppetSensitive #>" and, currently,
     # always inside a hash table to be passed along. This means we can (currently) expect the value to
     # always come after an equals sign.
-    # Note that the line may include a semi-colon and/or a newline character after the sensitive unwrap.
-    content.gsub(/= '.+' # PuppetSensitive;?(\\n)?$/,"= '[REDACTED]'")
+    content.gsub(/= ((?!' ; ').)+? <# PuppetSensitive #>/,"= '[REDACTED]'")
   end
 
   def ps_script_content(mode)

--- a/spec/unit/puppet/provider/powershell_spec.rb
+++ b/spec/unit/puppet/provider/powershell_spec.rb
@@ -39,17 +39,18 @@ describe Puppet::Type.type(:dsc_file).provider(:powershell) do
   describe "when secrets are present" do
     it "should unwrap secrets for passing to PowerShell" do
       sensitive_pass = Puppet::Pops::Types::PSensitiveType::Sensitive.new('password')
-      expect(subject.class.format_dsc_value(sensitive_pass)).to match(/'password' # PuppetSensitive/)
+      expect(subject.class.format_dsc_value(sensitive_pass)).to match(/'password' <# PuppetSensitive #>/)
     end
     it "should redact secrets for displaying in debug" do
       # Note that here we're passing a full string as it shows up in the script_content to be executed
       # This is because we built a matcher to redact the value being passed, but not the key.
       # This means a redaction of a string not including '= ' before the string value will not redact.
-      # Every secret unwrapped in this module will unwrap as "'secret' # PuppetSensitive" and, currently,
+      # Every secret unwrapped in this module will unwrap as "'secret' <# PuppetSensitive #>" and, currently,
       # always inside a hash table to be passed along. This means we can (currently) expect the value to
       # always come after an equals sign.
-      expect(subject.class.redact_content(" 'password' = 'password' # PuppetSensitive\n")).not_to match(/# PuppetSensitive/)
-      expect(subject.class.redact_content(" 'password' = 'password' # PuppetSensitive\n")).to match(/'password' = '\[REDACTED\]'/)
+      expect(subject.class.redact_content("'password' = 'password' <# PuppetSensitive #>\n")).not_to match(/<# PuppetSensitive #>/)
+      expect(subject.class.redact_content("'password' = 'password' <# PuppetSensitive #>\n")).to match(/'password' = '\[REDACTED\]'/)
+      expect(subject.class.redact_content("'user' = 'username' <# PuppetSensitive #> ; 'password' = 'passwordz' <# PuppetSensitive #>\n")).not_to match(/(username|passwordz)/)
     end
   end
 end


### PR DESCRIPTION
This PR fixes the regression introduced in #405 if the `dsc_psdscrunascredential` parameter is used by dsc_* resources in Puppet. If this was the case, the following was part of the Powershell code Puppet generated for DSC:

`password = [PSCustomObject]@{'user' = 'some_user'; 'password' = 'secret'} # PuppetSensitive | new-pscredential`

The use of '#' as the start of the comment breaks the parsing of the Powershell code because everything after the '#' was disregarded. Also the debug log wasn't redacted because the line didn't match.

This PR fixes this by using the multiline comment syntax on a single line which generates the code as following:

`password = [PSCustomObject]@{'user' = 'some_user'; 'password' = 'secret'} <# PuppetSensitive #> | new-pscredential`

Also the match was altered in two ways to account for this situation:
- Match the new  multiline comment suffix.
- Backreference anything before the sensitive value so we don't lose preceding key/value pairs in the redacted debug log because of the non-greedy match of preceding text.

This was needed otherwise the redacted version looked this:

`password = [PSCustomObject]@{'user' = '[REDACTED]' | new-pscredential`