### PR TITLE
(maint) Reinstate gitignore for DSC imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 .DS_Store
 .envrc
 /inventory.yaml
+import
+!build/vendor/

--- a/.sync.yml
+++ b/.sync.yml
@@ -70,6 +70,9 @@ appveyor.yml:
 .gitignore:
   required:
     - ---.project
+  paths:
+    - import
+    - "!build/vendor/"
 
 .gitlab-ci.yml:
   delete: true


### PR DESCRIPTION
Previously in commit 0bf48aa73315 the PDK update removed the gitignores for the
DSC import process. This the import process would result in 1000s of files
wanting to be checked in.  This commit adds the require gitignores back into the
module.
