### PR TITLE
WIP - MODULES-10435 - update tested platforms

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -1,9 +1,9 @@
 default:
   provisioner: vmpooler
-  images: ['win-2012r2-wmf5-x86_64']
+  images: ['win-2012r2-core-x86_64']
 release_checks:
   provisioner: vmpooler
-  images: ['win-2012r2-wmf5-x86_64', 'win-2016-core-x86_64', 'win-2019-core-x86_64']
+  images: ['win-2012r2-core-x86_64', 'win-2016-core-x86_64', 'win-2019-core-x86_64']
 vagrant:
   provisioner: vagrant
   images: ['gusztavvargadr/windows-server']


### PR DESCRIPTION
win-2012r2-wmf5-x86_64 was removed from vmpooler.
we replaced it with win-2012r2-core-x86_64 to keep testing on win2012