### PR TITLE
(MODULES-7762) State Exact PS Version Requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+- Added a note to the readme specifying the exact PowerShell version required for the module to function ([MODULES-7762](https://tickets.puppetlabs.com/browse/MODULES-7762))
+
 ### Changed
 
 - Increase the named pipe timeout to 180 seconds to prevent runs from failing waiting for a pipe to open ([MODULES-9087](https://tickets.puppetlabs.com/browse/MODULES-9087)).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ In this version, the following DSC Resources are already built and ready for use
 ## Windows System Prerequisites
 
  - PowerShell 5, which is included in [Windows Management Framework 5.0][wmf-5.0].
+   - Note: PowerShell version as obtained from `$PSVersionTable` must be 5.0.10586.117 or greater.
  - [Windows 2003 is not supported](#known-issues).
 
 ## Setup


### PR DESCRIPTION
This is a documentation change to make it clear exactly what version
of PowerShell is required for the module to function. While 99% of
customers running WMF 5.0 will have a valid version, there was at least
one release that had a PowerShell version that will not support this
module and the DSC capabilities it requires.