### PR TITLE
(FM-8298) Cleanup Acceptance Spec commands

### DIFF
--- a/spec/acceptance/basic_dsc_resources/file/dir_valid_spec.rb
+++ b/spec/acceptance/basic_dsc_resources/file/dir_valid_spec.rb
@@ -18,11 +18,11 @@ describe 'Apply DSC "File" (directory) resource' do
     let(:dsc_destinationpath) { 'C:/test_dir' }
 
     before(:each) do
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -Path #{dsc_destinationpath} -Force -Recurse\"", expect_failures: true)
+      run_shell("Remove-Item -Path #{dsc_destinationpath} -Force -Recurse", expect_failures: true)
     end
 
     after(:each) do
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -Path #{dsc_destinationpath} -Force -Recurse\"", expect_failures: true)
+      run_shell("Remove-Item -Path #{dsc_destinationpath} -Force -Recurse", expect_failures: true)
     end
 
     it "should create and remove a directory resource on #{ENV['TARGET_HOST']}" do
@@ -60,17 +60,17 @@ describe 'Apply DSC "File" (directory) resource' do
     let(:test_dirs) { Array.new(3) { |n| "sub_dir_test_#{n}" } }
 
     before(:each) do
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"New-Item -Path 'C:/#{sourcepath}' -ItemType 'directory'\"")
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"New-Item -Path 'C:/#{sourcepath}/#{test_dirs[0]}' -ItemType 'directory'\"")
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"New-Item -Path 'C:/#{sourcepath}/#{test_dirs[1]}' -ItemType 'directory'\"")
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"New-Item -Path 'C:/#{sourcepath}/#{test_dirs[2]}' -ItemType 'directory'\"")
+      run_shell("New-Item -Path 'C:/#{sourcepath}' -ItemType 'directory'")
+      run_shell("New-Item -Path 'C:/#{sourcepath}/#{test_dirs[0]}' -ItemType 'directory'")
+      run_shell("New-Item -Path 'C:/#{sourcepath}/#{test_dirs[1]}' -ItemType 'directory'")
+      run_shell("New-Item -Path 'C:/#{sourcepath}/#{test_dirs[2]}' -ItemType 'directory'")
 
       run_shell("Remove-Item -path C:/temp/#{destinationpath} -Force -Recurse", expect_failures: true)
     end
 
     after(:each) do
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{sourcepath} -Force -Recurse\"", expect_failures: true)
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{destinationpath} -Force -Recurse\"", expect_failures: true)
+      run_shell("Remove-Item -path C:/#{sourcepath} -Force -Recurse", expect_failures: true)
+      run_shell("Remove-Item -path C:/#{destinationpath} -Force -Recurse", expect_failures: true)
     end
 
     it "creates directories from source to destination recursively on #{ENV['TARGET_HOST']}" do
@@ -86,7 +86,7 @@ describe 'Apply DSC "File" (directory) resource' do
       apply_manifest(dsc_manifest, expect_changes: true)
 
       test_dirs.each do |testdir|
-        run_shell("powershell.exe -NoProfile -Nologo -Command \"Test-Path C:/#{destinationpath}/#{testdir}\"") do |result|
+        run_shell("Test-Path C:/#{destinationpath}/#{testdir}") do |result|
           expect(result.stdout).to match(%r{True})
         end
       end
@@ -109,8 +109,8 @@ describe 'Apply DSC "File" (directory) resource' do
     end
 
     after(:each) do
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{test_dir_name} -Force -Recurse\"", expect_failures: true)
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/temp/#{test_manifest_name} -Force -Recurse\"", expect_failures: true)
+      run_shell("Remove-Item -path C:/#{test_dir_name} -Force -Recurse", expect_failures: true)
+      run_shell("Remove-Item -path C:/temp/#{test_manifest_name} -Force -Recurse", expect_failures: true)
     end
 
     it "should create a directory with Unicode characters in the name on #{ENV['TARGET_HOST']}" do
@@ -118,7 +118,7 @@ describe 'Apply DSC "File" (directory) resource' do
         expect(result.stderr).not_to match(%r{Error:})
       end
 
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Test-Path C:/#{test_dir_name}\"") do |result|
+      run_shell("Test-Path C:/#{test_dir_name}") do |result|
         expect(result.stdout).to match(%r{True})
       end
     end

--- a/spec/acceptance/basic_dsc_resources/file/file_valid_spec.rb
+++ b/spec/acceptance/basic_dsc_resources/file/file_valid_spec.rb
@@ -19,11 +19,11 @@ describe 'Apply DSC "File" resource' do
     let(:dsc_destinationpath) { "C:/#{work_dir}/test1.file" }
 
     before(:each) do
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"New-Item -Path 'C:/#{work_dir}' -ItemType 'directory'\"")
+      run_shell("New-Item -Path 'C:/#{work_dir}' -ItemType 'directory'")
     end
 
     after(:each) do
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{work_dir} -Force -Recurse\"", expect_failures: true)
+      run_shell("Remove-Item -path C:/#{work_dir} -Force -Recurse", expect_failures: true)
     end
 
     it "creates and remove a file resource on #{ENV['TARGET_HOST']}" do
@@ -66,7 +66,7 @@ describe 'Apply DSC "File" resource' do
     end
 
     after(:each) do
-      run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{work_dir} -Force -Recurse\"", expect_failures: true)
+      run_shell("Remove-Item -path C:/#{work_dir} -Force -Recurse", expect_failures: true)
     end
 
     it "creates a destination file from the source file on #{ENV['TARGET_HOST']}" do
@@ -79,7 +79,7 @@ describe 'Apply DSC "File" resource' do
 
       apply_manifest(dsc_manifest)
 
-      result = run_shell("powershell.exe -NoProfile -Nologo -Command \"cat C:/#{work_dir}/#{destinationpath}\"")
+      result = run_shell("cat C:/#{work_dir}/#{destinationpath}")
       expect(result.stdout).to match(source_file_contents)
     end
   end
@@ -100,13 +100,13 @@ describe 'Apply DSC "File" resource' do
         }
         dsc_manifest = single_dsc_resource_manifest(dsc_resource, dsc_props)
 
-        run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{work_dir} -Force -Recurse\"", expect_failures: true)
+        run_shell("Remove-Item -path C:/#{work_dir} -Force -Recurse", expect_failures: true)
 
         create_windows_file("C:/#{work_dir}/", test_manifest_name, dsc_manifest)
       end
 
       after(:each) do
-        run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{work_dir} -Force -Recurse\"", expect_failures: true)
+        run_shell("Remove-Item -path C:/#{work_dir} -Force -Recurse", expect_failures: true)
       end
 
       it 'does not scramble UTF8 content in the destination file' do
@@ -115,7 +115,7 @@ describe 'Apply DSC "File" resource' do
         end
 
         # Powershell SHA256 hash
-        md5_result = run_shell("powershell.exe -NoProfile -Nologo -Command \"Get-FileHash C:/#{work_dir}/#{test_file_name}\"")
+        md5_result = run_shell("Get-FileHash C:/#{work_dir}/#{test_file_name}")
         test_file_md5_sum_regex = %r{A57D8BFFBA5EEF3BC09FC7B692046479F928B5254D94F313ED33ECC53B41}
 
         expect(md5_result.stdout).to match(test_file_md5_sum_regex)
@@ -139,12 +139,12 @@ describe 'Apply DSC "File" resource' do
       end
 
       after(:each) do
-        run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{work_dir} -Force -Recurse\"", expect_failures: true)
+        run_shell("Remove-Item -path C:/#{work_dir} -Force -Recurse", expect_failures: true)
       end
 
       it "creates a file with Unicode characters in the name on #{ENV['TARGET_HOST']}" do
         run_shell("puppet apply C:/#{work_dir}/#{test_manifest_name}")
-        run_shell("powershell.exe -NoProfile -Nologo -Command \"Test-Path C:/#{work_dir}/#{test_file_name}\"") do |result|
+        run_shell("Test-Path C:/#{work_dir}/#{test_file_name}") do |result|
           expect(result.stdout).to match(%r{True})
         end
       end
@@ -171,7 +171,7 @@ describe 'Apply DSC "File" resource' do
       end
 
       after(:each) do
-        run_shell("powershell.exe -NoProfile -Nologo -Command \"Remove-Item -path C:/#{work_dir} -Force -Recurse\"", expect_failures: true)
+        run_shell("Remove-Item -path C:/#{work_dir} -Force -Recurse", expect_failures: true)
       end
 
       it "creates a file with Unicode characters in the SourcePath on #{ENV['TARGET_HOST']}" do


### PR DESCRIPTION
This commit removes the PowerShell prefixes to the run_shell calls
in the acceptance spec tests as Bolt now uses PowerShell as the
default shell for target nodes.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppetlabs-dsc/blob/master/CONTRIBUTING.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - A ticket was created at https://tickets.puppetlabs.com/secure/CreateIssueDetails!init.jspa?pid=10707&issuetype=1&components=13413&summary=%5BDSC%5D%20, or you have an existing ticket #
 - You are not submitting a pull request from your MASTER branch.
 - The first line of your  git commit message has the ticket # and a short summary of the fix, followed by a detailed explanation of the fix in the git commit body.
 - Your git commit message format is important. We have a very defined expectation for this format and are keep to it. Really, READ the entire Contributing document. It will save you and us time.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
