### PR TITLE
MODULES-10117: Fix typo in xRDServer

### DIFF
--- a/lib/puppet_x/dsc_resources/xRemoteDesktopSessionHost/DSCResources/MSFT_xRDServer/MSFT_xRDServer.psm1
+++ b/lib/puppet_x/dsc_resources/xRemoteDesktopSessionHost/DSCResources/MSFT_xRDServer/MSFT_xRDServer.psm1
@@ -170,7 +170,7 @@ function Set-TargetResource
     write-verbose "Adding server '$($Server.ToLower())' as $Role to the deployment on '$($ConnectionBroker.ToLower())'..."
 
     # validate parameters
-    ValidateCustomModeParameters -Role $Role -GateewayExternalFqdn $GatewayExternalFqdn
+    ValidateCustomModeParameters -Role $Role -GatewayExternalFqdn $GatewayExternalFqdn
 
     if ($Role -eq 'RDS-Gateway') 
     {


### PR DESCRIPTION
Fix typo in the xRDServer powershell module that prevents the script from executing succesfully.
