### PR TITLE
(MODULES-9800) Fix Lib Environment Variable Check

### DIFF
--- a/lib/puppet_x/puppetlabs/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/powershell_manager.rb
@@ -38,16 +38,18 @@ module PuppetX
         !win32console_enabled?
       end
 
-      def invalid_lib_paths?
-        if ENV["lib"].nil? || ENV["lib"].empty?
-          return false
-        else
-          ENV["lib"].split(";").each do |path|
-            if !File.directory?(path)
-              return true
-            end
+      def invalid_lib_paths?(path_collection)
+        invalid_paths = false
+
+        return invalid_paths if path_collection.nil? || path_collection.empty?
+
+        path_collection.split(';').each do |path|
+          unless File.directory?(path)
+            invalid_paths = true
           end
         end
+
+        invalid_paths
       end
 
       def initialize(cmd, debug, pipe_timeout)
@@ -55,7 +57,7 @@ module PuppetX
 
         named_pipe_name = "#{SecureRandom.uuid}PuppetPsHost"
 
-        raise "Bad configuration for ENV['lib']=#{ENV['lib']} - invalid path" if invalid_lib_paths?
+        raise "Bad configuration for ENV['lib']=#{ENV['lib']} - invalid path" if invalid_lib_paths?(ENV['lib'])
 
         ps_args = ['-File', self.class.init_path, "\"#{named_pipe_name}\""]
         ps_args << '"-EmitDebugOutput"' if debug

--- a/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_manager_spec.rb
@@ -760,4 +760,40 @@ $bytes_in_k = (1024 * 64) + 1
     end
   end
 
+  describe 'when the manager checks calls the invalid_lib_paths? function' do
+    it 'returns false if there is no lib environment variable defined' do
+      skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+      expect(manager.invalid_lib_paths?(nil)).to be false
+    end
+
+    it 'returns false if one valid path is provided' do
+      skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+      expect(manager.invalid_lib_paths?('c:\\windows')).to be false
+    end
+
+    it 'returns false if a collection of valid paths is provided' do
+      skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+      expect(manager.invalid_lib_paths?('c:\\;c:\\windows')).to be false
+    end
+
+    it 'returns true if there is only one path and it is invalid' do
+      skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+      expect(manager.invalid_lib_paths?('c:\\notavalidpath')).to be true
+    end
+
+    it 'returns true if the collection has on valid and one invalid member' do
+      skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+      expect(manager.invalid_lib_paths?('c:\\windows;c:\\notavalidpath')).to be true
+    end
+
+    it 'returns false if empty string' do
+      skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+      expect(manager.invalid_lib_paths?('')).to be false
+    end
+
+    it 'returns false if collection has empty members' do
+      skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+      expect(manager.invalid_lib_paths?('c:\\windows;;;')).to be false
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, the function that checks for valid paths in the
`lib` environment variable was broken. It would return true, and raise
an error if any value at all was assigned to that variable.

This commit fixes the behavior of that function and unit tests it to
prevent regressions.
